### PR TITLE
ci(release): SLSA Build L3 via reusable workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+# Reusable release builder — the SLSA Build L3 boundary.
+#
+# Everything that produces and attests the release lives HERE, in a reusable
+# workflow (`on: workflow_call`), not in the caller (`release.yml`). That split
+# is what earns **SLSA v1 Build Level 3**: GitHub generates the provenance from a
+# trusted, isolated reusable workflow whose identity (`job_workflow_ref`) is
+# baked into the signing certificate, so a verifier can prove a `.uf2` was built
+# by *this specific* workflow — not merely "something in the repo" (which is all
+# an inline `attest-build-provenance` step can prove, i.e. Build L2).
+# See https://docs.github.com/actions/security-guides/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3
+#
+# This job: builds the 8 firmware flavors reproducibly via `nix build`, GATES on
+# a bit-identical rebuild of all eight (a non-reproducible image fails the job
+# before anything is published), generates a CycloneDX SBOM, hashes everything
+# into SHA256SUMS, attests GitHub build provenance for every .uf2, signs the
+# checksums with keyless cosign (sigstore/Fulcio via OIDC — no private key), and
+# publishes the GitHub Release.
+#
+# The provenance is a GitHub attestation (Sigstore-signed, in the attestation API
+# + the public Rekor log), NOT a release asset — so it stays compatible with
+# immutable releases. A consumer verifies WHICH reusable workflow / commit /
+# runner built each .uf2 with `gh attestation verify --signer-workflow`
+# (docs/supply-chain.md).
+#
+# Because cosign + attest run inside THIS workflow, the Sigstore certificate's
+# identity (SAN) is this file's ref, e.g.
+#   https://github.com/TheMaxMur/RS-Key/.github/workflows/release-build.yml@refs/tags/vX
+# — that is the identity to verify against, not release.yml's.
+#
+# The .uf2 images are UNSIGNED for secure boot — cosign + the SLSA provenance
+# attest the BUILD, not the boot seal. On a secure-boot device, seal an image
+# with your own key before flashing (docs/production.md). Verifying a download:
+# docs/releases.md and docs/supply-chain.md.
+
+name: release-build
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "tag to build a release for, e.g. v0.1.0"
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    permissions:
+      contents: write # create the release + upload assets
+      id-token: write # keyless cosign + the attestation's Fulcio OIDC token
+      attestations: write # GitHub build-provenance attestation (immutable-safe)
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag }}
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'flake.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: resolve tag
+        id: tag
+        run: |
+          tag="${{ inputs.tag }}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: build the 8 reproducible firmware flavors
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          mkdir -p dist
+          for pkg in firmware firmware-pqc firmware-fips firmware-fips-pqc \
+                     firmware-no-touch firmware-no-touch-pqc \
+                     firmware-no-touch-fips firmware-no-touch-fips-pqc; do
+            echo "::group::nix build .#$pkg"
+            out="$(nix build ".#$pkg" --no-link --print-out-paths)"
+            label="${pkg#firmware}"; label="${label#-}"
+            [ -z "$label" ] && label="default"
+            cp "$out/$pkg.uf2" "dist/rs-key-${tag}-${label}.uf2"
+            echo "::endgroup::"
+          done
+          ls -l dist
+
+      - name: reproducibility gate — rebuild all 8, require bit-identical
+        run: |
+          # `nix build --rebuild` recompiles the derivation already in the store
+          # and fails with a hash mismatch if the output is not bit-identical.
+          # A non-reproducible flavor fails here, before the release is created.
+          for pkg in firmware firmware-pqc firmware-fips firmware-fips-pqc \
+                     firmware-no-touch firmware-no-touch-pqc \
+                     firmware-no-touch-fips firmware-no-touch-fips-pqc; do
+            echo "::group::nix build .#$pkg --rebuild"
+            nix build ".#$pkg" --rebuild --no-link
+            echo "::endgroup::"
+          done
+          echo "all 8 flavors rebuilt bit-identical"
+
+      - name: generate the CycloneDX SBOM
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          # Scoped to the firmware crate (the shipped artifact) and its build
+          # target; cargo-cyclonedx writes firmware/firmware.cdx.json (plus a
+          # per-crate file for every workspace member, which we ignore).
+          nix develop -c cargo cyclonedx \
+            --manifest-path firmware/Cargo.toml \
+            --target thumbv8m.main-none-eabihf \
+            --format json
+          sbom="firmware/firmware.cdx.json"
+          if [ ! -f "$sbom" ]; then
+            # fall back to the first per-crate file cargo-cyclonedx emitted
+            for f in firmware/*.cdx.json; do
+              [ -e "$f" ] || continue
+              sbom="$f"
+              break
+            done
+          fi
+          if [ ! -f "$sbom" ]; then echo "no SBOM produced" >&2; exit 1; fi
+          cp "$sbom" "dist/rs-key-${tag}-sbom.cdx.json"
+
+      - name: checksums
+        run: |
+          cd dist
+          sha256sum ./*.uf2 ./*.cdx.json > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: attest build provenance
+        # GitHub-native build provenance for every .uf2 — signed keyless via
+        # Sigstore/Fulcio against this run's OIDC identity, recorded in the GitHub
+        # attestation API + the public Rekor log (NOT a release asset, so it is
+        # compatible with immutable releases). Because this runs in a reusable
+        # workflow, the provenance binds to THIS workflow's identity → SLSA Build
+        # L3. Verify with `gh attestation verify --signer-workflow`.
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/*.uf2
+
+      - name: sign SHA256SUMS (keyless cosign)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign-blob \
+            --bundle dist/SHA256SUMS.cosign.bundle \
+            dist/SHA256SUMS
+
+      - name: extract release notes from CHANGELOG
+        run: |
+          ver="${{ steps.tag.outputs.version }}"
+          awk -v v="$ver" '
+            $0 ~ "^## \\[" v "\\]" { f = 1; print; next }
+            /^## \[/ { if (f) exit }
+            f { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "RS-Key ${{ steps.tag.outputs.tag }}" > release-notes.md
+          fi
+          {
+            echo
+            echo "---"
+            echo "Verify a download: https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.tag }}/docs/supply-chain.md"
+          } >> release-notes.md
+          cat release-notes.md
+
+      - name: create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          gh release create "$tag" \
+            --title "RS-Key $tag" \
+            --notes-file release-notes.md \
+            dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,22 +3,16 @@
 
 # Cut a release from a pushed `v*` tag.
 #
-# `build` builds the 8 firmware flavors reproducibly via `nix build`, then GATES
-# on a bit-identical rebuild of all eight (a non-reproducible image fails the job
-# before anything is published), generates a CycloneDX SBOM, hashes everything
-# into SHA256SUMS, signs that with keyless cosign (sigstore/Fulcio via OIDC — no
-# private key), attests GitHub build provenance for every .uf2, and publishes the
-# GitHub Release.
+# This is a thin CALLER: it only resolves the tag and invokes the reusable
+# `release-build.yml`, which does all the building, attesting and publishing.
+# The split is deliberate — running the build + provenance inside a reusable
+# workflow is what earns **SLSA v1 Build Level 3** (the provenance binds to the
+# reusable workflow's own identity, so consumers can prove which trusted builder
+# produced each artifact, not merely that "something in this repo" did). See the
+# header of release-build.yml and docs/supply-chain.md.
 #
-# The provenance is a GitHub attestation (Sigstore-signed, in the attestation API
-# + the public Rekor log), NOT a release asset — so it stays compatible with
-# immutable releases. A consumer verifies which workflow / commit / runner built
-# each .uf2 with `gh attestation verify` (docs/supply-chain.md).
-#
-# The .uf2 images are UNSIGNED for secure boot — cosign + the SLSA provenance
-# attest the BUILD, not the boot seal. On a secure-boot device, seal an image
-# with your own key before flashing (docs/production.md). Verifying a download:
-# docs/releases.md and docs/supply-chain.md.
+# Permissions are granted HERE and flow down to the reusable workflow (a called
+# workflow's token can be no broader than its caller's).
 
 name: release
 
@@ -36,136 +30,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 150
+  release:
     permissions:
       contents: write # create the release + upload assets
       id-token: write # keyless cosign + the attestation's Fulcio OIDC token
       attestations: write # GitHub build-provenance attestation (immutable-safe)
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.tag || github.ref }}
-
-      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-
-      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'flake.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: resolve tag
-        id: tag
-        run: |
-          tag="${{ github.event.inputs.tag || github.ref_name }}"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
-
-      - name: build the 8 reproducible firmware flavors
-        run: |
-          tag="${{ steps.tag.outputs.tag }}"
-          mkdir -p dist
-          for pkg in firmware firmware-pqc firmware-fips firmware-fips-pqc \
-                     firmware-no-touch firmware-no-touch-pqc \
-                     firmware-no-touch-fips firmware-no-touch-fips-pqc; do
-            echo "::group::nix build .#$pkg"
-            out="$(nix build ".#$pkg" --no-link --print-out-paths)"
-            label="${pkg#firmware}"; label="${label#-}"
-            [ -z "$label" ] && label="default"
-            cp "$out/$pkg.uf2" "dist/rs-key-${tag}-${label}.uf2"
-            echo "::endgroup::"
-          done
-          ls -l dist
-
-      - name: reproducibility gate — rebuild all 8, require bit-identical
-        run: |
-          # `nix build --rebuild` recompiles the derivation already in the store
-          # and fails with a hash mismatch if the output is not bit-identical.
-          # A non-reproducible flavor fails here, before the release is created.
-          for pkg in firmware firmware-pqc firmware-fips firmware-fips-pqc \
-                     firmware-no-touch firmware-no-touch-pqc \
-                     firmware-no-touch-fips firmware-no-touch-fips-pqc; do
-            echo "::group::nix build .#$pkg --rebuild"
-            nix build ".#$pkg" --rebuild --no-link
-            echo "::endgroup::"
-          done
-          echo "all 8 flavors rebuilt bit-identical"
-
-      - name: generate the CycloneDX SBOM
-        run: |
-          tag="${{ steps.tag.outputs.tag }}"
-          # Scoped to the firmware crate (the shipped artifact) and its build
-          # target; cargo-cyclonedx writes firmware/firmware.cdx.json (plus a
-          # per-crate file for every workspace member, which we ignore).
-          nix develop -c cargo cyclonedx \
-            --manifest-path firmware/Cargo.toml \
-            --target thumbv8m.main-none-eabihf \
-            --format json
-          sbom="firmware/firmware.cdx.json"
-          [ -f "$sbom" ] || sbom="$(ls firmware/*.cdx.json 2>/dev/null | head -1)"
-          if [ -z "$sbom" ] || [ ! -f "$sbom" ]; then echo "no SBOM produced" >&2; exit 1; fi
-          cp "$sbom" "dist/rs-key-${tag}-sbom.cdx.json"
-
-      - name: checksums
-        run: |
-          cd dist
-          sha256sum ./*.uf2 ./*.cdx.json > SHA256SUMS
-          cat SHA256SUMS
-
-      - name: attest build provenance
-        # GitHub-native build provenance for every .uf2 — signed keyless via
-        # Sigstore/Fulcio against this run's OIDC identity, recorded in the GitHub
-        # attestation API + the public Rekor log (NOT a release asset, so it is
-        # compatible with immutable releases). Verify with `gh attestation verify`.
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: dist/*.uf2
-
-      - name: sign SHA256SUMS (keyless cosign)
-        env:
-          COSIGN_YES: "true"
-        run: |
-          cosign sign-blob \
-            --bundle dist/SHA256SUMS.cosign.bundle \
-            dist/SHA256SUMS
-
-      - name: extract release notes from CHANGELOG
-        run: |
-          ver="${{ steps.tag.outputs.version }}"
-          awk -v v="$ver" '
-            $0 ~ "^## \\[" v "\\]" { f = 1; print; next }
-            /^## \[/ { if (f) exit }
-            f { print }
-          ' CHANGELOG.md > release-notes.md
-          if [ ! -s release-notes.md ]; then
-            echo "RS-Key ${{ steps.tag.outputs.tag }}" > release-notes.md
-          fi
-          {
-            echo
-            echo "---"
-            echo "Verify a download: https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.tag }}/docs/supply-chain.md"
-          } >> release-notes.md
-          cat release-notes.md
-
-      - name: create the GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          tag="${{ steps.tag.outputs.tag }}"
-          gh release create "$tag" \
-            --title "RS-Key $tag" \
-            --notes-file release-notes.md \
-            dist/*
+    uses: ./.github/workflows/release-build.yml
+    with:
+      tag: ${{ github.event.inputs.tag || github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,24 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
-## [0.2.1] — 2026-06-15
+## [0.2.2] — 2026-06-15
 
 No firmware change — `bcdDevice` stays `0x0760` and the eight `.uf2` images are
-bit-identical to 0.2.0. This release ships the fixed release pipeline: 0.2.0
-published its GitHub Release without provenance, because the SLSA generator's
-"append the provenance to the release" model is incompatible with GitHub's
-immutable releases (the late asset upload is rejected — even on a draft).
+bit-identical to 0.2.0. This release ships the fixed, hardened release pipeline:
+0.2.0 published its GitHub Release without provenance, because the SLSA
+generator's "append the provenance to the release" model is incompatible with
+GitHub's immutable releases (the late asset upload is rejected — even on a draft).
 
 ### Changed
 
-- Build provenance now uses GitHub's native `attest-build-provenance`: each
-  `.uf2` is attested keyless (Sigstore/Fulcio + the Rekor log) into the
-  **attestation API** instead of being uploaded as a release asset, so it is
-  compatible with immutable releases. Verify with `gh attestation verify`
-  (`docs/supply-chain.md`).
+- Build provenance now uses GitHub's native `attest-build-provenance`, generated
+  from inside a **reusable workflow** (`release-build.yml`). Running the build
+  and the attestation in an isolated, identity-bound reusable workflow raises the
+  release to **SLSA v1 Build Level 3** (an inline attestation step alone is only
+  Build L2). Each `.uf2` is attested keyless (Sigstore/Fulcio + the Rekor log)
+  into the **attestation API** instead of being uploaded as a release asset, so
+  it stays compatible with immutable releases. Verify with
+  `gh attestation verify --signer-workflow …` (`docs/supply-chain.md`).
 - All GitHub Actions bumped to their current major versions (off the deprecated
   Node 20 runtime).
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -21,7 +21,7 @@ See [production.md](production.md) for that.
 | Reproducible build | the 8 `.uf2` flavors | the binary is a pure function of the source at the tag — anyone can rebuild it |
 | Repro **gate** | (CI, blocking) | the release job *fails* if any flavor doesn't rebuild bit-identical, so a non-reproducible image is never published |
 | Checksums + signature | `SHA256SUMS` + `SHA256SUMS.cosign.bundle` | the hashes were signed by this repo's release workflow (keyless cosign) |
-| Build provenance | a GitHub **attestation** (not a release file) | which workflow, at which commit, on which runner built each `.uf2` (keyless, via `attest-build-provenance`) |
+| Build provenance | a GitHub **attestation** (not a release file) | which reusable workflow, at which commit, on which runner built each `.uf2` — **SLSA v1 Build L3**, keyless via `attest-build-provenance` |
 | SBOM | `rs-key-<tag>-sbom.cdx.json` | the CycloneDX bill of materials for the firmware crate |
 | Dependency audit | `supply-chain/` (in-repo) | every dependency is covered by an imported audit or a recorded exemption (cargo-vet) |
 
@@ -46,23 +46,34 @@ CI already enforces this: the release job rebuilds all eight flavors with
 ```sh
 cosign verify-blob \
   --bundle SHA256SUMS.cosign.bundle \
-  --certificate-identity-regexp '^https://github.com/TheMaxMur/RS-Key/\.github/workflows/release\.yml@.*$' \
+  --certificate-identity-regexp '^https://github.com/TheMaxMur/RS-Key/\.github/workflows/release-build\.yml@.*$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS
 sha256sum -c SHA256SUMS          # then check the artifacts against it
 ```
 
+The certificate identity is **`release-build.yml`**, not `release.yml`: cosign
+runs inside the reusable builder, and Sigstore stamps the cert with the reusable
+workflow's identity (`job_workflow_ref`).
+
 ### 3. Build provenance (GitHub attestation)
 
 ```sh
-gh attestation verify rs-key-<tag>-default.uf2 --repo TheMaxMur/RS-Key
+gh attestation verify rs-key-<tag>-default.uf2 \
+  --repo TheMaxMur/RS-Key \
+  --signer-workflow TheMaxMur/RS-Key/.github/workflows/release-build.yml
 ```
 
-This confirms the `.uf2` was built by `release.yml` in this repo — the attestation
-records the workflow, commit and runner, so a hand-built upload won't verify. The
-provenance is a GitHub attestation (Sigstore-signed, logged in Rekor) kept in the
-attestation API rather than as a release asset, so it stays available even though
-the published release is immutable.
+This confirms the `.uf2` was built by the **`release-build.yml` reusable
+workflow** in this repo — the attestation records the workflow, commit and
+runner, so a hand-built upload won't verify. Pinning `--signer-workflow` to the
+reusable builder is the **SLSA Build L3** check: it proves a *specific, trusted*
+workflow produced the artifact, not merely that something in the repo did.
+(Dropping `--signer-workflow` still verifies an attestation exists for this repo —
+a weaker, Build-L2-style check.) The provenance is a GitHub attestation
+(Sigstore-signed, logged in Rekor) kept in the attestation API rather than as a
+release asset, so it stays available even though the published release is
+immutable.
 
 ## Dependency review — cargo-vet
 


### PR DESCRIPTION
## SLSA Build L3 via reusable workflow

Restructures the release pipeline so build provenance is generated from inside a
**reusable workflow** (`release-build.yml`, `on: workflow_call`), which raises the
release from SLSA Build **L2** (an inline `attest-build-provenance` step) to SLSA
v1 Build **L3** — GitHub generates the provenance from an isolated, identity-bound
builder, so a consumer can prove a *specific, trusted* workflow produced each
`.uf2`.

### What changed
- **New** `.github/workflows/release-build.yml` — reusable builder holding all of:
  8-flavor `nix build` → reproducibility gate (`--rebuild`, ×8, blocking) →
  CycloneDX SBOM → SHA256SUMS → `attest-build-provenance` → keyless cosign →
  `gh release create`.
- **Slimmed** `.github/workflows/release.yml` to a thin caller (tag trigger +
  concurrency + permissions, then `uses: ./.github/workflows/release-build.yml`).
- **docs/supply-chain.md** — verification commands now target `release-build.yml`:
  cosign `--certificate-identity-regexp` and `gh attestation verify
  --signer-workflow` (the Sigstore cert SAN binds to `job_workflow_ref`, i.e. the
  reusable workflow, not the caller).
- **CHANGELOG** `[0.2.1]` → `[0.2.2]` (the `v0.2.1` git tag is burned by a prior
  immutable release; next release is `v0.2.2`). No firmware change — `bcdDevice`
  stays `0x0760`, the 8 `.uf2` are bit-identical to 0.2.0.
- Fixes a pre-existing SC2012 (`ls | head`) in the SBOM fallback.

Validated with `actionlint` (both workflows clean). The release workflow itself
runs only on the `v0.2.2` tag push after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
