### PR TITLE
Release v0.2.1 — fix the release pipeline (draft → provenance → publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,15 @@
 # on a bit-identical rebuild of all eight (a non-reproducible image fails the job
 # before anything is published), generates a CycloneDX SBOM, hashes everything
 # into SHA256SUMS, signs that with keyless cosign (sigstore/Fulcio via OIDC — no
-# private key), and publishes the GitHub Release.
+# private key), and creates the GitHub Release as a DRAFT.
 #
-# `provenance` then emits SLSA build provenance for every released artifact via
-# the slsa-github-generator reusable workflow (also keyless): a consumer can
-# verify which workflow, at which commit, on which runner built each .uf2.
+# `provenance` emits SLSA build provenance for every released artifact via the
+# slsa-github-generator reusable workflow (also keyless) and uploads it to the
+# draft: a consumer can verify which workflow, at which commit, on which runner
+# built each .uf2.
+#
+# `publish` un-drafts the release once the provenance is attached — a release
+# becomes immutable on publish, so the provenance must land while it's a draft.
 #
 # The .uf2 images are UNSIGNED for secure boot — cosign + the SLSA provenance
 # attest the BUILD, not the boot seal. On a secure-boot device, seal an image
@@ -159,7 +163,7 @@ jobs:
           } >> release-notes.md
           cat release-notes.md
 
-      - name: create the GitHub Release
+      - name: create the GitHub Release (draft — published after provenance)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -167,6 +171,7 @@ jobs:
           gh release create "$tag" \
             --title "RS-Key $tag" \
             --notes-file release-notes.md \
+            --draft \
             dist/*
 
   # SLSA build provenance for every released artifact, generated + signed in the
@@ -190,3 +195,21 @@ jobs:
       upload-assets: true
       upload-tag-name: "${{ needs.build.outputs.tag }}"
       provenance-name: "rs-key-${{ needs.build.outputs.tag }}.intoto.jsonl"
+
+  # Publish (un-draft) the release only after the provenance asset is attached.
+  # A release becomes immutable on publish, so the draft must carry everything —
+  # artifacts (build) and provenance (provenance) — before this flips it live.
+  publish:
+    needs: [build, provenance]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # publish (un-draft) the release
+    steps:
+      - name: publish the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit "${{ needs.build.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --draft=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-06-15
+
+No firmware change — `bcdDevice` stays `0x0760` and the eight `.uf2` images are
+bit-identical to 0.2.0. This release ships the fixed release pipeline: 0.2.0
+published its GitHub Release before the SLSA provenance was attached, and
+GitHub's immutable releases rejected the late upload.
+
+### Fixed
+
+- The release workflow now creates the GitHub Release as a draft, uploads the
+  SLSA provenance to it, then publishes last — so the provenance lands before the
+  release turns immutable.
+
+### Changed
+
+- All GitHub Actions bumped to their current major versions (off the deprecated
+  Node 20 runtime).
+
 ## [0.2.0] — 2026-06-15
 
 The cycle since 0.1.0. USB `bcdDevice` is now `0x0760` (incremented once per


### PR DESCRIPTION
Ships the fixed release workflow so SLSA provenance attaches before GitHub's immutable releases lock the assets (0.2.0 published without provenance). No firmware change — bcdDevice stays 0x0760, the .uf2 are bit-identical to 0.2.0. CHANGELOG 0.2.1. CI-only, no device behavior touched.