### PR TITLE
docs: reflect the v0.1.0 release in project status and security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ replacement for an audited commercial key.
 
 ## Project status
 
-A working, single-maintainer hobby project under active development. There are
-no releases yet — the supported version is the tip of `main`, and every
-behavior change bumps the USB `bcdDevice` build counter so a build can be named
-precisely. Most of the protocol surface works against real host software; what
+A working, single-maintainer hobby project under active development. The first
+tagged release is **v0.1.0**; day to day the supported version is the tip of
+`main`, and every behavior change bumps the USB `bcdDevice` build counter so a
+build can be named precisely. Most of the protocol surface works against real host software; what
 has actually been checked on hardware (with dates) is in
 [docs/interop.md](docs/interop.md). Treat anything not in that matrix as
 unverified.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,9 @@ welcome but absolutely not required.
 ## What to expect
 
 One maintainer, best effort: an acknowledgment usually within a few days, a
-fix on `main` as fast as severity warrants. Since there are no releases yet,
-"the fix" means a commit on `main` plus a note in the advisory; bcdDevice
-bumps on every change, so affected builds are easy to name precisely.
+fix on `main` as fast as severity warrants. There are no maintained release
+branches, so "the fix" means a commit on `main` plus a note in the advisory;
+bcdDevice bumps on every change, so affected builds are easy to name precisely.
 
 ## Supported versions
 


### PR DESCRIPTION
README no longer claims there are no releases; SECURITY.md drops the 'no releases yet' framing in favor of 'no maintained release branches', which stays true alongside the v0.1.0 tag.

## Just change readme

<!-- What changes, and why. A couple of sentences is fine; link the issue if there is one. -->

## How it was tested

<!-- Keep what applies, delete the rest. -->

- [x] `nix develop -c ./scripts/check.sh` passes locally
- [ ] On hardware: board = …, what was exercised = …
- [x] Host-only change (CLI / docs / CI) — no device behavior touched

## Checklist

<!-- Tick what applies; "N/A" is fine — most host-only PRs leave the firmware lines blank. -->

- [ ] Device behavior / image changed → `config.device_release` (bcdDevice) bumped by one (hex)
      in `firmware/src/main.rs` — host-only (CLI / docs / CI / build) does not (CONTRIBUTING.md)
- [ ] Fixes something a downgrade would reopen → flag whether the next release should advance the
      rollback **epoch** (`docs/production.md`, stage 3) — a seal-time `--rollback` call, not a code bump
- [ ] New or changed `unsafe` → justified in `docs/unsafe.md`
- [x] User-visible behavior → the matching guide under `docs/` updated
- [ ] New files carry the SPDX header (`AGPL-3.0-only`)
- [x] Commit messages use the zone prefix style (`fido:`, `piv:`, `rsk:`, `docs:`, …)
