### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **PIV tab *still* slow after the present-cache fix below: `GET METADATA` over
+  empty key slots.** That bitmap guarded `read` and `size`, but `has_data` — a
+  third absent-probe method — still called the backend directly, so a missing
+  FID scanned the whole partition. PIV `GET METADATA` checks `has_data(slot)`
+  first, and `ykman piv info` / Yubico Authenticator's PIV tab read metadata for
+  ~24 mostly-empty slots (`9A/9C/9D/9E` + 20 retired), so each tab switch paid
+  ~24 full scans ≈ 4 s of green-blinking even though every individual APDU
+  answered in ~30 ms. `has_data` now consults the same bitmap → `O(1)` for an
+  absent slot; measured `ykman piv info` **4.16 s → 0.26 s** (~16×) on hardware.
+  `bcdDevice` `0x0762` → `0x0763`.
+
 - **Slow applet listing (PIV especially), seen as long green-blinking when
   switching tabs in Yubico Authenticator.** A backend `read`/`size` of an
   *absent* file scanned the entire ~1.4 MB KV partition to confirm absence, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **USB enumeration race at boot (first field report).** On a Waveshare RP2350
+  the device would "blink red and not be recognised," recovering only after
+  several replugs. `builder.build()` asserts the bus pull-up, so the host begins
+  enumerating the moment the device attaches — but the task that answers control
+  transfers (`usb_task`) was spawned only after a block of per-boot init (seed +
+  attestation cert + OpenPGP DEK + flash writes, heaviest on a fresh device). The
+  host enumerated into an attached-but-mute device and timed out the first
+  descriptor request; a lenient host (macOS) usually won, a strict one often did
+  not. Boot now completes all that init **before** attaching, and spawns
+  `usb_task` immediately after `build()`, so enumeration is serviced with no
+  blocking gap. `bcdDevice` `0x0760` → `0x0761`.
+
 ## [0.2.2] — 2026-06-15
 
 No firmware change — `bcdDevice` stays `0x0760` and the eight `.uf2` images are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-06-18
+
 ### Changed
 
 - **LED turns green (idle) as soon as the host configures the device**, instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **~90 s boot stall (LED stuck on the red BOOT status) on some RP2350 boards.**
+  `FidoRng::new` seeds the HMAC-DRBG with 48 bytes from the hardware TRNG, and
+  the embassy driver runs an autocorrelation health-check on every generated
+  block — on a failed check it soft-resets and re-samples in a loop. At the
+  default `sample_count` of 25, consecutive ROSC samples on a marginal unit are
+  too correlated, so the check failed almost every time and seeding blocked a
+  variable 30–105 s on **every** boot (init runs before the USB pull-up, so the
+  device was simply absent from the bus that whole time — looked dead, worst on
+  strict hosts). Raising `sample_count` to 1000 decorrelates the samples so the
+  check passes first try: **~1.5 s boot, HW-verified** on the affected board.
+  Entropy quality is unchanged — the NIST health checks stay enabled and the
+  source is the same; the seed is just gathered reliably. `bcdDevice` `0x0763`
+  → `0x0764`.
+
 - **PIV tab *still* slow after the present-cache fix below: `GET METADATA` over
   empty key slots.** That bitmap guarded `read` and `size`, but `has_data` — a
   third absent-probe method — still called the backend directly, so a missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **Slow applet listing (PIV especially), seen as long green-blinking when
+  switching tabs in Yubico Authenticator.** A backend `read`/`size` of an
+  *absent* file scanned the entire ~1.4 MB KV partition to confirm absence, so
+  enumerating a sparse object range was `O(slots · flash)` — opening the
+  Certificates tab probes ~25 mostly-empty PIV certificate slots, each a full
+  scan. (OATH had the same class of bug, fixed earlier; PIV/others did not.) The
+  filesystem now keeps a fixed present/absent bitmap of all FIDs (rebuilt on
+  boot, maintained on every write/remove), so an absent `read`/`size` returns
+  without touching the backend — `O(1)` instead of a full scan. `bcdDevice`
+  `0x0761` → `0x0762`.
+
 - **USB enumeration race at boot (first field report).** On a Waveshare RP2350
   the device would "blink red and not be recognised," recovering only after
   several replugs. `builder.build()` asserts the bus pull-up, so the host begins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Changed
+
+- **LED turns green (idle) as soon as the host configures the device**, instead
+  of staying on the red boot status until the first applet command arrives. A
+  healthy, enumerated key that nothing is talking to yet — e.g. a Linux host with
+  no PC/SC daemon running — used to look dead (red) even though it was ready. A
+  device-level USB `Handler::configured` callback now flips the status on
+  configuration. `bcdDevice` `0x0764` → `0x0765`.
+
 ### Fixed
 
 - **~90 s boot stall (LED stuck on the red BOOT status) on some RP2350 boards.**

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ replacement for an audited commercial key.
 
 ## Project status
 
-A working, single-maintainer hobby project under active development. The first
-tagged release is **v0.1.0**; day to day the supported version is the tip of
+A working, single-maintainer hobby project under active development. The latest
+tagged release is **v0.2.3**; day to day the supported version is the tip of
 `main`, and every behavior change bumps the USB `bcdDevice` build counter so a
 build can be named precisely. Most of the protocol surface works against real host software; what
 has actually been checked on hardware (with dates) is in

--- a/crates/rsk-fs/src/fs.rs
+++ b/crates/rsk-fs/src/fs.rs
@@ -159,6 +159,9 @@ impl<S: Storage> Fs<S> {
 
     /// Whether the file exists with non-empty contents.
     pub fn has_data(&mut self, fid: u16) -> bool {
+        if !self.present_bit(fid) {
+            return false; // absent — skip the backend's full-partition scan
+        }
         self.storage.size(fid).is_some_and(|n| n > 0)
     }
 
@@ -390,6 +393,42 @@ mod tests {
         Fs::new(RamStorage::new(), TABLE)
     }
 
+    /// A `Storage` that counts backend probes, proving the present-cache answers
+    /// absent lookups without the (on-device, O(flash)) `fetch_item` scan.
+    struct CountingStorage {
+        inner: RamStorage,
+        read_calls: u32,
+        size_calls: u32,
+    }
+    impl CountingStorage {
+        fn new() -> Self {
+            Self {
+                inner: RamStorage::new(),
+                read_calls: 0,
+                size_calls: 0,
+            }
+        }
+    }
+    impl Storage for CountingStorage {
+        fn read(&mut self, fid: u16, buf: &mut [u8]) -> Option<usize> {
+            self.read_calls += 1;
+            self.inner.read(fid, buf)
+        }
+        fn write(&mut self, fid: u16, data: &[u8]) -> Result<()> {
+            self.inner.write(fid, data)
+        }
+        fn remove(&mut self, fid: u16) -> Result<()> {
+            self.inner.remove(fid)
+        }
+        fn size(&mut self, fid: u16) -> Option<usize> {
+            self.size_calls += 1;
+            self.inner.size(fid)
+        }
+        fn for_each_key(&mut self, f: &mut dyn FnMut(u16)) {
+            self.inner.for_each_key(f)
+        }
+    }
+
     #[test]
     fn put_read_size() {
         let mut fs = fs();
@@ -468,6 +507,27 @@ mod tests {
         assert_eq!(&buf[..8], b"sig-cert");
         assert_eq!(fs2.read(0xCF09, &mut buf), Some(8));
         assert_eq!(fs2.read(0xD20B, &mut buf), None); // never-written sibling
+    }
+
+    #[test]
+    fn absent_probes_never_touch_the_backend() {
+        // On device a backend read/size of an absent FID scans the whole flash
+        // partition (~160 ms via sequential-storage `fetch_item`). The present
+        // cache MUST answer every absent probe — `read`, `size`, AND `has_data`
+        // — without the backend. PIV GET METADATA probes ~24 empty key slots, so
+        // a missing guard on `has_data` alone cost ~4 s per `ykman piv info` (the
+        // Yubico Authenticator PIV-tab lag).
+        let mut fs = Fs::new(CountingStorage::new(), TABLE);
+        let mut buf = [0u8; 8];
+        assert_eq!(fs.read(0xD205, &mut buf), None);
+        assert_eq!(fs.size(0xD205), None);
+        assert!(!fs.has_data(0xD205));
+        let st = fs.into_storage();
+        assert_eq!(st.read_calls, 0, "absent read must not probe the backend");
+        assert_eq!(
+            st.size_calls, 0,
+            "absent size/has_data must not probe the backend"
+        );
     }
 
     #[test]

--- a/crates/rsk-fs/src/fs.rs
+++ b/crates/rsk-fs/src/fs.rs
@@ -12,6 +12,10 @@ use crate::{EF_META, FILE_EF_TRANSPARENT, FILE_TYPE_WORKING_EF, MAX_DYNAMIC_FILE
 /// Max size of the meta side-store blob.
 const META_MAX: usize = 1024;
 
+/// One bit per 16-bit FID: the full `0x0000..=0xFFFF` space as a present/absent
+/// bitmap (8 KiB). Backs the fast-negative cache in [`Fs`].
+const FID_PRESENT_BYTES: usize = (u16::MAX as usize + 1) / 8;
+
 /// Static descriptor of a known file. File *contents* live in [`Storage`],
 /// not here.
 #[derive(Clone, Copy, Debug)]
@@ -45,6 +49,15 @@ pub struct Fs<S: Storage> {
     storage: S,
     table: &'static [FileDesc],
     dynamic: Vec<u16, MAX_DYNAMIC_FILES>,
+    /// Fast-negative cache: bit `fid` is set iff the backend currently stores a
+    /// value for `fid`. Lets `read`/`size` answer "absent" without touching the
+    /// backend — a backend `read` of an absent key scans the whole flash
+    /// partition, so probing a sparse object range (e.g. the ~25 mostly-empty
+    /// PIV certificate slots Yubico Authenticator reads) was O(slots · flash).
+    /// Mirrors the backend exactly: set on every write, cleared on every
+    /// remove, rebuilt from `for_each_key` in [`Fs::scan`]. A fixed bitmap (not
+    /// the bounded `dynamic` Vec) so it can never overflow into a false absent.
+    present: [u8; FID_PRESENT_BYTES],
     /// Set after user authentication; gates PIN-protected ACL entries.
     pub user_authenticated: bool,
 }
@@ -55,6 +68,7 @@ impl<S: Storage> Fs<S> {
             storage,
             table,
             dynamic: Vec::new(),
+            present: [0u8; FID_PRESENT_BYTES],
             user_authenticated: false,
         }
     }
@@ -65,13 +79,37 @@ impl<S: Storage> Fs<S> {
         self.storage
     }
 
+    /// Does the present-cache say `fid` has a stored value? Only authoritative
+    /// after [`Fs::scan`] (or when every write went through this `Fs` from an
+    /// empty backend), which is the contract — same as the `dynamic` set.
+    #[inline]
+    fn present_bit(&self, fid: u16) -> bool {
+        self.present[(fid >> 3) as usize] & (1u8 << (fid & 7)) != 0
+    }
+
+    #[inline]
+    fn mark_present(&mut self, fid: u16) {
+        self.present[(fid >> 3) as usize] |= 1u8 << (fid & 7);
+    }
+
+    #[inline]
+    fn mark_absent(&mut self, fid: u16) {
+        self.present[(fid >> 3) as usize] &= !(1u8 << (fid & 7));
+    }
+
     /// Rebuild the dynamic-file set from what's already in storage (run once
     /// after a reboot).
     pub fn scan(&mut self) {
         let table = self.table;
+        // Disjoint field borrows so the `for_each_key` closure can update both
+        // while `self.storage` drives the pass.
         let dynamic = &mut self.dynamic;
+        let present = &mut self.present;
         dynamic.clear();
+        present.fill(0);
         self.storage.for_each_key(&mut |fid| {
+            // Every stored key — static, dynamic, or EF_META — feeds the cache.
+            present[(fid >> 3) as usize] |= 1u8 << (fid & 7);
             if fid == EF_META {
                 return;
             }
@@ -105,11 +143,17 @@ impl<S: Storage> Fs<S> {
 
     /// Copy file contents into `buf`; returns the value's full length, or `None`.
     pub fn read(&mut self, fid: u16, buf: &mut [u8]) -> Option<usize> {
+        if !self.present_bit(fid) {
+            return None; // absent — skip the backend's full-partition scan
+        }
         self.storage.read(fid, buf)
     }
 
     /// Length of the file's contents, or `None` if absent.
     pub fn size(&mut self, fid: u16) -> Option<usize> {
+        if !self.present_bit(fid) {
+            return None;
+        }
         self.storage.size(fid)
     }
 
@@ -137,6 +181,7 @@ impl<S: Storage> Fs<S> {
     /// Store file contents, registering a dynamic file if new.
     pub fn put(&mut self, fid: u16, data: &[u8]) -> Result<()> {
         self.storage.write(fid, data)?;
+        self.mark_present(fid);
         if !self.is_static(fid) && !self.dynamic.contains(&fid) {
             self.dynamic.push(fid).map_err(|_| Error::NoMemory)?;
         }
@@ -147,6 +192,7 @@ impl<S: Storage> Fs<S> {
     pub fn delete(&mut self, fid: u16) -> Result<()> {
         let _ = self.meta_delete(fid);
         self.storage.remove(fid)?;
+        self.mark_absent(fid);
         self.dynamic.retain(|&f| f != fid);
         Ok(())
     }
@@ -173,6 +219,9 @@ impl<S: Storage> Fs<S> {
 
     /// Copy the metadata for `fid` into `out`; returns its full length.
     pub fn meta_find(&mut self, fid: u16, out: &mut [u8]) -> Option<usize> {
+        if !self.present_bit(EF_META) {
+            return None;
+        }
         let mut scratch = [0u8; META_MAX];
         let n = self.storage.read(EF_META, &mut scratch)?.min(scratch.len());
         let blob = &scratch[..n];
@@ -198,18 +247,26 @@ impl<S: Storage> Fs<S> {
     /// Insert or replace the metadata for `fid`.
     pub fn meta_add(&mut self, fid: u16, data: &[u8]) -> Result<()> {
         let mut scratch = [0u8; META_MAX];
-        let n = self
-            .storage
-            .read(EF_META, &mut scratch)
-            .unwrap_or(0)
-            .min(scratch.len());
+        let n = if self.present_bit(EF_META) {
+            self.storage
+                .read(EF_META, &mut scratch)
+                .unwrap_or(0)
+                .min(scratch.len())
+        } else {
+            0
+        };
         let mut out = [0u8; META_MAX];
         let w = rebuild_meta(&scratch[..n], fid, Some(data), &mut out)?;
-        self.storage.write(EF_META, &out[..w])
+        self.storage.write(EF_META, &out[..w])?;
+        self.mark_present(EF_META);
+        Ok(())
     }
 
     /// Remove the metadata for `fid` (clears EF_META once empty).
     pub fn meta_delete(&mut self, fid: u16) -> Result<()> {
+        if !self.present_bit(EF_META) {
+            return Ok(()); // no meta blob → nothing to drop, no backend scan
+        }
         let mut scratch = [0u8; META_MAX];
         let n = match self.storage.read(EF_META, &mut scratch) {
             Some(n) => n.min(scratch.len()),
@@ -218,9 +275,11 @@ impl<S: Storage> Fs<S> {
         let mut out = [0u8; META_MAX];
         let w = rebuild_meta(&scratch[..n], fid, None, &mut out)?;
         if w == 0 {
-            self.storage.remove(EF_META)
+            self.storage.remove(EF_META)?;
+            self.mark_absent(EF_META);
+            Ok(())
         } else {
-            self.storage.write(EF_META, &out[..w])
+            self.storage.write(EF_META, &out[..w]) // EF_META stays present
         }
     }
 }
@@ -370,6 +429,45 @@ mod tests {
         fs.delete(0xCF02).unwrap();
         assert!(fs.search(0xCF02).is_none());
         assert!(!fs.has_data(0xCF02));
+    }
+
+    #[test]
+    fn present_cache_tracks_put_delete_reput() {
+        let mut fs = fs();
+        let fid = 0xD205; // a PIV-style object FID; absent at first
+        let mut buf = [0u8; 8];
+        // Absent → fast-negative path, no stale data.
+        assert_eq!(fs.read(fid, &mut buf), None);
+        assert_eq!(fs.size(fid), None);
+        // Put → readable (fails if the write did not mark the FID present).
+        fs.put(fid, b"cert").unwrap();
+        assert_eq!(fs.read(fid, &mut buf), Some(4));
+        assert_eq!(fs.size(fid), Some(4));
+        // Delete → absent again.
+        fs.delete(fid).unwrap();
+        assert_eq!(fs.read(fid, &mut buf), None);
+        assert_eq!(fs.size(fid), None);
+        // Re-put after delete → readable (catches a clear-then-set cache bug).
+        fs.put(fid, b"again").unwrap();
+        assert_eq!(fs.read(fid, &mut buf), Some(5));
+        assert_eq!(&buf[..5], b"again");
+    }
+
+    #[test]
+    fn present_cache_rebuilt_by_scan() {
+        // The negative cache MUST be rebuilt by scan(), or post-reboot reads of
+        // present files would falsely return None — silent data loss.
+        let mut fs = fs();
+        fs.put(0xD20A, b"sig-cert").unwrap();
+        fs.put(0xCF09, b"resident").unwrap();
+        let storage = fs.into_storage();
+        let mut fs2 = Fs::new(storage, TABLE);
+        fs2.scan();
+        let mut buf = [0u8; 16];
+        assert_eq!(fs2.read(0xD20A, &mut buf), Some(8));
+        assert_eq!(&buf[..8], b"sig-cert");
+        assert_eq!(fs2.read(0xCF09, &mut buf), Some(8));
+        assert_eq!(fs2.read(0xD20B, &mut buf), None); // never-written sibling
     }
 
     #[test]

--- a/firmware/src/led.rs
+++ b/firmware/src/led.rs
@@ -171,3 +171,17 @@ pub async fn led_task(mut ws2812: PioWs2812<'static, PIO0, 0, NUM_LEDS, Rgb>) {
         Timer::after_millis(5).await;
     }
 }
+
+/// USB device-event handler: flip the boot status to idle the moment the host
+/// *configures* the device, so the LED shows "enumerated & ready" (green) rather
+/// than staying on the red boot status until the first application command. On a
+/// host with no PC/SC daemon (and nothing else probing the key) that first
+/// command may never arrive even though the key is healthy and enumerated, which
+/// looked like a hang. The worker still drives processing/idle per command.
+pub struct StatusHandler;
+
+impl embassy_usb::Handler for StatusHandler {
+    fn configured(&mut self, configured: bool) {
+        set_status(if configured { STATUS_IDLE } else { STATUS_BOOT });
+    }
+}

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -244,7 +244,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x0762; // bcdDevice: our build counter
+    config.device_release = 0x0763; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -206,6 +206,35 @@ async fn main(_spawner: Spawner) {
         usb_itf = rsk_rescue::phy::effective_usb_itf(&phy);
     }
 
+    // Provision/recover all persistent state BEFORE attaching to USB. `builder.build()`
+    // below asserts the bus pull-up (embassy `driver.start` -> `set_pullup_en`), so the
+    // host starts enumerating the instant we attach. The task that answers control
+    // transfers (`usb_task` -> `device.run()`) must then be spawned with no blocking
+    // work in between — otherwise the host enumerates into a device that is attached
+    // but mute and times out the first descriptor request. That window (heaviest on a
+    // fresh device: seed + attestation cert + OpenPGP DEK + flash writes) was the
+    // "blink red / not recognised until several replugs" report on a Waveshare RP2350.
+    let mut trng_cfg = TrngConfig::default();
+    trng_cfg.inverter_chain_length = InverterChainLength::None;
+    let trng = Trng::new(p.TRNG, Irqs, trng_cfg);
+    let mut rng = FidoRng::new(trng);
+
+    let dev = Device {
+        serial_hash: &serial_hash,
+        serial_id: &serial_id,
+        otp_key: otp_mkek.as_ref(),
+    };
+    let _ = rsk_fido::seed::migrate_keydev_boot(&dev, &mut fs);
+    rsk_rescue::keydev::migrate_kbase(&dev, &mut fs);
+    rsk_piv::migrate_kbase(&dev, &mut fs, &mut rng);
+    let _ = rsk_fido::seed::ensure_seed(&dev, &mut fs, &mut rng);
+    let _ = rsk_openpgp::scan_files(&dev, &mut fs, &mut rng);
+    vendor::load_led_config(&mut fs);
+    rsk_otp::power_up_bump(&mut fs);
+
+    let fs_ref = FS.init(RefCell::new(fs));
+    let rng_ref = RNG_CELL.init(RefCell::new(rng));
+
     let driver = UsbDriver::new(p.USB, Irqs);
     Timer::after_millis(200).await;
 
@@ -215,7 +244,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x0760; // bcdDevice: our build counter
+    config.device_release = 0x0761; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,
@@ -259,32 +288,13 @@ async fn main(_spawner: Spawner) {
         )
     });
 
+    // Attach to the host (pull-up) and immediately start servicing it: no blocking
+    // work between `build()` and the `usb_task` spawn (see the init note above).
     let usb = builder.build();
     let ctap = hid.map(|h| {
         let (reader, writer) = h.split();
         CtapHid::new(reader, writer, ClientCtap, presence::up_pending)
     });
-
-    let mut trng_cfg = TrngConfig::default();
-    trng_cfg.inverter_chain_length = InverterChainLength::None;
-    let trng = Trng::new(p.TRNG, Irqs, trng_cfg);
-    let mut rng = FidoRng::new(trng);
-
-    let dev = Device {
-        serial_hash: &serial_hash,
-        serial_id: &serial_id,
-        otp_key: otp_mkek.as_ref(),
-    };
-    let _ = rsk_fido::seed::migrate_keydev_boot(&dev, &mut fs);
-    rsk_rescue::keydev::migrate_kbase(&dev, &mut fs);
-    rsk_piv::migrate_kbase(&dev, &mut fs, &mut rng);
-    let _ = rsk_fido::seed::ensure_seed(&dev, &mut fs, &mut rng);
-    let _ = rsk_openpgp::scan_files(&dev, &mut fs, &mut rng);
-    vendor::load_led_config(&mut fs);
-    rsk_otp::power_up_bump(&mut fs);
-
-    let fs_ref = FS.init(RefCell::new(fs));
-    let rng_ref = RNG_CELL.init(RefCell::new(rng));
 
     interrupt::SWI_IRQ_1.set_priority(Priority::P2);
     let hp = EXECUTOR_HIGH.start(interrupt::SWI_IRQ_1);

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -116,6 +116,7 @@ static CONTROL_BUF: StaticCell<[u8; 64]> = StaticCell::new();
 static HID_STATE: StaticCell<HidState> = StaticCell::new();
 static KBD_STATE: StaticCell<HidState> = StaticCell::new();
 static OTP_HID_HANDLER: StaticCell<otp_kbd::OtpHidHandler> = StaticCell::new();
+static USB_HANDLER: StaticCell<led::StatusHandler> = StaticCell::new();
 static FS: StaticCell<RefCell<Store>> = StaticCell::new();
 static FLASH_CELL: StaticCell<RefCell<flash_storage::AsyncFlash>> = StaticCell::new();
 static RNG_CELL: StaticCell<RefCell<FidoRng>> = StaticCell::new();
@@ -249,7 +250,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x0764; // bcdDevice: our build counter
+    config.device_release = 0x0765; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,
@@ -292,6 +293,11 @@ async fn main(_spawner: Spawner) {
             },
         )
     });
+
+    // Go green (idle) the moment the host configures us, not on the first applet
+    // command — a healthy, enumerated key with no PC/SC client talking to it would
+    // otherwise sit on the red boot status. (See `led::StatusHandler`.)
+    builder.handler(USB_HANDLER.init(led::StatusHandler));
 
     // Attach to the host (pull-up) and immediately start servicing it: no blocking
     // work between `build()` and the `usb_task` spawn (see the init note above).

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -244,7 +244,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x0761; // bcdDevice: our build counter
+    config.device_release = 0x0762; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -21,9 +21,7 @@ use embassy_rp::interrupt::{InterruptExt, Priority};
 use embassy_rp::peripherals::{DMA_CH0, PIO0, TRNG, USB};
 use embassy_rp::pio::{InterruptHandler as PioIrq, Pio};
 use embassy_rp::pio_programs::ws2812::{PioWs2812, PioWs2812Program};
-use embassy_rp::trng::{
-    Config as TrngConfig, InterruptHandler as TrngIrq, InverterChainLength, Trng,
-};
+use embassy_rp::trng::{Config as TrngConfig, InterruptHandler as TrngIrq, Trng};
 use embassy_rp::usb::{Driver as UsbDriver, InterruptHandler as UsbIrq};
 use embassy_time::Timer;
 use embassy_usb::class::hid::{
@@ -215,7 +213,14 @@ async fn main(_spawner: Spawner) {
     // fresh device: seed + attestation cert + OpenPGP DEK + flash writes) was the
     // "blink red / not recognised until several replugs" report on a Waveshare RP2350.
     let mut trng_cfg = TrngConfig::default();
-    trng_cfg.inverter_chain_length = InverterChainLength::None;
+    // The default sample_count (25) is too low for some RP2350 ROSC units: the
+    // TRNG's autocorrelation health-check fails, the hardware soft-resets and
+    // re-samples in a loop, so seeding the DRBG (48 B, `FidoRng::new`) blocked
+    // ~90 s on EVERY boot on one Waveshare RP2350 unit (variable 30–105 s). A
+    // higher sample_count decorrelates consecutive ROSC samples so the check
+    // passes the first time (~1.5 s boot, HW-verified). Entropy quality is
+    // unchanged — the NIST health checks stay enabled, the source is unchanged.
+    trng_cfg.sample_count = 1000;
     let trng = Trng::new(p.TRNG, Irqs, trng_cfg);
     let mut rng = FidoRng::new(trng);
 
@@ -244,7 +249,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x0763; // bcdDevice: our build counter
+    config.device_release = 0x0764; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,


### PR DESCRIPTION
Release **v0.2.3**. Firmware `bcdDevice` `0x0760` → `0x0765` (all HW-verified on RP2350; gate green).

### Fixed
- **USB enumeration race at boot** — attach (pull-up) before `usb_task` serviced enumeration; strict hosts timed out. (`e0f5416`, 0x0761)
- **FS present-cache** — absent `read`/`size` scanned the whole 1.4 MB KV partition; now O(1) via a present/absent FID bitmap. (`0c4eda6`, 0x0762)
- **PIV `GET METADATA` scan** — `has_data` bypassed the bitmap, so `ykman piv info` / Yubico Authenticator's PIV tab scanned ~24 empty slots (~4 s); now O(1), 4.16 s → 0.26 s. (`9031a23`, 0x0763)
- **~90 s boot stall on some RP2350 boards** — the TRNG autocorrelation health-check failed repeatedly at the default `sample_count=25`; raised to 1000 → ~1.5 s boot, entropy quality unchanged. (`2cdcc28`, 0x0764)

### Changed
- **LED goes green (idle) on USB-configured**, not on the first applet command — an enumerated key with nothing probing it (e.g. Linux without pcscd) no longer looks dead. (`aef33c6`, 0x0765)

Full detail in [CHANGELOG.md](CHANGELOG.md). Merging triggers the `v0.2.3` tag → `release.yml` (8 flavors + SBOM + cosign + SLSA Build L3 provenance).
