### PR TITLE
Release v0.2.4 — seal hardening + CLI/TUI PIN consistency + run-without-Nix

### DIFF
--- a/.github/workflows/rekor-monitor.yml
+++ b/.github/workflows/rekor-monitor.yml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+# Rekor transparency-log identity monitor — a supply-chain tripwire.
+#
+# Our releases sign keyless inside release-build.yml: cosign over SHA256SUMS
+# plus the SLSA build-provenance attestation, both recorded in the PUBLIC Rekor
+# transparency log (docs/supply-chain.md). That log is tamper-EVIDENT, not
+# tamper-proof — it only helps if someone actually watches it.
+#
+# Every hour this asks sigstore/rekor-monitor "did anything sign as an RS-Key
+# GitHub-Actions identity?" and files a GitHub issue with whatever it finds.
+# Every legitimate release adds entries from release-build.yml, so a couple of
+# EXPECTED issues per release are normal — confirm and close them. The signal
+# that matters is an entry you do NOT recognise: that would mean our signing
+# identity was used by something we did not run (a compromised GitHub-OIDC
+# token, repo, or Actions runner) — the one thing that could forge provenance
+# the SLSA Build L3 attestation otherwise vouches for.
+#
+# We watch the WHOLE …/RS-Key/.github/workflows/ namespace, not just
+# release-build.yml: only release-build.yml ever signs legitimately, so a
+# signature from any other workflow path in this repo is itself the alarm.
+#
+# rekor-monitor ships no tags/releases, so the reusable workflow is pinned to a
+# main commit; Dependabot's weekly github-actions group keeps the pin fresh.
+
+name: rekor-monitor
+
+on:
+  schedule:
+    - cron: "23 * * * *" # hourly at :23 — upstream-recommended cadence (off the top of the hour, which GitHub heavily contends)
+  workflow_dispatch:
+
+# Deny everything at the top; the job below grants exactly what the reusable
+# workflow needs and nothing more.
+permissions: {}
+
+concurrency:
+  group: rekor-monitor
+  cancel-in-progress: false # never abort a run mid-checkpoint
+
+jobs:
+  monitor:
+    permissions:
+      contents: read # checkout the reusable workflow
+      issues: write # file an issue when a watched identity appears
+      id-token: write # detect the running repo/ref for the reusable workflow
+    uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@50847dce81efa8d76093c64e08ba48d2c21399c3 # main @ 2026-06-18
+    with:
+      file_issue: true
+      once: true
+      config: |
+        monitoredValues:
+          certIdentities:
+            - certSubject: '^https://github\.com/TheMaxMur/RS-Key/\.github/workflows/.*$'
+              issuers:
+                - '^https://token\.actions\.githubusercontent\.com$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   `fs.put(key_fid, raw_secret)` no longer compiles (asserted by a `compile_fail`
   doctest). This is the chokepoint whose absence let OATH ship its secrets in
   the clear; every applet's key FIDs were moved onto it.
+- **Resident-credential RP domains are now boxed at rest.** A discoverable
+  credential's `EF_RP` record stored the relying-party id (the site's domain)
+  in cleartext, so a flash dump revealed the *list of sites you hold passkeys
+  for* — a privacy leak, even though the keys themselves were sealed. The domain
+  is now ChaCha20-Poly1305-boxed under the device seed (the same seal the
+  credential body uses), with the rpId **hash** kept in cleartext as the O(1)
+  lookup key. A boot migration re-boxes records enrolled before this release.
+  Honest residual: the rpId hash remains, so a dump can still *dictionary-attack*
+  guessable domains — but the plaintext site list is gone. `bcdDevice` `0x0766`
+  → `0x0767`.
 
 ## [0.2.3] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Security
+
+- **OATH credential secrets are now sealed at rest.** Every other applet
+  (FIDO, PIV, OpenPGP, rescue) AES-encrypts its keys before they reach flash;
+  OATH alone stored its TOTP/HOTP shared secrets — and the SET CODE key — as
+  plaintext TLV. They are now AES-256-GCM-sealed under the device `kbase`
+  (`HKDF(serial_hash, kbase, "OATH/KEYS")`), the same device-seal the PIV slot
+  keys use. A one-time boot migration re-seals any credential enrolled before
+  this release, so existing accounts keep working. With the OTP MKEK burned, an
+  extracted flash image no longer reveals OATH secrets. `bcdDevice` `0x0765` →
+  `0x0766`.
+- **The at-rest seal path is now enforced by types, not convention.** A slot
+  that holds a sealed secret is a `KeyFid`, distinct from a plaintext `u16` file
+  id, and the only writer that accepts one is `Fs::put_key(KeyFid, Sealed)` —
+  where `Sealed` is produced only by a seal routine. A stray
+  `fs.put(key_fid, raw_secret)` no longer compiles (asserted by a `compile_fail`
+  doctest). This is the chokepoint whose absence let OATH ship its secrets in
+  the clear; every applet's key FIDs were moved onto it.
+
 ## [0.2.3] — 2026-06-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   through one chokepoint (`rsk.common.resolve_pin`) that only prompts when the
   device actually has a PIN, so touch-only devices are never asked. Host-tool
   only; no `bcdDevice` bump.
+- **The `rsk-tui` cockpit now routes PIN entry through one chokepoint too.** Its
+  four per-action PIN steps collapsed into a single `App::gate_pin` +
+  `Step::PinThenRun`, so "prompt for the FIDO2 PIN iff the device has one, else
+  run" lives in exactly one place (mirroring the CLI's `resolve_pin`). PIN-vs-
+  phrase collection in the modal flow is now explicit instead of a catch-all (a
+  stray text input can no longer land in the PIN buffer), and the four
+  `device requires a PIN` strings were unified. No behaviour change for users;
+  host-tool only, no `bcdDevice` bump.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-06-19
+
 ### Added
 
 - **The `rsk` CLI can run without Nix.** A `tools/pyproject.toml` packages the
@@ -44,8 +46,21 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   `device requires a PIN` strings were unified. No behaviour change for users;
   host-tool only, no `bcdDevice` bump.
 
+### Fixed
+
+- **`rsk secure-boot` no longer refuses provisioning on a chip with a benign
+  `LOCK_NS`.** `pages_locked()` read the whole OTP lock row, so a pre-set
+  non-secure-page lock (`LOCK_NS=1`, `0x040404`) looked like a bootloader lock
+  and wrongly blocked `load-key`; it now masks `LOCK_BL` specifically. Host-tool
+  only; a mutation-proven regression test was added.
+
 ### Security
 
+- **Transparency-log monitoring for our release signing identity.** A scheduled
+  GitHub Action (`sigstore/rekor-monitor`) watches the Rekor log for entries
+  signed under our release workflow's OIDC identity, so illegitimate use of it —
+  a signature we did not produce — becomes detectable, complementing the SLSA
+  Build L3 provenance. CI only; see `docs/supply-chain.md`.
 - **OATH credential secrets are now sealed at rest.** Every other applet
   (FIDO, PIV, OpenPGP, rescue) AES-encrypts its keys before they reach flash;
   OATH alone stored its TOTP/HOTP shared secrets — and the SET CODE key — as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Added
+
+- **The `rsk` CLI can run without Nix.** A `tools/pyproject.toml` packages the
+  CLI so it installs from any Python ≥ 3.9 toolchain —
+  `uvx --from ./tools rsk …`, `uv tool install ./tools`, `pipx install ./tools`,
+  or plain `pip`. The Nix dev shell stays the primary, pinned path; this mirrors
+  its CLI runtime deps (`hidapi`, `cryptography`, `pyscard`, `fido2`,
+  `mnemonic`, `shamir-mnemonic`) for hosts without Nix. See
+  [tools/README.md](tools/README.md). Host-tool only; no `bcdDevice` bump.
+
+### Changed
+
+- **FIDO2 PIN entry is now uniform across the CLI.** Commands disagreed on how
+  to take a PIN: most accepted only `--pin` (and aborted on a PIN-protected
+  device when it was omitted), while `fido list-passkeys` and `fido set-pin`
+  prompted interactively with no flag at all. Every PIN-gated command (`backup
+  export`/`restore`, `audit log`/`verify`, `lock enable`/`disable`, `inventory
+  verify`, `fido list-passkeys`/`set-pin`/`attestation import`/`clear`) now
+  accepts the PIN **either** way — `--pin` flag **or** an interactive prompt —
+  through one chokepoint (`rsk.common.resolve_pin`) that only prompts when the
+  device actually has a PIN, so touch-only devices are never asked. Host-tool
+  only; no `bcdDevice` bump.
+
 ### Security
 
 - **OATH credential secrets are now sealed at rest.** Every other applet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,7 @@ dependencies = [
  "rsk-crypto",
  "rsk-fs",
  "rsk-sdk",
+ "zeroize",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ replacement for an audited commercial key.
 ## Project status
 
 A working, single-maintainer hobby project under active development. The latest
-tagged release is **v0.2.3**; day to day the supported version is the tip of
+tagged release is **v0.2.4**; day to day the supported version is the tip of
 `main`, and every behavior change bumps the USB `bcdDevice` build counter so a
 build can be named precisely. Most of the protocol surface works against real host software; what
 has actually been checked on hardware (with dates) is in

--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ Inside the dev shell two commands are on `PATH`:
 - **`rsk-tui`** — a terminal dashboard for day-to-day reads and a few in-band
   actions ([guide](docs/guides/tui.md); `rsk-tui --demo` needs no hardware)
 
+Without the dev shell, `rsk` also runs on a plain Python ≥ 3.9 toolchain via
+[uv](https://docs.astral.sh/uv/) or pip — `uvx --from ./tools rsk status`,
+`uv tool install ./tools`, or `pipx install ./tools`. Details and the native-lib
+notes are in [tools/README.md](tools/README.md).
+
 Separately, **`rsk-wipe`** is a RAM-only flash-erase *image* you flash
 deliberately to wipe a board for clean-slate testing — it is built and flashed
 like firmware, not run from `PATH` ([rsk-wipe/README.md](rsk-wipe/README.md)).

--- a/crates/rsk-fido/src/clientpin.rs
+++ b/crates/rsk-fido/src/clientpin.rs
@@ -1124,7 +1124,7 @@ mod tests {
         let pin_hash = sha256(b"9246");
         crate::seed::wrap_keydev_legacy(&dev(), &mut fs, &pin_hash[..16]);
         let mut raw = [0u8; 61];
-        assert_eq!(fs.read(EF_KEY_DEV, &mut raw), Some(61));
+        assert_eq!(fs.read(EF_KEY_DEV.get(), &mut raw), Some(61));
         assert_eq!(raw[0], 0x03);
 
         // The OTP build: first verify migrates the verifier and unwraps the
@@ -1143,7 +1143,7 @@ mod tests {
         let mut pin_rec = [0u8; PIN_FILE_LEN];
         ctx.fs.read(EF_PIN, &mut pin_rec).unwrap();
         assert_eq!(pin_rec[0], MAX_PIN_RETRIES);
-        assert_eq!(ctx.fs.read(EF_KEY_DEV, &mut raw), Some(33));
+        assert_eq!(ctx.fs.read(EF_KEY_DEV.get(), &mut raw), Some(33));
         assert_eq!(raw[0], 0x11);
         assert_eq!(load_keydev(&otp_dev(), ctx.fs), Some(seed0));
 

--- a/crates/rsk-fido/src/config.rs
+++ b/crates/rsk-fido/src/config.rs
@@ -7,7 +7,7 @@
 //! the soft-lock pair additionally requires a physical touch.
 
 use minicbor::Decoder;
-use rsk_fs::Storage;
+use rsk_fs::{Sealed, Storage};
 use zeroize::Zeroize;
 
 use rsk_crypto::pinproto::PinProto;
@@ -178,7 +178,7 @@ pub fn authenticator_config<S: Storage, R: Rng>(
 /// power cycle needs a vendor UNLOCK before any FIDO operation; recovery from a
 /// lost lock key is an authenticatorReset (the identity is gone — by design).
 fn aut_enable<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, param: &[u8]) -> CtapResult {
-    if !ctx.fs.has_data(EF_KEY_DEV) {
+    if !ctx.fs.has_key(EF_KEY_DEV) {
         return Err(CtapError::NotAllowed); // already locked, or no seed at all
     }
     if !ctx.state.mse_active {
@@ -194,8 +194,8 @@ fn aut_enable<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, param: &[u8]) -> CtapResu
         let blob = seal_seed_locked(ctx.rng, &lock_key, &seed);
         seed.zeroize();
         ctx.fs
-            .put(EF_KEY_DEV_ENC, &blob)
-            .and_then(|()| ctx.fs.delete(EF_KEY_DEV))
+            .put_key(EF_KEY_DEV_ENC, Sealed::wrap(&blob))
+            .and_then(|()| ctx.fs.delete_key(EF_KEY_DEV))
     });
     lock_key.zeroize();
     match r {
@@ -225,7 +225,7 @@ fn aut_disable<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>) -> CtapResult {
     seed.zeroize();
     r.map_err(|_| CtapError::Other)?;
     ctx.fs
-        .delete(EF_KEY_DEV_ENC)
+        .delete_key(EF_KEY_DEV_ENC)
         .map_err(|_| CtapError::Other)?;
     ctx.state.clear_keydev_dec();
     journal::append(ctx, journal::EV_LOCK_RELEASE, 0, &[]);

--- a/crates/rsk-fido/src/consts.rs
+++ b/crates/rsk-fido/src/consts.rs
@@ -4,6 +4,8 @@
 //! FIDO constants — AIDs, CTAP command bytes, COSE algorithms/curves, auth-data
 //! flags, the AAGUID, size limits and flash file ids.
 
+use rsk_fs::KeyFid;
+
 /// FIDO2 applet AID.
 pub const FIDO_AID: &[u8] = &[0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x01];
 /// Backup FIDO2 applet AID.
@@ -167,14 +169,14 @@ pub const MAX_RESIDENT_CREDENTIALS: u16 = 256;
 pub const EF_AUDIT_META: u16 = 0xC100; // ver ‖ seq_next ‖ start ‖ epoch hash
 pub const EF_AUDIT_RING: u16 = 0xC110; // entry slots, 0xC110..0xC110+AUDIT_RING_SLOTS
 pub const AUDIT_RING_SLOTS: u32 = 128;
-pub const EF_KEY_DEV: u16 = 0xCC00; // device master seed, encrypted
+pub const EF_KEY_DEV: KeyFid = KeyFid::new(0xCC00); // device master seed, kbase-sealed
 pub const EF_BACKUP_SEALED: u16 = 0xCC02; // [1] once the seed has been backed up
 /// Soft-locked seed: ChaCha20-Poly1305(host lock key) over the seed value.
-pub const EF_KEY_DEV_ENC: u16 = 0xCC03;
+pub const EF_KEY_DEV_ENC: KeyFid = KeyFid::new(0xCC03);
 pub const EF_EE_DEV: u16 = 0xCE00; // U2F end-entity attestation certificate
 // Org-provisioned attestation (vendor ATT_IMPORT). Device identity, not user
 // data: both survive authenticatorReset; ATT_CLEAR removes them.
-pub const EF_ATT_KEY: u16 = 0xCE10; // org attestation P-256 scalar, kbase-sealed
+pub const EF_ATT_KEY: KeyFid = KeyFid::new(0xCE10); // org attestation P-256 scalar, kbase-sealed
 pub const EF_ATT_CHAIN: u16 = 0xCE11; // packed DER chain: count ‖ (len LE ‖ der)*
 /// `enableEnterpriseAttestation` — persists until reset (CTAP 2.1), hence flash.
 pub const EF_EA_ENABLED: u16 = 0xCE12;

--- a/crates/rsk-fido/src/credential.rs
+++ b/crates/rsk-fido/src/credential.rs
@@ -31,6 +31,9 @@ use crate::keyderiv::{KEY_HANDLE_LEN, verify_key};
 
 const CRED_PROTO: &[u8; 4] = b"\xf1\xd0\x02\x02";
 const CRED_PROTO_RESIDENT: &[u8; 4] = b"\xf1\xd0\x02\x03";
+/// Derive label for the EF_RP rpId box — domain-separated from the credential-id
+/// protos so the rpId box key can never coincide with a cred-box key.
+const RP_PROTO: &[u8] = b"RS-Key/EF_RP/rpId";
 const PROTO_LEN: usize = 4;
 const IV_LEN: usize = 12;
 const TAG_LEN: usize = 16;
@@ -404,6 +407,9 @@ pub fn derive_large_blob_key(seed: &[u8; 32], cred_id: &[u8]) -> [u8; 32] {
 /// A resident record is `rp_id_hash(32) ‖ resident_id(42) ‖ full_cred_id`.
 pub const RECORD_PREFIX: usize = 32 + CRED_RESIDENT_LEN;
 
+/// EF_RP head before the (boxed) rpId tail: `count(1) ‖ rpIdHash(32)`.
+pub(crate) const RP_PREFIX: usize = 1 + 32;
+
 /// Mark, in one storage pass, which slots `base+0..base+out.len()` hold a live
 /// record (`out[i]` is occupied iff a key `base+i` exists). One pass is
 /// O(items); per-slot `fs.read` probing is not — a `read` of an *absent* slot
@@ -473,13 +479,21 @@ pub fn credential_store<S: Storage>(
     fs.put(EF_CRED + slot, &rec[..total])?;
 
     if new_record {
-        bump_rp(fs, rp_id_hash, rp_id)?;
+        bump_rp(fs, seed, rp_id_hash, rp_id)?;
     }
     Ok(())
 }
 
 /// Increment the credential count for an rp, creating its EF_RP record if new.
-fn bump_rp<S: Storage>(fs: &mut Fs<S>, rp_id_hash: &[u8; 32], rp_id: &str) -> Result<()> {
+/// A new record's rpId domain is boxed under the device seed (see [`seal_rp_id`])
+/// so a flash dump never reveals the cleartext list of relying parties; the
+/// rpIdHash stays cleartext as the O(1) lookup key.
+fn bump_rp<S: Storage>(
+    fs: &mut Fs<S>,
+    seed: &[u8; 32],
+    rp_id_hash: &[u8; 32],
+    rp_id: &str,
+) -> Result<()> {
     let mut rec = [0u8; 256];
     let mut free: Option<u16> = None;
     let mut occupied = [false; MAX_RESIDENT_CREDENTIALS as usize];
@@ -493,24 +507,134 @@ fn bump_rp<S: Storage>(fs: &mut Fs<S>, rp_id_hash: &[u8; 32], rp_id: &str) -> Re
         }
         let fid = EF_RP + i;
         if let Some(n) = fs.read(fid, &mut rec)
-            && n >= 33
-            && rec[1..33] == *rp_id_hash
+            && n >= RP_PREFIX
+            && rec[1..RP_PREFIX] == *rp_id_hash
         {
+            // Existing rp: bump the count, re-storing the boxed tail verbatim.
             let n = n.min(rec.len());
             rec[0] = rec[0].saturating_add(1);
             return fs.put(fid, &rec[..n]);
         }
     }
     let slot = free.ok_or(Error::NoMemory)?;
+    rec[0] = 1;
+    rec[1..RP_PREFIX].copy_from_slice(rp_id_hash);
+    let blen = seal_rp_id(seed, rp_id, rp_id_hash, &mut rec[RP_PREFIX..])?;
+    fs.put(EF_RP + slot, &rec[..RP_PREFIX + blen])
+}
+
+/// Box the rpId domain under the device seed. Layout written to `out`:
+/// `iv(12) ‖ ciphertext ‖ poly1305_tag(16)`, ChaCha20-Poly1305 with the rpIdHash
+/// as AAD. The IV is *deterministic* — there is exactly one EF_RP record per
+/// rpIdHash and its plaintext (the domain) is immutable, so a fixed (key, iv)
+/// never encrypts two different messages, which is the only thing nonce reuse
+/// must avoid. Returns the box length.
+pub(crate) fn seal_rp_id(
+    seed: &[u8; 32],
+    rp_id: &str,
+    rp_id_hash: &[u8; 32],
+    out: &mut [u8],
+) -> Result<usize> {
     let id = rp_id.as_bytes();
-    let total = 1 + 32 + id.len();
-    if total > rec.len() {
+    let total = IV_LEN + id.len() + TAG_LEN;
+    if total > out.len() {
         return Err(Error::NoMemory);
     }
-    rec[0] = 1;
-    rec[1..33].copy_from_slice(rp_id_hash);
-    rec[33..total].copy_from_slice(id);
-    fs.put(EF_RP + slot, &rec[..total])
+    let mut key = derive_chacha_key(seed, RP_PROTO);
+    let iv_full = hmac_sha256(&key, rp_id_hash);
+    let mut iv = [0u8; IV_LEN];
+    iv.copy_from_slice(&iv_full[..IV_LEN]);
+    out[..IV_LEN].copy_from_slice(&iv);
+    out[IV_LEN..IV_LEN + id.len()].copy_from_slice(id);
+    let tag = chacha20poly1305_encrypt(&key, &iv, rp_id_hash, &mut out[IV_LEN..IV_LEN + id.len()]);
+    out[IV_LEN + id.len()..total].copy_from_slice(&tag);
+    key.zeroize();
+    Ok(total)
+}
+
+/// Recover the rpId domain from an EF_RP `tail`, whether it is a box (written by
+/// [`seal_rp_id`]) or a legacy cleartext domain. The recovered string is written
+/// into `out` and returned alongside a `was_boxed` flag (used by the boot
+/// migration to decide whether to re-box). Trial-decryption distinguishes the
+/// two formats: a cleartext domain fails the poly1305 check (probability of a
+/// false positive ≈ 2⁻¹²⁸).
+pub(crate) fn unseal_rp_id<'a>(
+    seed: &[u8; 32],
+    rp_id_hash: &[u8; 32],
+    tail: &[u8],
+    out: &'a mut [u8],
+) -> Option<(&'a str, bool)> {
+    let n = tail.len();
+    // A box is iv(12) ‖ ct ‖ tag(16): at least 28 bytes, and it authenticates.
+    if n >= IV_LEN + TAG_LEN && n <= out.len() {
+        let ct_len = n - IV_LEN - TAG_LEN;
+        let mut iv = [0u8; IV_LEN];
+        iv.copy_from_slice(&tail[..IV_LEN]);
+        let mut tag = [0u8; TAG_LEN];
+        tag.copy_from_slice(&tail[n - TAG_LEN..]);
+        out[..ct_len].copy_from_slice(&tail[IV_LEN..IV_LEN + ct_len]);
+        let mut key = derive_chacha_key(seed, RP_PROTO);
+        let ok = chacha20poly1305_decrypt(&key, &iv, rp_id_hash, &mut out[..ct_len], &tag).is_ok();
+        key.zeroize();
+        if ok {
+            return core::str::from_utf8(&out[..ct_len]).ok().map(|s| (s, true));
+        }
+    }
+    // Legacy cleartext domain (the failed decrypt above left `out` garbled, so
+    // re-copy the raw tail here).
+    if n <= out.len() {
+        out[..n].copy_from_slice(tail);
+        return core::str::from_utf8(&out[..n]).ok().map(|s| (s, false));
+    }
+    None
+}
+
+/// Boot pass: re-box any legacy cleartext EF_RP record so a flash dump no longer
+/// reveals the cleartext list of relying parties. Idempotent and crash-safe —
+/// already-boxed records authenticate and are skipped, and a partially-migrated
+/// set converges over boots. Must run after the keydev seed is readable under
+/// the current root (i.e. after [`crate::seed::migrate_keydev_boot`]).
+pub fn migrate_rp_seal<S: Storage>(dev: &Device, fs: &mut Fs<S>) {
+    let mut occupied = [false; MAX_RESIDENT_CREDENTIALS as usize];
+    slot_map(fs, EF_RP, &mut occupied);
+    if !occupied.iter().any(|&b| b) {
+        return; // no resident-cred RPs → nothing to seal, don't materialize the seed
+    }
+    let Some(mut seed) = crate::seed::load_keydev(dev, fs) else {
+        return;
+    };
+    let mut buf = [0u8; 256];
+    let mut plain = [0u8; 256];
+    let mut out = [0u8; 256];
+    for i in 0..MAX_RESIDENT_CREDENTIALS {
+        if !occupied[i as usize] {
+            continue;
+        }
+        let fid = EF_RP + i;
+        let Some(n) = fs.read(fid, &mut buf) else {
+            continue;
+        };
+        let n = n.min(buf.len());
+        if n < RP_PREFIX {
+            continue;
+        }
+        let mut rp_id_hash = [0u8; 32];
+        rp_id_hash.copy_from_slice(&buf[1..RP_PREFIX]);
+        let Some((domain, was_boxed)) =
+            unseal_rp_id(&seed, &rp_id_hash, &buf[RP_PREFIX..n], &mut plain)
+        else {
+            continue;
+        };
+        if was_boxed {
+            continue; // already sealed
+        }
+        out[0] = buf[0];
+        out[1..RP_PREFIX].copy_from_slice(&rp_id_hash);
+        if let Ok(blen) = seal_rp_id(&seed, domain, &rp_id_hash, &mut out[RP_PREFIX..]) {
+            let _ = fs.put(fid, &out[..RP_PREFIX + blen]);
+        }
+    }
+    seed.zeroize();
 }
 
 #[cfg(test)]
@@ -715,7 +839,14 @@ mod tests {
         let m = fs.read(EF_RP, &mut rp).unwrap();
         assert_eq!(rp[0], 1);
         assert_eq!(&rp[1..33], &rp_hash[..]);
-        assert_eq!(&rp[33..m], b"example.com");
+        // The rpId domain tail is boxed under the seed: not cleartext on flash,
+        // but it un-boxes back to the original domain.
+        assert_ne!(&rp[RP_PREFIX..m], b"example.com");
+        let mut scratch = [0u8; 256];
+        let (domain, was_boxed) =
+            unseal_rp_id(&SEED, &rp_hash, &rp[RP_PREFIX..m], &mut scratch).unwrap();
+        assert_eq!(domain, "example.com");
+        assert!(was_boxed);
 
         // Re-registering the SAME user reuses the slot (no new RP record / count bump).
         let iv2 = [0x22u8; 12];

--- a/crates/rsk-fido/src/credmgmt.rs
+++ b/crates/rsk-fido/src/credmgmt.rs
@@ -24,8 +24,8 @@ use crate::consts::{
     EF_CRED, EF_RP, MAX_RESIDENT_CREDENTIALS,
 };
 use crate::credential::{
-    CRED_RESIDENT_LEN, CredInput, RECORD_PREFIX, credential_create, credential_load,
-    credential_store, derive_large_blob_key, slot_map,
+    CRED_RESIDENT_LEN, CredInput, RECORD_PREFIX, RP_PREFIX, credential_create, credential_load,
+    credential_store, derive_large_blob_key, slot_map, unseal_rp_id,
 };
 use crate::ec::CredKey;
 use crate::error::{CtapError, CtapResult};
@@ -34,8 +34,9 @@ use crate::state::{FidoState, PERM_CM};
 use crate::{Ctx, Rng};
 
 const MAX_RAW_SUBPARA: usize = 256;
-/// EF_RP record: `count(1) ‖ rpIdHash(32) ‖ rpId_text`.
-const RP_PREFIX: usize = 33;
+// EF_RP record: `count(1) ‖ rpIdHash(32) ‖ box(rpId_text)` — the rpId domain is
+// boxed under the device seed (see `credential::seal_rp_id`); `RP_PREFIX` spans
+// the cleartext `count ‖ rpIdHash` head.
 
 struct Req<'a> {
     subcommand: u64,
@@ -314,12 +315,20 @@ fn enumerate_rps<S: Storage, R: Rng>(
     }
     ctx.state.cm.rp_counter = target.saturating_add(1);
 
-    let rp_id = core::str::from_utf8(&rp[RP_PREFIX..rp_len]).map_err(|_| CtapError::Other)?;
+    // The EF_RP tail is boxed under the device seed — recover the rpId domain.
+    let mut rp_id_hash = [0u8; 32];
+    rp_id_hash.copy_from_slice(&rp[1..RP_PREFIX]);
+    let mut seed = ctx.load_keydev().ok_or(CtapError::NotAllowed)?;
+    let mut scratch = [0u8; 256];
+    let unsealed = unseal_rp_id(&seed, &rp_id_hash, &rp[RP_PREFIX..rp_len], &mut scratch);
+    seed.zeroize();
+    let (rp_id, _) = unsealed.ok_or(CtapError::Other)?;
+
     let mut enc = Encoder::new(Cursor::new(out));
     enc.map(if begin { 3 } else { 2 })
         .and_then(|e| e.u8(3)?.map(1))
         .and_then(|e| e.str("id")?.str(rp_id))
-        .and_then(|e| e.u8(4)?.bytes(&rp[1..RP_PREFIX]))
+        .and_then(|e| e.u8(4)?.bytes(&rp_id_hash))
         .map_err(|_| CtapError::Other)?;
     if begin {
         enc.u8(5)
@@ -1369,6 +1378,98 @@ mod tests {
         assert_eq!(
             run(&mut fs, &mut state, &cm_next(0x05), &mut out),
             Err(CtapError::NotAllowed)
+        );
+    }
+
+    // Does any live EF_RP record contain `needle` in its raw at-rest bytes?
+    fn rp_flash_has(fs: &mut Fs<RamStorage>, needle: &[u8]) -> bool {
+        let mut occupied = [false; MAX_RESIDENT_CREDENTIALS as usize];
+        slot_map(fs, EF_RP, &mut occupied);
+        let mut buf = [0u8; 256];
+        for i in 0..MAX_RESIDENT_CREDENTIALS {
+            if !occupied[i as usize] {
+                continue;
+            }
+            if let Some(n) = fs.read(EF_RP + i, &mut buf) {
+                let n = n.min(buf.len());
+                if buf[..n].windows(needle.len()).any(|w| w == needle) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn rp_domain_sealed_on_flash() {
+        let (mut fs, mut rng) = setup();
+        register(&mut fs, &mut rng, "example.com", &[1, 1], "alice");
+        // The rpId domain must not survive in cleartext in the EF_RP record...
+        assert!(
+            !rp_flash_has(&mut fs, b"example.com"),
+            "rpId domain leaked in cleartext on flash"
+        );
+        // ...but enumerateRPs still round-trips it to the host.
+        let mut state = armed(PERM_CM);
+        let mut out = [0u8; 256];
+        let n = run(
+            &mut fs,
+            &mut state,
+            &cm_request(0x02, None, &TOKEN),
+            &mut out,
+        )
+        .unwrap();
+        let (id, hash, _) = parse_rp(&out[..n], true);
+        assert_eq!(id, "example.com");
+        assert_eq!(hash, sha256(b"example.com"));
+    }
+
+    #[test]
+    fn legacy_plaintext_rp_migrates_and_stays_usable() {
+        let (mut fs, _rng) = setup();
+        // A pre-migration EF_RP record: count(1) ‖ rpIdHash(32) ‖ cleartext domain.
+        let hash = sha256(b"example.com");
+        let mut rec = std::vec::Vec::new();
+        rec.push(1u8);
+        rec.extend_from_slice(&hash);
+        rec.extend_from_slice(b"example.com");
+        fs.put(EF_RP, &rec).unwrap();
+        assert!(rp_flash_has(&mut fs, b"example.com"));
+
+        // Boot migration boxes the cleartext domain in place.
+        crate::credential::migrate_rp_seal(&dev(), &mut fs);
+        assert!(
+            !rp_flash_has(&mut fs, b"example.com"),
+            "migration left the rpId domain in cleartext"
+        );
+        // The count byte survives the re-box.
+        let mut buf = [0u8; 256];
+        let n = fs.read(EF_RP, &mut buf).unwrap();
+        assert_eq!(buf[0], 1);
+        assert_eq!(buf[1..RP_PREFIX], hash[..]);
+
+        // enumerateRPs still recovers the original domain.
+        let mut state = armed(PERM_CM);
+        let mut out = [0u8; 256];
+        let n2 = run(
+            &mut fs,
+            &mut state,
+            &cm_request(0x02, None, &TOKEN),
+            &mut out,
+        )
+        .unwrap();
+        let (id, h, _) = parse_rp(&out[..n2], true);
+        assert_eq!(id, "example.com");
+        assert_eq!(h, hash);
+
+        // Idempotent: a second pass is a no-op and the record stays usable.
+        let before = buf[..n.min(buf.len())].to_vec();
+        crate::credential::migrate_rp_seal(&dev(), &mut fs);
+        let m = fs.read(EF_RP, &mut buf).unwrap();
+        assert_eq!(
+            &buf[..m.min(buf.len())],
+            &before[..],
+            "migration not idempotent"
         );
     }
 }

--- a/crates/rsk-fido/src/reset.rs
+++ b/crates/rsk-fido/src/reset.rs
@@ -62,20 +62,23 @@ pub fn reset<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>) -> CtapResult {
 /// 0x10xx range (FIDO `EF_PIN` 0x1080 vs OpenPGP PW1 0x1081), so this is an
 /// explicit set plus the resident-credential ranges, not a range test.
 fn is_fido_fid(fid: u16) -> bool {
-    matches!(
-        fid,
-        EF_KEY_DEV
-            | EF_KEY_DEV_ENC
-            | EF_BACKUP_SEALED
-            | EF_EE_DEV
-            | EF_COUNTER
-            | EF_PIN
-            | EF_AUTHTOKEN
-            | EF_PAUTHTOKEN
-            | EF_MINPINLEN
-            | EF_LARGEBLOB
-            | EF_EA_ENABLED
-    ) || (EF_CRED..EF_CRED + MAX_RESIDENT_CREDENTIALS).contains(&fid)
+    // EF_KEY_DEV / EF_KEY_DEV_ENC are `KeyFid`s (sealed seed slots), so they
+    // can't sit in the `u16` match arm — compare their raw FIDs explicitly.
+    fid == EF_KEY_DEV.get()
+        || fid == EF_KEY_DEV_ENC.get()
+        || matches!(
+            fid,
+            EF_BACKUP_SEALED
+                | EF_EE_DEV
+                | EF_COUNTER
+                | EF_PIN
+                | EF_AUTHTOKEN
+                | EF_PAUTHTOKEN
+                | EF_MINPINLEN
+                | EF_LARGEBLOB
+                | EF_EA_ENABLED
+        )
+        || (EF_CRED..EF_CRED + MAX_RESIDENT_CREDENTIALS).contains(&fid)
         || (EF_RP..EF_RP + MAX_RESIDENT_CREDENTIALS).contains(&fid)
 }
 

--- a/crates/rsk-fido/src/seed.rs
+++ b/crates/rsk-fido/src/seed.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroize;
 
 use rsk_crypto::chachapoly::{chacha20poly1305_decrypt, chacha20poly1305_encrypt};
 use rsk_crypto::{Device, Mode, PinKdf, aes_decrypt, aes_encrypt};
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Sealed, Storage};
 use rsk_sdk::error::{Error, Result};
 
 use crate::Rng;
@@ -49,7 +49,7 @@ pub const LOCK_BLOB_LEN: usize = 12 + 32 + 16;
 
 /// Whether the soft lock is engaged (the wrapped blob is what's on flash).
 pub fn lock_engaged<S: Storage>(fs: &mut Fs<S>) -> bool {
-    fs.has_data(EF_KEY_DEV_ENC)
+    fs.has_key(EF_KEY_DEV_ENC)
 }
 
 /// Wrap the seed value under a host-supplied 32-byte lock key (AUT_ENABLE).
@@ -130,9 +130,9 @@ pub fn store_att_key<S: Storage>(dev: &Device, fs: &mut Fs<S>, key: &[u8; 32]) -
 }
 
 /// Read and decrypt a 32-byte kbase-sealed value (format tags as above).
-fn get_sealed32<S: Storage>(dev: &Device, fs: &mut Fs<S>, fid: u16) -> Option<[u8; 32]> {
+fn get_sealed32<S: Storage>(dev: &Device, fs: &mut Fs<S>, fid: KeyFid) -> Option<[u8; 32]> {
     let mut buf = [0u8; 64];
-    let n = fs.read(fid, &mut buf)?;
+    let n = fs.read_key(fid, &mut buf)?;
     let seal_dev = dev_for_tag(dev, buf[0]);
     if !(matches!(buf[0], FORMAT_F1 | FORMAT_F1_OTP) && n == KEYDEV_F1_LEN) || seal_dev.is_none() {
         buf.zeroize();
@@ -166,7 +166,7 @@ pub fn encrypt_keydev_f1<S: Storage>(dev: &Device, fs: &mut Fs<S>, seed: &[u8; 3
 fn put_sealed32<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
-    fid: u16,
+    fid: KeyFid,
     value: &[u8; 32],
 ) -> Result<()> {
     let mut kdata = [0u8; KEYDEV_F1_LEN];
@@ -181,7 +181,7 @@ fn put_sealed32<S: Storage>(
         kdata.zeroize();
         return Err(Error::ExecError);
     }
-    let r = fs.put(fid, &kdata);
+    let r = fs.put_key(fid, Sealed::wrap(&kdata));
     kdata.zeroize();
     r
 }
@@ -197,7 +197,7 @@ pub fn migrate_keydev_boot<S: Storage>(dev: &Device, fs: &mut Fs<S>) -> Result<(
         return Ok(());
     }
     let mut buf = [0u8; 64];
-    let Some(KEYDEV_F1_LEN) = fs.read(EF_KEY_DEV, &mut buf) else {
+    let Some(KEYDEV_F1_LEN) = fs.read_key(EF_KEY_DEV, &mut buf) else {
         return Ok(());
     };
     if buf[0] != FORMAT_F1 {
@@ -229,7 +229,7 @@ pub fn migrate_keydev_boot<S: Storage>(dev: &Device, fs: &mut Fs<S>) -> Result<(
 /// verified 16-byte PIN hash.
 pub fn migrate_keydev_pin<S: Storage>(dev: &Device, fs: &mut Fs<S>, pin_hash: &[u8]) -> Result<()> {
     let mut buf = [0u8; 64];
-    let Some(KEYDEV_F3_LEN) = fs.read(EF_KEY_DEV, &mut buf) else {
+    let Some(KEYDEV_F3_LEN) = fs.read_key(EF_KEY_DEV, &mut buf) else {
         return Ok(());
     };
     let (seal_dev, plain) = match buf[0] {
@@ -248,7 +248,7 @@ pub fn migrate_keydev_pin<S: Storage>(dev: &Device, fs: &mut Fs<S>, pin_hash: &[
         out.zeroize();
         return Err(Error::ExecError);
     }
-    let r = fs.put(EF_KEY_DEV, &out);
+    let r = fs.put_key(EF_KEY_DEV, Sealed::wrap(&out));
     out.zeroize();
     r?;
     // A pre-OTP blob on an OTP device still needs its inner layer re-sealed.
@@ -265,7 +265,7 @@ pub fn migrate_keydev_pin<S: Storage>(dev: &Device, fs: &mut Fs<S>, pin_hash: &[
 /// the seed is unreadable here anyway).
 pub fn ensure_seed<S: Storage>(dev: &Device, fs: &mut Fs<S>, rng: &mut impl Rng) -> Result<()> {
     let locked = lock_engaged(fs);
-    if !fs.has_data(EF_KEY_DEV) && !locked {
+    if !fs.has_key(EF_KEY_DEV) && !locked {
         let mut seed = [0u8; 32];
         loop {
             rng.fill(&mut seed);
@@ -321,7 +321,7 @@ pub fn bump_sign_counter<S: Storage>(fs: &mut Fs<S>) -> Result<u32> {
 #[cfg(test)]
 pub(crate) fn wrap_keydev_legacy<S: Storage>(dev: &Device, fs: &mut Fs<S>, pin_hash: &[u8]) {
     let mut raw = [0u8; KEYDEV_F1_LEN];
-    assert_eq!(fs.read(EF_KEY_DEV, &mut raw), Some(KEYDEV_F1_LEN));
+    assert_eq!(fs.read(EF_KEY_DEV.get(), &mut raw), Some(KEYDEV_F1_LEN));
     assert_eq!(raw[0], plain_tag(dev));
     let mut out = [0u8; KEYDEV_F3_LEN];
     out[0] = if dev.otp_key.is_some() {
@@ -332,7 +332,7 @@ pub(crate) fn wrap_keydev_legacy<S: Storage>(dev: &Device, fs: &mut Fs<S>, pin_h
     let session = dev.pin_derive_session(pin_hash);
     dev.encrypt_with_aad(&session, &raw[1..], PinKdf::V2, &[0x24; 12], &mut out[1..])
         .unwrap();
-    fs.put(EF_KEY_DEV, &out).unwrap();
+    fs.put(EF_KEY_DEV.get(), &out).unwrap();
 }
 
 #[cfg(test)]
@@ -369,9 +369,9 @@ mod tests {
         let seed = [0x5A; 32];
         encrypt_keydev_f1(&d, &mut fs, &seed).unwrap();
         // Stored as format(1) + 32 encrypted bytes, not the plaintext seed.
-        assert_eq!(fs.size(EF_KEY_DEV), Some(33));
+        assert_eq!(fs.size(EF_KEY_DEV.get()), Some(33));
         let mut raw = [0u8; 33];
-        fs.read(EF_KEY_DEV, &mut raw).unwrap();
+        fs.read(EF_KEY_DEV.get(), &mut raw).unwrap();
         assert_eq!(raw[0], 0x01);
         assert_ne!(&raw[1..], &seed);
         // load_keydev recovers it.
@@ -398,13 +398,13 @@ mod tests {
         let pin_hash = [0x99u8; 16];
         encrypt_keydev_f1(&d, &mut fs, &seed).unwrap();
         wrap_keydev_legacy(&d, &mut fs, &pin_hash);
-        assert_eq!(fs.size(EF_KEY_DEV), Some(61));
+        assert_eq!(fs.size(EF_KEY_DEV.get()), Some(61));
         // The wrapped blob is unreadable (the UP-only failure window)…
         assert_eq!(load_keydev(&d, &mut fs), None);
         // …until a PIN verify unwraps it back to 0x01, permanently.
         migrate_keydev_pin(&d, &mut fs, &pin_hash).unwrap();
         let mut raw = [0u8; 33];
-        assert_eq!(fs.read(EF_KEY_DEV, &mut raw), Some(33));
+        assert_eq!(fs.read(EF_KEY_DEV.get(), &mut raw), Some(33));
         assert_eq!(raw[0], 0x01);
         assert_eq!(load_keydev(&d, &mut fs), Some(seed));
         // Idempotent.
@@ -420,7 +420,7 @@ mod tests {
         wrap_keydev_legacy(&d, &mut fs, &[0x99u8; 16]);
         assert!(migrate_keydev_pin(&d, &mut fs, &[0x11u8; 16]).is_err());
         let mut raw = [0u8; 61];
-        assert_eq!(fs.read(EF_KEY_DEV, &mut raw), Some(61));
+        assert_eq!(fs.read(EF_KEY_DEV.get(), &mut raw), Some(61));
         assert_eq!(raw[0], 0x03);
     }
 
@@ -471,9 +471,9 @@ mod tests {
         let mut fs = fs();
         let mut rng = SeqRng(9);
         let blob = seal_seed_locked(&mut rng, &[0x4D; 32], &[0x5A; 32]);
-        fs.put(EF_KEY_DEV_ENC, &blob).unwrap();
+        fs.put(EF_KEY_DEV_ENC.get(), &blob).unwrap();
         ensure_seed(&d, &mut fs, &mut rng).unwrap();
-        assert!(!fs.has_data(EF_KEY_DEV));
+        assert!(!fs.has_data(EF_KEY_DEV.get()));
         assert!(fs.has_data(EF_COUNTER)); // the rest of the scan still runs
         assert!(!fs.has_data(EF_EE_DEV)); // cert step skipped (seed unreadable)
     }
@@ -495,7 +495,7 @@ mod tests {
 
         migrate_keydev_boot(&otp_dev(), &mut fs).unwrap();
         let mut raw = [0u8; 33];
-        fs.read(EF_KEY_DEV, &mut raw).unwrap();
+        fs.read(EF_KEY_DEV.get(), &mut raw).unwrap();
         assert_eq!(raw[0], 0x11);
         assert_eq!(load_keydev(&otp_dev(), &mut fs), Some(seed));
 
@@ -510,7 +510,7 @@ mod tests {
         encrypt_keydev_f1(&dev(), &mut fs, &[0x5A; 32]).unwrap();
         migrate_keydev_boot(&dev(), &mut fs).unwrap();
         let mut raw = [0u8; 33];
-        fs.read(EF_KEY_DEV, &mut raw).unwrap();
+        fs.read(EF_KEY_DEV.get(), &mut raw).unwrap();
         assert_eq!(raw[0], 0x01);
     }
 
@@ -522,7 +522,7 @@ mod tests {
         let seed = [0x5A; 32];
         encrypt_keydev_f1(&otp_dev(), &mut fs, &seed).unwrap();
         let mut raw = [0u8; 33];
-        fs.read(EF_KEY_DEV, &mut raw).unwrap();
+        fs.read(EF_KEY_DEV.get(), &mut raw).unwrap();
         assert_eq!(raw[0], 0x11);
         assert_eq!(load_keydev(&dev(), &mut fs), None);
     }
@@ -537,18 +537,18 @@ mod tests {
         encrypt_keydev_f1(&dev(), &mut fs, &seed).unwrap();
         wrap_keydev_legacy(&dev(), &mut fs, &pin_hash);
         let mut raw = [0u8; 61];
-        fs.read(EF_KEY_DEV, &mut raw).unwrap();
+        fs.read(EF_KEY_DEV.get(), &mut raw).unwrap();
         assert_eq!(raw[0], 0x03);
 
         // The boot pass cannot touch a PIN-wrapped blob.
         migrate_keydev_boot(&otp_dev(), &mut fs).unwrap();
-        fs.read(EF_KEY_DEV, &mut raw).unwrap();
+        fs.read(EF_KEY_DEV.get(), &mut raw).unwrap();
         assert_eq!(raw[0], 0x03);
 
         // First PIN verify on the OTP build unwraps the outer layer AND re-seals
         // the inner one — straight to a plain 0x11, loadable with no session.
         migrate_keydev_pin(&otp_dev(), &mut fs, &pin_hash).unwrap();
-        assert_eq!(fs.read(EF_KEY_DEV, &mut raw), Some(33));
+        assert_eq!(fs.read(EF_KEY_DEV.get(), &mut raw), Some(33));
         assert_eq!(raw[0], 0x11);
         assert_eq!(load_keydev(&otp_dev(), &mut fs), Some(seed));
 
@@ -567,17 +567,17 @@ mod tests {
         encrypt_keydev_f1(&otp_dev(), &mut fs, &seed).unwrap();
         wrap_keydev_legacy(&otp_dev(), &mut fs, &pin_hash);
         let mut raw = [0u8; 61];
-        fs.read(EF_KEY_DEV, &mut raw).unwrap();
+        fs.read(EF_KEY_DEV.get(), &mut raw).unwrap();
         assert_eq!(raw[0], 0x13);
 
         // Orphan on a no-OTP build: no-op, no error, still closed.
         migrate_keydev_pin(&dev(), &mut fs, &pin_hash).unwrap();
-        fs.read(EF_KEY_DEV, &mut raw).unwrap();
+        fs.read(EF_KEY_DEV.get(), &mut raw).unwrap();
         assert_eq!(raw[0], 0x13);
         assert_eq!(load_keydev(&dev(), &mut fs), None);
 
         migrate_keydev_pin(&otp_dev(), &mut fs, &pin_hash).unwrap();
-        assert_eq!(fs.read(EF_KEY_DEV, &mut raw), Some(33));
+        assert_eq!(fs.read(EF_KEY_DEV.get(), &mut raw), Some(33));
         assert_eq!(raw[0], 0x11);
         assert_eq!(load_keydev(&otp_dev(), &mut fs), Some(seed));
     }

--- a/crates/rsk-fido/src/vendor.rs
+++ b/crates/rsk-fido/src/vendor.rs
@@ -188,7 +188,7 @@ fn att_import<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, req: &Req) -> CtapResult 
 /// `ATT_CLEAR`: drop the org attestation (same gate as the import).
 fn att_clear<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, req: &Req) -> CtapResult {
     gate(ctx, req)?;
-    let _ = ctx.fs.delete(EF_ATT_KEY);
+    let _ = ctx.fs.delete_key(EF_ATT_KEY);
     let _ = ctx.fs.delete(EF_ATT_CHAIN);
     journal::append(ctx, journal::EV_ATT_CLEAR, 0, &[]);
     Ok(0)
@@ -198,7 +198,7 @@ fn att_clear<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, req: &Req) -> CtapResult {
 /// BACKUP_STATE; the chain itself is public.
 fn att_state<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, out: &mut [u8]) -> CtapResult {
     let mut chain = [0u8; cert::ATT_CHAIN_MAX + 1 + 2 * cert::ATT_CHAIN_MAX_CERTS];
-    let present = ctx.fs.has_data(EF_ATT_KEY);
+    let present = ctx.fs.has_key(EF_ATT_KEY);
     let n = ctx.fs.read(EF_ATT_CHAIN, &mut chain).unwrap_or(0);
     encode(out, |e| {
         e.map(if present && n > 0 { 2 } else { 1 })?
@@ -280,7 +280,7 @@ fn unlock<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, req: &Req) -> CtapResult {
         return Err(CtapError::IntegrityFailure);
     }
     let mut blob = [0u8; LOCK_BLOB_LEN];
-    let n = ctx.fs.read(EF_KEY_DEV_ENC, &mut blob);
+    let n = ctx.fs.read_key(EF_KEY_DEV_ENC, &mut blob);
     let seed = n.and_then(|n| open_seed_locked(&lock_key, &blob[..n]));
     lock_key.zeroize();
     match seed {
@@ -478,7 +478,7 @@ fn backup_finalize<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>) -> CtapResult {
 /// cycle.
 fn backup_state<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, out: &mut [u8]) -> CtapResult {
     let sealed = ctx.fs.has_data(EF_BACKUP_SEALED);
-    let has_seed = ctx.fs.has_data(EF_KEY_DEV);
+    let has_seed = ctx.fs.has_key(EF_KEY_DEV);
     let locked = lock_engaged(ctx.fs);
     let unlocked = ctx.state.keydev_dec.is_some();
     encode(out, |e| {
@@ -1134,8 +1134,8 @@ mod tests {
     #[test]
     fn lock_enable_wraps_seed_and_drops_plain() {
         let (mut fs, mut rng, mut st, _host, _seed) = locked_setup();
-        assert!(!fs.has_data(EF_KEY_DEV));
-        assert_eq!(fs.size(EF_KEY_DEV_ENC), Some(LOCK_BLOB_LEN));
+        assert!(!fs.has_data(EF_KEY_DEV.get()));
+        assert_eq!(fs.size(EF_KEY_DEV_ENC.get()), Some(LOCK_BLOB_LEN));
         // No RAM copy after enable — operations are locked out immediately.
         assert!(st.keydev_dec.is_none());
         assert_eq!(load_keydev(&dev(), &mut fs), None);
@@ -1161,7 +1161,7 @@ mod tests {
             presence: &mut presence,
         };
         assert_eq!(ctx.load_keydev(), Some(seed));
-        assert!(!fs.has_data(EF_KEY_DEV));
+        assert!(!fs.has_data(EF_KEY_DEV.get()));
         assert_eq!(
             state_flags(&mut fs, &mut rng, &mut st),
             (false, false, true, true)
@@ -1191,7 +1191,7 @@ mod tests {
         let mut req = [0u8; 192];
         let n = config_vendor_req(crate::consts::CONFIG_AUT_DISABLE, None, &mut req);
         run_config(&mut fs, &mut rng, &mut st, &mut AlwaysConfirm, &req[..n]).unwrap();
-        assert!(!fs.has_data(EF_KEY_DEV_ENC));
+        assert!(!fs.has_data(EF_KEY_DEV_ENC.get()));
         assert!(st.keydev_dec.is_none()); // no stale RAM copy
         assert_eq!(load_keydev(&dev(), &mut fs), Some(seed));
         assert_eq!(
@@ -1207,7 +1207,7 @@ mod tests {
         let n = config_vendor_req(crate::consts::CONFIG_AUT_DISABLE, None, &mut req);
         let e = run_config(&mut fs, &mut rng, &mut st, &mut AlwaysConfirm, &req[..n]);
         assert_eq!(e, Err(CtapError::PinAuthInvalid));
-        assert!(fs.has_data(EF_KEY_DEV_ENC));
+        assert!(fs.has_data(EF_KEY_DEV_ENC.get()));
     }
 
     #[test]
@@ -1229,7 +1229,7 @@ mod tests {
         let n = config_vendor_req(crate::consts::CONFIG_AUT_ENABLE, Some(&blob), &mut req);
         let e = run_config(&mut fs, &mut rng, &mut st, &mut AlwaysConfirm, &req[..n]);
         assert_eq!(e, Err(CtapError::NotAllowed));
-        assert!(fs.has_data(EF_KEY_DEV));
+        assert!(fs.has_data(EF_KEY_DEV.get()));
     }
 
     #[test]
@@ -1242,8 +1242,8 @@ mod tests {
         let n = config_vendor_req(crate::consts::CONFIG_AUT_ENABLE, Some(&blob), &mut req);
         let e = run_config(&mut fs, &mut rng, &mut st, &mut Decline, &req[..n]);
         assert_eq!(e, Err(CtapError::OperationDenied));
-        assert!(fs.has_data(EF_KEY_DEV));
-        assert!(!fs.has_data(EF_KEY_DEV_ENC));
+        assert!(fs.has_data(EF_KEY_DEV.get()));
+        assert!(!fs.has_data(EF_KEY_DEV_ENC.get()));
     }
 
     #[test]
@@ -1317,7 +1317,7 @@ mod tests {
             presence: &mut presence,
         };
         crate::reset::reset(&mut ctx).unwrap();
-        assert!(!fs.has_data(EF_KEY_DEV_ENC));
+        assert!(!fs.has_data(EF_KEY_DEV_ENC.get()));
         let new_seed = load_keydev(&dev(), &mut fs).unwrap();
         assert_ne!(new_seed, old_seed); // fresh identity — the recovery path
     }
@@ -1326,7 +1326,7 @@ mod tests {
     fn ensure_seed_does_not_regenerate_under_lock() {
         let (mut fs, mut rng, mut st, host, seed) = locked_setup();
         ensure_seed(&dev(), &mut fs, &mut rng).unwrap();
-        assert!(!fs.has_data(EF_KEY_DEV)); // boot on a locked device: no regen
+        assert!(!fs.has_data(EF_KEY_DEV.get())); // boot on a locked device: no regen
         run_unlock(&mut fs, &mut rng, &mut st, &LOCK_KEY, &host, 0x27).unwrap();
         assert_eq!(st.keydev_dec, Some(seed)); // blob untouched, same seed
     }

--- a/crates/rsk-fs/src/fs.rs
+++ b/crates/rsk-fs/src/fs.rs
@@ -6,6 +6,7 @@
 use heapless::Vec;
 use rsk_sdk::error::{Error, Result};
 
+use crate::sealed::{KeyFid, Sealed};
 use crate::storage::Storage;
 use crate::{EF_META, FILE_EF_TRANSPARENT, FILE_TYPE_WORKING_EF, MAX_DYNAMIC_FILES};
 
@@ -198,6 +199,34 @@ impl<S: Storage> Fs<S> {
         self.mark_absent(fid);
         self.dynamic.retain(|&f| f != fid);
         Ok(())
+    }
+
+    // ---- typed key-slot API ----
+    // Secret key material reaches flash only through these. They delegate to the
+    // plaintext primitives, but because a [`KeyFid`] is not a `u16` and
+    // [`put_key`](Self::put_key) demands a [`Sealed`] payload, a key slot can be
+    // neither written nor read by the generic `put`/`read` — the seal API is the
+    // only route in. See [`crate::sealed`].
+
+    /// Store sealed key material at `fid`.
+    pub fn put_key(&mut self, fid: KeyFid, sealed: Sealed) -> Result<()> {
+        self.put(fid.get(), sealed.as_bytes())
+    }
+
+    /// Copy a sealed key blob into `buf`; returns its full length, or `None` if
+    /// the slot is absent.
+    pub fn read_key(&mut self, fid: KeyFid, buf: &mut [u8]) -> Option<usize> {
+        self.read(fid.get(), buf)
+    }
+
+    /// Whether the key slot holds non-empty data.
+    pub fn has_key(&mut self, fid: KeyFid) -> bool {
+        self.has_data(fid.get())
+    }
+
+    /// Delete a key slot.
+    pub fn delete_key(&mut self, fid: KeyFid) -> Result<()> {
+        self.delete(fid.get())
     }
 
     /// ACL gate for `op` (an `ACL_OP_*` index).
@@ -528,6 +557,31 @@ mod tests {
             st.size_calls, 0,
             "absent size/has_data must not probe the backend"
         );
+    }
+
+    #[test]
+    fn typed_key_api_roundtrips() {
+        // The typed key API (`put_key`/`read_key`/`has_key`/`delete_key`) is the
+        // only way to reach a `KeyFid` slot; it must behave exactly like the
+        // plaintext path it delegates to.
+        let mut fs = fs();
+        let slot = KeyFid::new(0xCEFF);
+        let mut buf = [0u8; 32];
+        // Absent at first.
+        assert_eq!(fs.read_key(slot, &mut buf), None);
+        assert!(!fs.has_key(slot));
+        // Store a (notionally sealed) blob and read it back.
+        let blob = b"nonce|ciphertext|tag";
+        fs.put_key(slot, Sealed::wrap(blob)).unwrap();
+        assert!(fs.has_key(slot));
+        assert_eq!(fs.read_key(slot, &mut buf), Some(blob.len()));
+        assert_eq!(&buf[..blob.len()], blob);
+        // Same bytes underneath — the type is a guard rail, not a separate store.
+        assert_eq!(fs.read(slot.get(), &mut buf), Some(blob.len()));
+        // Delete clears it.
+        fs.delete_key(slot).unwrap();
+        assert!(!fs.has_key(slot));
+        assert_eq!(fs.read_key(slot, &mut buf), None);
     }
 
     #[test]

--- a/crates/rsk-fs/src/lib.rs
+++ b/crates/rsk-fs/src/lib.rs
@@ -9,9 +9,11 @@
 //! a RAM backend. File metadata (type/ACL/parent) comes from a static table.
 
 pub mod fs;
+pub mod sealed;
 pub mod storage;
 
 pub use fs::{FileDesc, Fs};
+pub use sealed::{KeyFid, Sealed};
 pub use storage::Storage;
 
 // ---- file types ----

--- a/crates/rsk-fs/src/sealed.rs
+++ b/crates/rsk-fs/src/sealed.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! Type-enforced chokepoint for at-rest secret key material.
+//!
+//! Every secret RS-Key persists — FIDO seeds, PIV/OpenPGP private keys, OATH
+//! shared secrets, DEKs — must be cipher-sealed *before* it reaches flash: the
+//! [`Storage`](crate::Storage) backend is plaintext, so a bare
+//! `fs.put(fid, raw_secret)` would leave a recoverable secret on the chip.
+//! Historically that rule held only by convention — a stray `fs.put` of a raw
+//! key compiled fine. These two newtypes make it a compile-time property:
+//!
+//! * [`KeyFid`] names a slot that holds sealed secret material. It is *not* a
+//!   `u16`, so the plaintext [`Fs::put`](crate::Fs::put) /
+//!   [`Fs::read`](crate::Fs::read) cannot target a key slot — a careless
+//!   `fs.put(EF_KEY_DEV, raw)` fails to compile. Key writes go through
+//!   [`Fs::put_key`](crate::Fs::put_key), reads through
+//!   [`Fs::read_key`](crate::Fs::read_key).
+//! * [`Sealed`] is the only payload [`Fs::put_key`](crate::Fs::put_key)
+//!   accepts. It is produced by [`Sealed::wrap`], which a seal routine calls on
+//!   its cipher output. The wrap is deliberately loud and greppable: getting a
+//!   raw secret into a key slot now reads `Sealed::wrap(raw)` at the call site,
+//!   which no longer looks like an innocent `put`.
+//!
+//! The backend stays untyped (it is format-agnostic plaintext I/O); the
+//! enforcement lives at the `Fs` API — the boundary every applet crosses.
+//!
+//! The compile-time guarantee, asserted: a key FID is a distinct type, so it
+//! can never reach the plaintext `u16` file API (this must NOT build):
+//!
+//! ```compile_fail
+//! use rsk_fs::KeyFid;
+//! const SECRET_SLOT: KeyFid = KeyFid::new(0xCC00);
+//! let _plain_fid: u16 = SECRET_SLOT; // KeyFid is not u16 — and `Fs::put` wants u16
+//! ```
+//!
+//! Recovering the raw FID is always explicit and greppable:
+//!
+//! ```
+//! use rsk_fs::KeyFid;
+//! const SECRET_SLOT: KeyFid = KeyFid::new(0xCC00);
+//! assert_eq!(SECRET_SLOT.get(), 0xCC00);
+//! ```
+
+/// A FID naming a slot that holds **sealed** secret key material.
+///
+/// Distinct from a plaintext `u16` FID precisely so the generic file API cannot
+/// write or read it. Build one from a slot constant or a computed FID with
+/// [`KeyFid::new`]; recover the raw FID with [`KeyFid::get`] only where a raw
+/// FID is genuinely required (iterating a slot range during migration, say) —
+/// prefer the typed [`Fs::put_key`](crate::Fs::put_key) /
+/// [`Fs::read_key`](crate::Fs::read_key) API.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct KeyFid(u16);
+
+impl KeyFid {
+    /// Name a key slot by its 16-bit FID.
+    #[inline]
+    pub const fn new(fid: u16) -> Self {
+        KeyFid(fid)
+    }
+
+    /// The underlying 16-bit FID — an explicit, greppable escape hatch.
+    #[inline]
+    pub const fn get(self) -> u16 {
+        self.0
+    }
+}
+
+/// Cipher output on its way to a [`KeyFid`] slot — the only payload
+/// [`Fs::put_key`](crate::Fs::put_key) accepts.
+///
+/// Borrows the sealed blob, whatever an applet's seal format is (`nonce ‖ ct ‖
+/// tag`, a CBC/CFB ciphertext, …). [`Sealed::wrap`] is intentionally the only
+/// constructor and intentionally loud: a seal routine calls it on the bytes it
+/// just encrypted, so putting a secret into a key slot is always visible as
+/// `Sealed::wrap(...)` at the call site. It is a marker, not a proof — it cannot
+/// verify the bytes are genuinely ciphertext — but it removes the silent path,
+/// and paired with [`KeyFid`] it makes the seal API the only route to a key
+/// slot.
+pub struct Sealed<'a>(&'a [u8]);
+
+impl<'a> Sealed<'a> {
+    /// Wrap freshly-sealed cipher output. Call at the end of a seal routine,
+    /// never on a plaintext secret.
+    #[inline]
+    pub fn wrap(blob: &'a [u8]) -> Self {
+        Sealed(blob)
+    }
+
+    /// The sealed bytes, for the one consumer that writes them to flash.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0
+    }
+}

--- a/crates/rsk-oath/Cargo.toml
+++ b/crates/rsk-oath/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 rsk-sdk = { workspace = true }
 rsk-fs = { workspace = true }
 rsk-crypto = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 # RamStorage for the host tests (the same backend rsk-fido/rsk-openpgp use).

--- a/crates/rsk-oath/src/lib.rs
+++ b/crates/rsk-oath/src/lib.rs
@@ -7,12 +7,15 @@
 
 #![cfg_attr(not(test), no_std)]
 
+mod seal;
+
 use core::cell::RefCell;
 
 use rsk_crypto::{Device, hmac_sha1, hmac_sha256, hmac_sha512};
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Storage};
 use rsk_sdk::tlv::{find_tag, format_len};
 use rsk_sdk::{Apdu, Applet, ResBuf, Sw};
+use zeroize::Zeroize;
 
 /// YKOATH applet AID.
 pub const OATH_AID: &[u8] = &[0xA0, 0x00, 0x00, 0x05, 0x27, 0x21, 0x01];
@@ -52,8 +55,8 @@ impl UserPresence for AlwaysConfirm {
 }
 
 // FIDs.
-const EF_OATH_CRED: u16 = 0xBA00; // 255 slots, 0xBA00..=0xBAFE
-const EF_OATH_CODE: u16 = 0xBAFF;
+const EF_OATH_CRED: u16 = 0xBA00; // 255 cred slots, 0xBA00..=0xBAFE (each a sealed KeyFid)
+const EF_OATH_CODE: KeyFid = KeyFid::new(0xBAFF); // SET CODE validation key, sealed
 const EF_OTP_PIN: u16 = 0x10A0;
 
 const MAX_OATH_CRED: u16 = 255;
@@ -229,16 +232,24 @@ impl<'a> OathApplet<'a> {
         }
 
         let mut scratch = [0u8; CRED_MAX];
-        let fid = match find_cred(fs, name, &mut scratch) {
+        let dev = self.device();
+        let fid = match find_cred(&dev, fs, name, &mut scratch) {
             Some((fid, _)) => fid,
             None => match free_slot(fs) {
                 Some(fid) => fid,
                 None => return Sw::FILE_FULL,
             },
         };
-        match fs.put(fid, &blob[..n]) {
-            Ok(()) => Sw::OK,
-            Err(_) => Sw::MEMORY_FAILURE,
+        if seal::seal_put(
+            &dev,
+            fs,
+            &mut *self.rng.borrow_mut(),
+            KeyFid::new(fid),
+            &blob[..n],
+        ) {
+            Sw::OK
+        } else {
+            Sw::MEMORY_FAILURE
         }
     }
 
@@ -250,7 +261,8 @@ impl<'a> OathApplet<'a> {
             return Sw::INCORRECT_PARAMS;
         };
         let mut scratch = [0u8; CRED_MAX];
-        match find_cred(fs, name, &mut scratch) {
+        let dev = self.device();
+        match find_cred(&dev, fs, name, &mut scratch) {
             Some((fid, _)) => {
                 let _ = fs.delete(fid);
                 Sw::OK
@@ -265,7 +277,7 @@ impl<'a> OathApplet<'a> {
         }
         let data = &apdu.data[..apdu.nc];
         if data.is_empty() {
-            let _ = fs.delete(EF_OATH_CODE);
+            let _ = fs.delete_key(EF_OATH_CODE);
             self.validated = true;
             return Sw::OK;
         }
@@ -273,7 +285,7 @@ impl<'a> OathApplet<'a> {
             return Sw::INCORRECT_PARAMS;
         };
         if key.is_empty() {
-            let _ = fs.delete(EF_OATH_CODE);
+            let _ = fs.delete_key(EF_OATH_CODE);
             self.validated = true;
             return Sw::OK;
         }
@@ -292,7 +304,8 @@ impl<'a> OathApplet<'a> {
             return Sw::DATA_INVALID;
         }
         self.rng.borrow_mut().fill(&mut self.challenge);
-        if fs.put(EF_OATH_CODE, key).is_err() {
+        let dev = self.device();
+        if !seal::seal_put(&dev, fs, &mut *self.rng.borrow_mut(), EF_OATH_CODE, key) {
             return Sw::MEMORY_FAILURE;
         }
         self.validated = false;
@@ -308,7 +321,7 @@ impl<'a> OathApplet<'a> {
         for &fid in &fids[..n] {
             let _ = fs.delete(fid);
         }
-        let _ = fs.delete(EF_OATH_CODE);
+        let _ = fs.delete_key(EF_OATH_CODE);
         let _ = fs.delete(EF_OTP_PIN);
         self.validated = true;
         Sw::OK
@@ -322,9 +335,10 @@ impl<'a> OathApplet<'a> {
         let ext = apdu.nc == 1 && apdu.data[0] == 0x01;
         let mut fids = [0u16; MAX_OATH_CRED as usize];
         let nfids = present_creds(fs, &mut fids);
+        let dev = self.device();
         let mut scratch = [0u8; CRED_MAX];
         for &fid in &fids[..nfids] {
-            let Some(n) = fs.read(fid, &mut scratch) else {
+            let Some(n) = seal::seal_read(&dev, fs, KeyFid::new(fid), &mut scratch) else {
                 continue;
             };
             let blob = &scratch[..n.min(CRED_MAX)];
@@ -374,7 +388,8 @@ impl<'a> OathApplet<'a> {
             return Sw::INCORRECT_PARAMS;
         };
         let mut code = [0u8; 128];
-        let Some(n) = fs.read(EF_OATH_CODE, &mut code) else {
+        let dev = self.device();
+        let Some(n) = seal::seal_read(&dev, fs, EF_OATH_CODE, &mut code) else {
             self.validated = true;
             return Sw::DATA_INVALID;
         };
@@ -416,7 +431,8 @@ impl<'a> OathApplet<'a> {
             return Sw::INCORRECT_PARAMS;
         };
         let mut scratch = [0u8; CRED_MAX];
-        let Some((fid, n)) = find_cred(fs, name, &mut scratch) else {
+        let dev = self.device();
+        let Some((fid, n)) = find_cred(&dev, fs, name, &mut scratch) else {
             return Sw::DATA_INVALID;
         };
         let blob = &scratch[..n];
@@ -460,7 +476,13 @@ impl<'a> OathApplet<'a> {
             counter.copy_from_slice(&scratch[r.start..r.start + 8]);
             let v = u64::from_be_bytes(counter).wrapping_add(1);
             scratch[r.start..r.start + 8].copy_from_slice(&v.to_be_bytes());
-            if fs.put(fid, &scratch[..n]).is_err() {
+            if !seal::seal_put(
+                &dev,
+                fs,
+                &mut *self.rng.borrow_mut(),
+                KeyFid::new(fid),
+                &scratch[..n],
+            ) {
                 return Sw::MEMORY_FAILURE;
             }
         }
@@ -484,9 +506,10 @@ impl<'a> OathApplet<'a> {
         };
         let mut fids = [0u16; MAX_OATH_CRED as usize];
         let nfids = present_creds(fs, &mut fids);
+        let dev = self.device();
         let mut scratch = [0u8; CRED_MAX];
         for &fid in &fids[..nfids] {
-            let Some(n) = fs.read(fid, &mut scratch) else {
+            let Some(n) = seal::seal_read(&dev, fs, KeyFid::new(fid), &mut scratch) else {
                 continue;
             };
             let blob = &scratch[..n.min(CRED_MAX)];
@@ -537,7 +560,8 @@ impl<'a> OathApplet<'a> {
         }
         // The named credential is ignored — slot 0 is always the one verified.
         let mut scratch = [0u8; CRED_MAX];
-        let Some(n) = fs.read(EF_OATH_CRED, &mut scratch) else {
+        let dev = self.device();
+        let Some(n) = seal::seal_read(&dev, fs, KeyFid::new(EF_OATH_CRED), &mut scratch) else {
             return Sw::DATA_INVALID;
         };
         let blob = &scratch[..n.min(CRED_MAX)];
@@ -591,7 +615,8 @@ impl<'a> OathApplet<'a> {
             return SW_WRONG_DATA;
         }
         let mut scratch = [0u8; CRED_MAX];
-        let Some((fid, n)) = find_cred(fs, name, &mut scratch) else {
+        let dev = self.device();
+        let Some((fid, n)) = find_cred(&dev, fs, name, &mut scratch) else {
             return Sw::DATA_INVALID;
         };
         // Rebuild the blob with the name TLV replaced in place.
@@ -610,9 +635,16 @@ impl<'a> OathApplet<'a> {
         if !ok {
             return Sw::FILE_FULL;
         }
-        match fs.put(fid, &blob[..bn]) {
-            Ok(()) => Sw::OK,
-            Err(_) => Sw::MEMORY_FAILURE,
+        if seal::seal_put(
+            &dev,
+            fs,
+            &mut *self.rng.borrow_mut(),
+            KeyFid::new(fid),
+            &blob[..bn],
+        ) {
+            Sw::OK
+        } else {
+            Sw::MEMORY_FAILURE
         }
     }
 
@@ -637,7 +669,8 @@ impl<'a> OathApplet<'a> {
             return SW_WRONG_DATA;
         };
         let mut scratch = [0u8; CRED_MAX];
-        let Some((_, n)) = find_cred(fs, name, &mut scratch) else {
+        let dev = self.device();
+        let Some((_, n)) = find_cred(&dev, fs, name, &mut scratch) else {
             return Sw::DATA_INVALID;
         };
         let blob = &scratch[..n];
@@ -740,7 +773,7 @@ impl<S: Storage> Applet<Fs<S>> for OathApplet<'_> {
         res.push(TAG_NAME);
         res.push(8);
         res.extend(&self.serial_name());
-        let code_set = fs.has_data(EF_OATH_CODE);
+        let code_set = fs.has_key(EF_OATH_CODE);
         if code_set {
             self.rng.borrow_mut().fill(&mut self.challenge);
             res.push(TAG_CHALLENGE);
@@ -845,18 +878,62 @@ fn present_creds<S: Storage>(fs: &mut Fs<S>, out: &mut [u16; MAX_OATH_CRED as us
 
 /// Find a present credential whose `TAG_NAME` equals `name`; the blob is left in
 /// `buf`. Only present slots are read (see [`present_creds`]).
-fn find_cred<S: Storage>(fs: &mut Fs<S>, name: &[u8], buf: &mut [u8]) -> Option<(u16, usize)> {
+fn find_cred<S: Storage>(
+    dev: &Device,
+    fs: &mut Fs<S>,
+    name: &[u8],
+    buf: &mut [u8],
+) -> Option<(u16, usize)> {
     let mut fids = [0u16; MAX_OATH_CRED as usize];
     let nfids = present_creds(fs, &mut fids);
     for &fid in &fids[..nfids] {
-        if let Some(n) = fs.read(fid, buf) {
-            let n = n.min(buf.len());
-            if find_tag(&buf[..n], TAG_NAME as u16) == Some(name) {
-                return Some((fid, n));
-            }
+        if let Some(n) = seal::seal_read(dev, fs, KeyFid::new(fid), buf)
+            && find_tag(&buf[..n], TAG_NAME as u16) == Some(name)
+        {
+            return Some((fid, n));
         }
     }
     None
+}
+
+/// Boot pass: seal any OATH secret slot still stored as legacy plaintext. A blob
+/// that already unseals is left alone; one that does not is taken to be a
+/// pre-seal plaintext credential and re-sealed in place. Covers every present
+/// credential and the SET CODE key. Idempotent and crash-safe per slot — GCM
+/// authentication tells the sealed and plaintext generations apart — so it can
+/// run unconditionally at every boot (see `firmware/src/main.rs`), before any
+/// host command touches a credential. Closes the one applet that historically
+/// stored its secrets in the clear (FIDO / PIV / OpenPGP always sealed theirs).
+pub fn migrate_seal<S: Storage>(dev: &Device, fs: &mut Fs<S>, rng: &mut dyn Rng) {
+    let mut fids = [0u16; MAX_OATH_CRED as usize];
+    let n = present_creds(fs, &mut fids);
+    let mut out = [0u8; CRED_MAX];
+    let mut raw = [0u8; CRED_MAX];
+    for &fid in &fids[..n] {
+        reseal_if_plaintext(dev, fs, rng, KeyFid::new(fid), &mut out, &mut raw);
+    }
+    reseal_if_plaintext(dev, fs, rng, EF_OATH_CODE, &mut out, &mut raw);
+    out.zeroize();
+    raw.zeroize();
+}
+
+/// Re-seal `fid` iff its stored bytes do not already authenticate as a sealed
+/// blob (legacy plaintext). No-op when the slot is absent or already sealed.
+fn reseal_if_plaintext<S: Storage>(
+    dev: &Device,
+    fs: &mut Fs<S>,
+    rng: &mut dyn Rng,
+    fid: KeyFid,
+    out: &mut [u8],
+    raw: &mut [u8],
+) {
+    if seal::seal_read(dev, fs, fid, out).is_some() {
+        return; // already sealed
+    }
+    if let Some(n) = fs.read_key(fid, raw) {
+        let n = n.min(raw.len());
+        let _ = seal::seal_put(dev, fs, rng, fid, &raw[..n]);
+    }
 }
 
 fn free_slot<S: Storage>(fs: &mut Fs<S>) -> Option<u16> {
@@ -1235,6 +1312,85 @@ mod tests {
         );
         assert_eq!(calc_code(&mut app, &mut fs, b"t", 1, 8), 94287082);
         assert_eq!(deny.borrow().1, 0);
+    }
+
+    #[test]
+    fn cred_secret_is_sealed_on_flash() {
+        // The whole point of the seal: an enrolled credential's HMAC secret must
+        // not sit in the clear on flash, and the seal must still round-trip.
+        let mut fs = new_fs();
+        let rng = RefCell::new(CountRng(7));
+        let touch = RefCell::new(StubPresence(Presence::Confirmed, 0));
+        let mut app = OathApplet::new(SERIAL, [0x22; 32], None, &rng, &touch);
+        assert_eq!(
+            put(
+                &mut app,
+                &mut fs,
+                &put_data(b"acct", 0x21, 8, SECRET_SHA1, false, None)
+            ),
+            Sw::OK
+        );
+
+        let mut fids = [0u16; MAX_OATH_CRED as usize];
+        assert_eq!(present_creds(&mut fs, &mut fids), 1);
+        let mut raw = [0u8; CRED_MAX];
+        let len = fs.read(fids[0], &mut raw).unwrap();
+        assert!(
+            !raw[..len]
+                .windows(SECRET_SHA1.len())
+                .any(|w| w == SECRET_SHA1),
+            "OATH HMAC secret stored in plaintext on flash",
+        );
+        // The seal round-trips — the RFC 6238 SHA-1 vector still computes.
+        assert_eq!(calc_code(&mut app, &mut fs, b"acct", 1, 8), 94287082);
+    }
+
+    #[test]
+    fn legacy_plaintext_cred_migrates_and_stays_usable() {
+        // A credential enrolled before sealing existed is stored as a bare TLV
+        // with the secret in the clear. The boot pass must seal it in place
+        // without losing it.
+        let mut fs = new_fs();
+        let rng = RefCell::new(CountRng(7));
+        let touch = RefCell::new(StubPresence(Presence::Confirmed, 0));
+        let mut app = OathApplet::new(SERIAL, [0x22; 32], None, &rng, &touch);
+
+        // Pre-seal layout: NAME ‖ KEY(type|alg, digits, secret), written raw.
+        let mut blob = tlv(TAG_NAME, b"acct");
+        let mut key = vec![0x21u8, 8];
+        key.extend_from_slice(SECRET_SHA1);
+        blob.extend(tlv(TAG_KEY, &key));
+        fs.put(EF_OATH_CRED, &blob).unwrap();
+        let mut raw = [0u8; CRED_MAX];
+        let len = fs.read(EF_OATH_CRED, &mut raw).unwrap();
+        assert!(
+            raw[..len]
+                .windows(SECRET_SHA1.len())
+                .any(|w| w == SECRET_SHA1),
+            "fixture should start as plaintext",
+        );
+
+        // Boot migration seals it (device must match the applet's identity).
+        let dev = Device {
+            serial_hash: &[0x22; 32],
+            serial_id: &SERIAL,
+            otp_key: None,
+        };
+        let mut mrng = CountRng(1);
+        migrate_seal(&dev, &mut fs, &mut mrng);
+
+        let len = fs.read(EF_OATH_CRED, &mut raw).unwrap();
+        assert!(
+            !raw[..len]
+                .windows(SECRET_SHA1.len())
+                .any(|w| w == SECRET_SHA1),
+            "migration left the OATH secret in plaintext",
+        );
+        // The credential is still usable: CALCULATE unseals and computes.
+        assert_eq!(calc_code(&mut app, &mut fs, b"acct", 1, 8), 94287082);
+        // Idempotent: a second pass is a no-op (it already authenticates).
+        migrate_seal(&dev, &mut fs, &mut mrng);
+        assert_eq!(calc_code(&mut app, &mut fs, b"acct", 1, 8), 94287082);
     }
 
     #[test]

--- a/crates/rsk-oath/src/seal.rs
+++ b/crates/rsk-oath/src/seal.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! At-rest sealing for OATH credential secrets. Each credential's TLV blob — it
+//! carries the shared HMAC seed (`TAG_KEY`), the actual TOTP/HOTP secret — is
+//! AES-256-GCM-sealed before it reaches flash, key = HKDF-SHA256(salt =
+//! serial_hash, ikm = kbase, info = "OATH/KEYS"), blob = `nonce(12) ‖ ct ‖
+//! tag(16)`, AAD = serial_hash. Device-sealed (no OATH PIN in the key): the
+//! credentials must compute without a separate at-rest unlock, exactly like the
+//! PIV slot keys ([`rsk_piv`]). With the OTP MKEK provisioned, `kbase` — and so
+//! this seal — roots in the hardware fuse key.
+//!
+//! This closes the one applet that stored its secrets in the clear: FIDO / PIV /
+//! OpenPGP all sealed, OATH did not. [`crate::migrate_seal`] re-seals any
+//! pre-existing plaintext credential at boot.
+
+use rsk_crypto::{Device, aes256gcm_decrypt, aes256gcm_encrypt, hkdf_sha256};
+use rsk_fs::{Fs, KeyFid, Sealed, Storage};
+use zeroize::Zeroize;
+
+use crate::{CRED_MAX, Rng};
+
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
+/// Largest sealed plaintext: a full credential blob.
+const MAX_PLAIN: usize = CRED_MAX;
+const MAX_BLOB: usize = NONCE_LEN + MAX_PLAIN + TAG_LEN;
+
+const INFO_OATH_KEYS: &[u8] = b"OATH/KEYS";
+
+fn kenc(dev: &Device) -> [u8; 32] {
+    let mut kbase = dev.derive_kbase();
+    let mut out = [0u8; 32];
+    hkdf_sha256(dev.serial_hash, &kbase, INFO_OATH_KEYS, &mut out)
+        .expect("32-byte HKDF output is in range");
+    kbase.zeroize();
+    out
+}
+
+/// Seal `plain` and write it to `fid` as `nonce ‖ ct ‖ tag`. `false` on an
+/// over-length plaintext or a storage failure.
+pub fn seal_put<S: Storage>(
+    dev: &Device,
+    fs: &mut Fs<S>,
+    rng: &mut dyn Rng,
+    fid: KeyFid,
+    plain: &[u8],
+) -> bool {
+    if plain.len() > MAX_PLAIN {
+        return false;
+    }
+    let mut blob = [0u8; MAX_BLOB];
+    let n = NONCE_LEN + plain.len() + TAG_LEN;
+    rng.fill(&mut blob[..NONCE_LEN]);
+    let mut nonce = [0u8; NONCE_LEN];
+    nonce.copy_from_slice(&blob[..NONCE_LEN]);
+    blob[NONCE_LEN..NONCE_LEN + plain.len()].copy_from_slice(plain);
+    let mut key = kenc(dev);
+    let tag = aes256gcm_encrypt(
+        &key,
+        &nonce,
+        dev.serial_hash,
+        &mut blob[NONCE_LEN..NONCE_LEN + plain.len()],
+    );
+    key.zeroize();
+    blob[NONCE_LEN + plain.len()..n].copy_from_slice(&tag);
+    let ok = fs.put_key(fid, Sealed::wrap(&blob[..n])).is_ok();
+    blob.zeroize();
+    ok
+}
+
+/// Read and unseal `fid` into `out`; returns the plaintext length, or `None` if
+/// the slot is absent, malformed, or does not authenticate (e.g. legacy
+/// plaintext — the caller treats that as "needs migration").
+pub fn seal_read<S: Storage>(
+    dev: &Device,
+    fs: &mut Fs<S>,
+    fid: KeyFid,
+    out: &mut [u8],
+) -> Option<usize> {
+    let mut blob = [0u8; MAX_BLOB];
+    let n = fs.read_key(fid, &mut blob)?;
+    if !(NONCE_LEN + TAG_LEN..=MAX_BLOB).contains(&n) {
+        blob.zeroize();
+        return None;
+    }
+    let pt_len = n - NONCE_LEN - TAG_LEN;
+    if out.len() < pt_len {
+        blob.zeroize();
+        return None;
+    }
+    let mut nonce = [0u8; NONCE_LEN];
+    nonce.copy_from_slice(&blob[..NONCE_LEN]);
+    let mut tag = [0u8; TAG_LEN];
+    tag.copy_from_slice(&blob[n - TAG_LEN..n]);
+    let mut key = kenc(dev);
+    let r = aes256gcm_decrypt(
+        &key,
+        &nonce,
+        dev.serial_hash,
+        &mut blob[NONCE_LEN..NONCE_LEN + pt_len],
+        &tag,
+    );
+    key.zeroize();
+    if r.is_err() {
+        blob.zeroize();
+        return None;
+    }
+    out[..pt_len].copy_from_slice(&blob[NONCE_LEN..NONCE_LEN + pt_len]);
+    blob.zeroize();
+    Some(pt_len)
+}

--- a/crates/rsk-openpgp/src/consts.rs
+++ b/crates/rsk-openpgp/src/consts.rs
@@ -4,6 +4,8 @@
 //! OpenPGP applet constants: AID/ATR, instruction bytes, EF/DO FIDs, PIN modes,
 //! and DEK sizing.
 
+use rsk_fs::KeyFid;
+
 /// OpenPGP application identifier.
 pub const OPENPGP_AID: &[u8] = &[0xD2, 0x76, 0x00, 0x01, 0x24, 0x01];
 
@@ -60,16 +62,16 @@ pub const EF_ALGO_PRIV2: u16 = 0x10c2;
 pub const EF_ALGO_PRIV3: u16 = 0x10c3;
 pub const EF_PW_PRIV: u16 = 0x10c4;
 pub const EF_PW_RETRIES: u16 = 0x10c5;
-pub const EF_PK_SIG: u16 = 0x10d1;
-pub const EF_PK_DEC: u16 = 0x10d2;
-pub const EF_PK_AUT: u16 = 0x10d3;
-pub const EF_PB_SIG: u16 = 0x10d4;
+pub const EF_PK_SIG: KeyFid = KeyFid::new(0x10d1); // private SIG key, DEK-sealed
+pub const EF_PK_DEC: KeyFid = KeyFid::new(0x10d2); // private DEC key, DEK-sealed
+pub const EF_PK_AUT: KeyFid = KeyFid::new(0x10d3); // private AUT key, DEK-sealed
+pub const EF_PB_SIG: u16 = 0x10d4; // public-key DO = EF_PK_SIG + 3 (not secret)
 pub const EF_PB_DEC: u16 = 0x10d5;
 pub const EF_PB_AUT: u16 = 0x10d6;
 pub const EF_DEK: u16 = 0x1099;
-pub const EF_DEK_PW1: u16 = 0x109a;
-pub const EF_DEK_RC: u16 = 0x109b;
-pub const EF_DEK_PW3: u16 = 0x109c;
+pub const EF_DEK_PW1: KeyFid = KeyFid::new(0x109a); // DEK wrapped under PW1
+pub const EF_DEK_RC: KeyFid = KeyFid::new(0x109b); // DEK wrapped under reset code
+pub const EF_DEK_PW3: KeyFid = KeyFid::new(0x109c); // DEK wrapped under PW3
 pub const EF_DEK_PWPIV: u16 = 0x109d;
 pub const EF_CH_1: u16 = 0x1f21;
 pub const EF_CH_2: u16 = 0x1f22;
@@ -104,7 +106,7 @@ pub const EF_TS_SIG: u16 = 0x00ce; // S
 pub const EF_TS_DEC: u16 = 0x00cf; // S
 pub const EF_TS_AUT: u16 = 0x00d0; // S
 pub const EF_RESET_CODE: u16 = 0x00d3; // S — PUT redirects to EF_RC
-pub const EF_AES_KEY: u16 = 0x00d5; // S — symmetric key for DEC slot
+pub const EF_AES_KEY: KeyFid = KeyFid::new(0x00d5); // S — symmetric key for DEC slot, DEK-sealed
 pub const EF_UIF_SIG: u16 = 0x00d6; // S — user-interaction flag (touch)
 pub const EF_UIF_DEC: u16 = 0x00d7; // S
 pub const EF_UIF_AUT: u16 = 0x00d8; // S

--- a/crates/rsk-openpgp/src/dobj.rs
+++ b/crates/rsk-openpgp/src/dobj.rs
@@ -263,7 +263,7 @@ impl<'a, S: Storage> DoWriter<'a, S> {
         }
         for (slot, fid) in [(0u8, EF_PK_SIG), (1, EF_PK_DEC), (2, EF_PK_AUT)] {
             self.push(slot);
-            let present = self.fs.has_data(fid);
+            let present = self.fs.has_key(fid);
             self.push(if present { 0x01 } else { 0x00 });
         }
         self.pos - init

--- a/crates/rsk-openpgp/src/files.rs
+++ b/crates/rsk-openpgp/src/files.rs
@@ -65,6 +65,17 @@ pub enum DoSource {
 
 /// Resolve a DO tag / FID to its source.
 pub fn source(fid: u16) -> DoSource {
+    // Private-key and DEK slots are `KeyFid`s (sealed secrets), so they can't be
+    // `u16` match patterns; like the other internal EFs they aren't GET-DATA-able.
+    if fid == EF_PK_SIG.get()
+        || fid == EF_PK_DEC.get()
+        || fid == EF_PK_AUT.get()
+        || fid == EF_DEK_PW1.get()
+        || fid == EF_DEK_RC.get()
+        || fid == EF_DEK_PW3.get()
+    {
+        return DoSource::Internal;
+    }
     match fid {
         EF_FULL_AID => DoSource::FullAid,
         EF_HIST_BYTES => DoSource::Rom(HISTORICAL_BYTES),
@@ -90,11 +101,12 @@ pub fn source(fid: u16) -> DoSource {
         | EF_TS_DEC | EF_TS_AUT | EF_UIF_SIG | EF_UIF_DEC | EF_UIF_AUT | EF_KDF | EF_RESET_CODE
         | EF_PRIV_DO_1 | EF_PRIV_DO_2 | EF_PRIV_DO_3 | EF_PRIV_DO_4 => DoSource::Flash,
 
-        // Internal EFs (keys, PINs, DEK, algo-priv, chaining): not GET-DATA-able.
+        // Internal EFs (PINs, public-key DOs, base/PWPIV DEK, algo-priv,
+        // chaining): not GET-DATA-able. The private-key + PW-DEK slots are
+        // handled by the KeyFid guard above.
         EF_PW1 | EF_RC | EF_PW3 | EF_ALGO_PRIV1 | EF_ALGO_PRIV2 | EF_ALGO_PRIV3 | EF_PW_PRIV
-        | EF_PW_RETRIES | EF_PK_SIG | EF_PK_DEC | EF_PK_AUT | EF_PB_SIG | EF_PB_DEC | EF_PB_AUT
-        | EF_DEK | EF_DEK_PW1 | EF_DEK_RC | EF_DEK_PW3 | EF_DEK_PWPIV | EF_CH_1 | EF_CH_2
-        | EF_CH_3 => DoSource::Internal,
+        | EF_PW_RETRIES | EF_PB_SIG | EF_PB_DEC | EF_PB_AUT | EF_DEK | EF_DEK_PWPIV | EF_CH_1
+        | EF_CH_2 | EF_CH_3 => DoSource::Internal,
 
         _ => DoSource::None,
     }

--- a/crates/rsk-openpgp/src/importdata.rs
+++ b/crates/rsk-openpgp/src/importdata.rs
@@ -7,7 +7,7 @@
 //! algorithm-attribute DO (`EF_ALGO_PRIV{1,2,3}`), set beforehand via PUT DATA.
 
 use rsk_crypto::Device;
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Storage};
 use rsk_sdk::Sw;
 
 use crate::consts::*;
@@ -69,7 +69,7 @@ pub fn import_data<S: Storage>(
 /// Parse the `4D` header through the control-reference template tag: returns the
 /// key-slot FID and the position just after the (skipped) CRT body. Pure (no fs /
 /// crypto), so it is fuzzable in isolation.
-pub fn parse_ehl_head(data: &[u8]) -> Result<(u16, usize), Sw> {
+pub fn parse_ehl_head(data: &[u8]) -> Result<(KeyFid, usize), Sw> {
     let mut pos = 0usize;
     // 4D extended-header-list tag + its (ignored) length.
     if *data.first().ok_or(WRONG_DATA)? != 0x4D {
@@ -148,7 +148,7 @@ fn try_import<S: Storage>(
     let (off, len) = parse_ehl_body(data, pos)?;
 
     // The algorithm attribute decides RSA vs EC and (for EC) the curve.
-    let algo_fid = fid - 0x10;
+    let algo_fid = fid.get() - 0x10;
     let mut algo_buf = [0u8; 16];
     let algo: &[u8] = match fs.read(algo_fid, &mut algo_buf) {
         Some(n) if n > 0 => &algo_buf[..n],
@@ -178,7 +178,7 @@ fn try_import<S: Storage>(
             // Public-key DO → EF_PB_* (slot FID + 3).
             let mut pub_do = [0u8; MAX_RSA_PUBDO];
             let don = make_rsa_response(&key, &mut pub_do);
-            fs.put(fid + 3, &pub_do[..don])
+            fs.put(fid.get() + 3, &pub_do[..don])
                 .map_err(|_| Sw::MEMORY_FAILURE)?;
 
             if fid == EF_PK_SIG {
@@ -201,7 +201,7 @@ fn try_import<S: Storage>(
             let plen = key.public_point(&mut point)?;
             let mut pub_do = [0u8; 8 + MAX_EC_POINT];
             let don = make_ec_pubkey_do(&point[..plen], &mut pub_do);
-            fs.put(fid + 3, &pub_do[..don])
+            fs.put(fid.get() + 3, &pub_do[..don])
                 .map_err(|_| Sw::MEMORY_FAILURE)?;
 
             if fid == EF_PK_SIG {

--- a/crates/rsk-openpgp/src/init.rs
+++ b/crates/rsk-openpgp/src/init.rs
@@ -8,7 +8,7 @@
 use zeroize::Zeroize;
 
 use rsk_crypto::{Device, PinKdf};
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, Sealed, Storage};
 
 use crate::Rng;
 use crate::consts::*;
@@ -60,9 +60,9 @@ pub fn scan_files<S: Storage>(
 ) -> Result<(), Error> {
     // DEK: generate once when none of the wrapped copies exist.
     let mut reset_dek = false;
-    if !fs.has_data(EF_DEK_PW1)
-        && !fs.has_data(EF_DEK_RC)
-        && !fs.has_data(EF_DEK_PW3)
+    if !fs.has_key(EF_DEK_PW1)
+        && !fs.has_key(EF_DEK_RC)
+        && !fs.has_key(EF_DEK_PW3)
         && !fs.has_data(EF_DEK)
     {
         let mut random_dek = [0u8; DEK_SIZE];
@@ -76,14 +76,17 @@ pub fn scan_files<S: Storage>(
         rng.fill(&mut nonce);
         dev.encrypt_with_aad(&session_pw1, &random_dek, PinKdf::V2, &nonce, &mut def[1..])
             .map_err(|_| Error::Crypto)?;
-        put(fs, EF_DEK_PW1, &def)?;
+        fs.put_key(EF_DEK_PW1, Sealed::wrap(&def))
+            .map_err(|_| Error::Storage)?;
 
         // RC and PW3 share one blob sealed under the PW3 session.
         rng.fill(&mut nonce);
         dev.encrypt_with_aad(&session_pw3, &random_dek, PinKdf::V2, &nonce, &mut def[1..])
             .map_err(|_| Error::Crypto)?;
-        put(fs, EF_DEK_RC, &def)?;
-        put(fs, EF_DEK_PW3, &def)?;
+        fs.put_key(EF_DEK_RC, Sealed::wrap(&def))
+            .map_err(|_| Error::Storage)?;
+        fs.put_key(EF_DEK_PW3, Sealed::wrap(&def))
+            .map_err(|_| Error::Storage)?;
 
         random_dek.zeroize();
         session_pw1.zeroize();
@@ -162,9 +165,9 @@ mod tests {
 
         // DEK files are 77 bytes, format byte 0x03.
         for fid in [EF_DEK_PW1, EF_DEK_RC, EF_DEK_PW3] {
-            assert_eq!(fs.size(fid), Some(DEK_FILE_SIZE));
+            assert_eq!(fs.size(fid.get()), Some(DEK_FILE_SIZE));
             let mut b = [0u8; 1];
-            fs.read(fid, &mut b);
+            fs.read(fid.get(), &mut b);
             assert_eq!(b[0], FORMAT_V3);
         }
         // PIN verifiers: [len, 1, verifier(32)].
@@ -193,7 +196,7 @@ mod tests {
 
         // The wrapped DEK is recoverable with the default PW1 session key.
         let mut blob = [0u8; DEK_FILE_SIZE];
-        let n = fs.read(EF_DEK_PW1, &mut blob).unwrap();
+        let n = fs.read(EF_DEK_PW1.get(), &mut blob).unwrap();
         assert_eq!(blob[0], FORMAT_V3);
         let session = d.pin_derive_session(PW1_DEFAULT);
         let mut dek = [0u8; DEK_SIZE];
@@ -203,7 +206,7 @@ mod tests {
         assert_eq!(m, DEK_SIZE);
         // RC and PW3 are the same blob sealed under PW3 and decrypt to the same DEK.
         let mut blob3 = [0u8; DEK_FILE_SIZE];
-        fs.read(EF_DEK_PW3, &mut blob3);
+        fs.read(EF_DEK_PW3.get(), &mut blob3);
         let session3 = d.pin_derive_session(PW3_DEFAULT);
         let mut dek3 = [0u8; DEK_SIZE];
         d.decrypt_with_aad(&session3, &blob3[1..], PinKdf::V2, &mut dek3)
@@ -216,11 +219,11 @@ mod tests {
         let mut fs = fresh();
         scan_files(&dev(), &mut fs, &mut CountRng(0)).unwrap();
         let mut first = [0u8; DEK_FILE_SIZE];
-        fs.read(EF_DEK_PW1, &mut first);
+        fs.read(EF_DEK_PW1.get(), &mut first);
         // A second run with a different RNG must not rewrite existing files.
         scan_files(&dev(), &mut fs, &mut CountRng(200)).unwrap();
         let mut second = [0u8; DEK_FILE_SIZE];
-        fs.read(EF_DEK_PW1, &mut second);
+        fs.read(EF_DEK_PW1.get(), &mut second);
         assert_eq!(first, second);
     }
 }

--- a/crates/rsk-openpgp/src/keypairgen.rs
+++ b/crates/rsk-openpgp/src/keypairgen.rs
@@ -6,7 +6,7 @@
 //! `B8`→DEC, `A4`→AUT) and returns its public-key DO; `P1 = 0x81` reads it back.
 
 use rsk_crypto::Device;
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Storage};
 use rsk_sdk::Sw;
 
 use crate::Rng;
@@ -73,12 +73,12 @@ fn generate<S: Storage>(
     fs: &mut Fs<S>,
     sess: &Session,
     rng: &mut dyn Rng,
-    fid: u16,
+    fid: KeyFid,
     out: &mut [u8],
 ) -> Result<usize, Sw> {
     // The algorithm attribute (slot FID − 0x10) decides RSA vs EC and the curve.
     let mut algo_buf = [0u8; 16];
-    let algo: &[u8] = match fs.read(fid - 0x10, &mut algo_buf) {
+    let algo: &[u8] = match fs.read(fid.get() - 0x10, &mut algo_buf) {
         Some(n) if n > 0 => &algo_buf[..n],
         _ => DEFAULT_ALGO,
     };
@@ -117,7 +117,7 @@ fn keygen_tail<S: Storage>(
     fs: &mut Fs<S>,
     sess: &Session,
     rng: &mut dyn Rng,
-    fid: u16,
+    fid: KeyFid,
 ) -> Result<(), Sw> {
     if fid == EF_PK_SIG {
         reset_sig_count(fs)?;
@@ -135,21 +135,22 @@ fn keygen_tail<S: Storage>(
 /// response.
 fn store_public<S: Storage>(
     fs: &mut Fs<S>,
-    fid: u16,
+    fid: KeyFid,
     pub_do: &[u8],
     out: &mut [u8],
 ) -> Result<usize, Sw> {
-    fs.put(fid + 3, pub_do).map_err(|_| Sw::MEMORY_FAILURE)?;
+    fs.put(fid.get() + 3, pub_do)
+        .map_err(|_| Sw::MEMORY_FAILURE)?;
     out[..pub_do.len()].copy_from_slice(pub_do);
     Ok(pub_do.len())
 }
 
 /// `P1 = 0x81`: return the stored public-key DO from `EF_PB_*` (slot FID + 3).
-fn read_public<S: Storage>(fs: &mut Fs<S>, fid: u16, out: &mut [u8]) -> Result<usize, Sw> {
-    if !fs.has_data(fid + 3) {
+fn read_public<S: Storage>(fs: &mut Fs<S>, fid: KeyFid, out: &mut [u8]) -> Result<usize, Sw> {
+    if !fs.has_data(fid.get() + 3) {
         return Err(Sw::REFERENCE_NOT_FOUND);
     }
-    fs.read(fid + 3, out).ok_or(Sw::REFERENCE_NOT_FOUND)
+    fs.read(fid.get() + 3, out).ok_or(Sw::REFERENCE_NOT_FOUND)
 }
 
 // --- CCID keepalive path: split RSA generate so the slow keygen can run async ---
@@ -169,7 +170,7 @@ pub fn rsa_generate_params<S: Storage>(
     p1: u8,
     p2: u8,
     data: &[u8],
-) -> Result<Option<(u16, usize)>, Sw> {
+) -> Result<Option<(KeyFid, usize)>, Sw> {
     if p1 != 0x80 {
         return Ok(None); // read-public (0x81) is fast
     }
@@ -189,7 +190,7 @@ pub fn rsa_generate_params<S: Storage>(
         _ => return Err(WRONG_DATA),
     };
     let mut algo_buf = [0u8; 16];
-    let algo: &[u8] = match fs.read(fid - 0x10, &mut algo_buf) {
+    let algo: &[u8] = match fs.read(fid.get() - 0x10, &mut algo_buf) {
         Some(n) if n > 0 => &algo_buf[..n],
         _ => DEFAULT_ALGO,
     };
@@ -208,7 +209,7 @@ pub fn rsa_generate_finish<S: Storage>(
     fs: &mut Fs<S>,
     sess: &Session,
     rng: &mut dyn Rng,
-    fid: u16,
+    fid: KeyFid,
     key: &RsaPrivateKey,
     out: &mut [u8],
 ) -> (usize, Sw) {

--- a/crates/rsk-openpgp/src/keys.rs
+++ b/crates/rsk-openpgp/src/keys.rs
@@ -12,7 +12,7 @@ use zeroize::Zeroize;
 
 use rsk_crypto::Device;
 use rsk_crypto::aes::{aes_decrypt_cfb_256, aes_encrypt_cfb_256};
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Sealed, Storage};
 use rsk_sdk::Sw;
 
 use p256::ecdsa::signature::hazmat::PrehashSigner;
@@ -478,7 +478,7 @@ pub fn store_ec_key<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
     sess: &Session,
-    fid: u16,
+    fid: KeyFid,
     key: &PrivKey,
 ) -> Result<(), Sw> {
     let scalar = key.scalar();
@@ -488,7 +488,8 @@ pub fn store_ec_key<S: Storage>(
     kdata[1..n].copy_from_slice(scalar);
     let r = (|| {
         dek_encrypt(dev, fs, sess, &mut kdata[..n])?;
-        fs.put(fid, &kdata[..n]).map_err(|_| Sw::MEMORY_FAILURE)
+        fs.put_key(fid, Sealed::wrap(&kdata[..n]))
+            .map_err(|_| Sw::MEMORY_FAILURE)
     })();
     kdata.zeroize();
     r
@@ -499,10 +500,12 @@ pub fn load_ec_key<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
     sess: &Session,
-    fid: u16,
+    fid: KeyFid,
 ) -> Result<PrivKey, Sw> {
     let mut kdata = [0u8; MAX_EC_KDATA];
-    let n = fs.read(fid, &mut kdata).ok_or(Sw::REFERENCE_NOT_FOUND)?;
+    let n = fs
+        .read_key(fid, &mut kdata)
+        .ok_or(Sw::REFERENCE_NOT_FOUND)?;
     if n < 2 {
         return Err(WRONG_DATA);
     }
@@ -555,7 +558,8 @@ pub fn store_aes_key<S: Storage>(
     let mut kdata = *key;
     let r = (|| {
         dek_encrypt(dev, fs, sess, &mut kdata)?;
-        fs.put(EF_AES_KEY, &kdata).map_err(|_| Sw::MEMORY_FAILURE)
+        fs.put_key(EF_AES_KEY, Sealed::wrap(&kdata))
+            .map_err(|_| Sw::MEMORY_FAILURE)
     })();
     kdata.zeroize();
     r
@@ -571,7 +575,7 @@ pub fn load_aes_key<S: Storage>(
 ) -> Result<([u8; 32], usize), Sw> {
     let mut kdata = [0u8; 32];
     let n = fs
-        .read(EF_AES_KEY, &mut kdata)
+        .read_key(EF_AES_KEY, &mut kdata)
         .filter(|&n| n > 0)
         .ok_or(Sw::REFERENCE_NOT_FOUND)?;
     if let Err(e) = dek_decrypt(dev, fs, sess, &mut kdata[..n]) {
@@ -867,7 +871,7 @@ pub fn store_rsa_key<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
     sess: &Session,
-    fid: u16,
+    fid: KeyFid,
     key: &RsaPrivateKey,
 ) -> Result<(), Sw> {
     let primes = key.primes();
@@ -890,7 +894,8 @@ pub fn store_rsa_key<S: Storage>(
     qb.zeroize();
     let r = (|| {
         dek_encrypt(dev, fs, sess, &mut kdata[..n])?;
-        fs.put(fid, &kdata[..n]).map_err(|_| Sw::MEMORY_FAILURE)
+        fs.put_key(fid, Sealed::wrap(&kdata[..n]))
+            .map_err(|_| Sw::MEMORY_FAILURE)
     })();
     kdata.zeroize();
     r
@@ -902,10 +907,12 @@ pub fn load_rsa_key<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
     sess: &Session,
-    fid: u16,
+    fid: KeyFid,
 ) -> Result<RsaPrivateKey, Sw> {
     let mut kdata = [0u8; MAX_RSA_KDATA];
-    let n = fs.read(fid, &mut kdata).ok_or(Sw::REFERENCE_NOT_FOUND)?;
+    let n = fs
+        .read_key(fid, &mut kdata)
+        .ok_or(Sw::REFERENCE_NOT_FOUND)?;
     if n < 2 || n % 2 != 0 {
         kdata.zeroize();
         return Err(WRONG_DATA);

--- a/crates/rsk-openpgp/src/lib.rs
+++ b/crates/rsk-openpgp/src/lib.rs
@@ -30,7 +30,7 @@ pub mod terminate;
 use core::cell::RefCell;
 
 use rsk_crypto::Device;
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Storage};
 use rsk_sdk::{Apdu, Applet, ResBuf, Sw};
 
 pub use init::{Error, scan_files};
@@ -149,7 +149,7 @@ impl<'a> OpenpgpApplet<'a> {
         p1: u8,
         p2: u8,
         data: &[u8],
-    ) -> Result<Option<(u16, usize)>, Sw> {
+    ) -> Result<Option<(KeyFid, usize)>, Sw> {
         keypairgen::rsa_generate_params(fs, &self.sess, p1, p2, data)
     }
 
@@ -159,7 +159,7 @@ impl<'a> OpenpgpApplet<'a> {
         &self,
         fs: &mut Fs<S>,
         rng: &mut dyn Rng,
-        fid: u16,
+        fid: KeyFid,
         key: &rsa::RsaPrivateKey,
         out: &mut [u8],
     ) -> (usize, Sw) {
@@ -554,7 +554,7 @@ mod tests {
         let mut fs = make_fs();
         let presence = RefCell::new(crate::AlwaysConfirm);
         let mut app = OpenpgpApplet::new(SERIAL_ID, SERIAL_HASH, None, &rng, &presence);
-        fs.put(consts::EF_PK_SIG, &[0xAB; 40]).unwrap();
+        fs.put(consts::EF_PK_SIG.get(), &[0xAB; 40]).unwrap();
         // Without PW3 (and PW3 unblocked) the terminate is refused — nothing wiped.
         let (_b, sw) = run(
             &mut app,
@@ -562,7 +562,7 @@ mod tests {
             &[0x00, consts::INS_TERMINATE_DF, 0x00, 0x00],
         );
         assert_eq!(sw, Sw::SECURITY_STATUS_NOT_SATISFIED);
-        assert!(fs.has_data(consts::EF_PK_SIG));
+        assert!(fs.has_data(consts::EF_PK_SIG.get()));
         // VERIFY PW3, then terminate wipes the imported key and re-seeds defaults.
         let mut v = vec![0x00, consts::INS_VERIFY, 0x00, consts::PW3_MODE83];
         v.push(consts::PW3_DEFAULT.len() as u8);
@@ -574,8 +574,8 @@ mod tests {
             &[0x00, consts::INS_TERMINATE_DF, 0x00, 0x00],
         );
         assert_eq!(sw, Sw::OK);
-        assert!(!fs.has_data(consts::EF_PK_SIG));
-        assert!(fs.has_data(consts::EF_DEK_PW1));
+        assert!(!fs.has_data(consts::EF_PK_SIG.get()));
+        assert!(fs.has_data(consts::EF_DEK_PW1.get()));
     }
 
     #[test]
@@ -1226,13 +1226,13 @@ mod tests {
         let mut app = OpenpgpApplet::new(SERIAL_ID, SERIAL_HASH, None, &rng, &presence);
         verify_pin(&mut app, &mut fs, consts::PW3_MODE83, consts::PW3_DEFAULT);
         assert_eq!(put(&mut app, &mut fs, 0x00, 0xC2, ATTR_P256_ECDH), Sw::OK);
-        assert!(!fs.has_data(consts::EF_AES_KEY));
+        assert!(!fs.has_data(consts::EF_AES_KEY.get()));
 
         let (do_, sw) = keygen(&mut app, &mut fs, 0x80, 0xB8);
         assert_eq!(sw, Sw::OK);
         let point = ec_point(&do_).to_vec();
         // Generating the DEC key also mints a fresh AES key.
-        assert!(fs.has_data(consts::EF_AES_KEY));
+        assert!(fs.has_data(consts::EF_AES_KEY.get()));
 
         // The card computes ECDH with the generated key; ECDH is symmetric, so
         // ECDH(dec_priv, eph_pub).x == ECDH(eph_priv, dec_pub).x.
@@ -1266,7 +1266,7 @@ mod tests {
         assert_eq!(put(&mut app, &mut fs, 0x00, 0xC2, ATTR_P256_ECDH), Sw::OK);
         let (_do, sw) = keygen(&mut app, &mut fs, 0x80, 0xB8); // mints EF_AES_KEY
         assert_eq!(sw, Sw::OK);
-        assert!(fs.has_data(consts::EF_AES_KEY));
+        assert!(fs.has_data(consts::EF_AES_KEY.get()));
 
         verify_pin(&mut app, &mut fs, consts::PW1_MODE82, consts::PW1_DEFAULT); // PW2
         let pt = [0xABu8; 32]; // two AES blocks

--- a/crates/rsk-openpgp/src/pin.rs
+++ b/crates/rsk-openpgp/src/pin.rs
@@ -8,7 +8,7 @@
 use zeroize::Zeroize;
 
 use rsk_crypto::{Device, PinKdf};
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Sealed, Storage};
 use rsk_sdk::Sw;
 
 use crate::Rng;
@@ -27,9 +27,9 @@ pub struct Session {
     /// the DEC / AUT slots; MANAGE SECURITY ENVIRONMENT (0x22) can repoint them,
     /// and a deselect resets them.
     pub algo_dec: u16,
-    pub pk_dec: u16,
+    pub pk_dec: KeyFid,
     pub algo_aut: u16,
-    pub pk_aut: u16,
+    pub pk_aut: KeyFid,
     /// Cardholder-certificate occurrence (0/1/2) selected by SELECT DATA,
     /// picking `EF_CH_1/2/3` for GET/PUT DATA of DO 7F21. Reset on deselect.
     pub cert_occ: u8,
@@ -217,7 +217,7 @@ fn migrate_pin_kbase<S: Storage>(
         _ => return Err(Sw::EXEC_ERROR),
     };
     let mut blob = [0u8; DEK_FILE_SIZE];
-    if let Some(n) = fs.read(dek_fid, &mut blob) {
+    if let Some(n) = fs.read_key(dek_fid, &mut blob) {
         if n < 1 || blob[0] != 0x03 {
             return Err(Sw::EXEC_ERROR);
         }
@@ -267,7 +267,7 @@ pub fn load_dek<S: Storage>(
         return Err(Sw::CONDITIONS_NOT_SATISFIED); // no PIN verified
     };
     let mut blob = [0u8; DEK_FILE_SIZE];
-    let n = fs.read(fid, &mut blob).ok_or(Sw::REFERENCE_NOT_FOUND)?;
+    let n = fs.read_key(fid, &mut blob).ok_or(Sw::REFERENCE_NOT_FOUND)?;
     if n < 1 || blob[0] != 0x03 {
         return Err(Sw::EXEC_ERROR);
     }
@@ -349,7 +349,7 @@ fn rewrap_dek<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
     rng: &mut dyn Rng,
-    dek_fid: u16,
+    dek_fid: KeyFid,
     pin: &[u8],
     dek: &[u8; DEK_SIZE],
 ) -> Result<[u8; 32], Sw> {
@@ -360,7 +360,9 @@ fn rewrap_dek<S: Storage>(
     rng.fill(&mut nonce);
     dev.encrypt_with_aad(&session, dek, PinKdf::V2, &nonce, &mut def[1..])
         .map_err(|_| Sw::EXEC_ERROR)?;
-    let r = fs.put(dek_fid, &def).map_err(|_| Sw::MEMORY_FAILURE);
+    let r = fs
+        .put_key(dek_fid, Sealed::wrap(&def))
+        .map_err(|_| Sw::MEMORY_FAILURE);
     def.zeroize();
     r.map(|()| session)
 }
@@ -510,7 +512,7 @@ pub fn put_reset_code<S: Storage>(
     }
     if data.is_empty() {
         let _ = fs.delete(EF_RC);
-        let _ = fs.delete(EF_DEK_RC);
+        let _ = fs.delete_key(EF_DEK_RC);
         sess.has_rc = false;
         return Sw::OK;
     }

--- a/crates/rsk-openpgp/src/terminate.rs
+++ b/crates/rsk-openpgp/src/terminate.rs
@@ -19,6 +19,17 @@ use crate::init::scan_files;
 /// with FIDO (FIDO `EF_PIN` 0x1080 falls between OpenPGP PW1 0x1081 and FIDO 0x1090),
 /// so those are an explicit set — never a range. Verified disjoint from `is_fido_fid`.
 pub fn is_openpgp_fid(fid: u16) -> bool {
+    // Private-key + PW-DEK slots are `KeyFid`s (sealed secrets), so they can't be
+    // `u16` match patterns — compare their raw FIDs explicitly.
+    if fid == EF_PK_SIG.get()
+        || fid == EF_PK_DEC.get()
+        || fid == EF_PK_AUT.get()
+        || fid == EF_DEK_PW1.get()
+        || fid == EF_DEK_RC.get()
+        || fid == EF_DEK_PW3.get()
+    {
+        return true;
+    }
     (0x0001..0x0200).contains(&fid)
         || (0x5f00..0x6000).contains(&fid)
         || (0x7f00..0x8000).contains(&fid)
@@ -32,16 +43,10 @@ pub fn is_openpgp_fid(fid: u16) -> bool {
                 | EF_ALGO_PRIV3
                 | EF_PW_PRIV
                 | EF_PW_RETRIES
-                | EF_PK_SIG
-                | EF_PK_DEC
-                | EF_PK_AUT
                 | EF_PB_SIG
                 | EF_PB_DEC
                 | EF_PB_AUT
                 | EF_DEK
-                | EF_DEK_PW1
-                | EF_DEK_RC
-                | EF_DEK_PW3
                 | EF_DEK_PWPIV
                 | EF_CH_1
                 | EF_CH_2
@@ -149,7 +154,7 @@ mod tests {
         for fid in [
             EF_PW1,
             EF_PW3,
-            EF_PK_SIG,
+            EF_PK_SIG.get(),
             EF_DEK,
             EF_LOGIN_DATA,
             EF_FP,
@@ -169,7 +174,7 @@ mod tests {
     fn terminate_wipes_openpgp_and_reseeds() {
         let mut fs = seeded();
         // User data that a terminate must erase.
-        fs.put(EF_PK_SIG, &[0xAB; 40]).unwrap();
+        fs.put(EF_PK_SIG.get(), &[0xAB; 40]).unwrap();
         fs.put(EF_LOGIN_DATA, b"alice").unwrap();
         // A FIDO file sharing the Fs must SURVIVE (0x1080 = FIDO EF_PIN).
         fs.put(0x1080, &[8, 4, 1, 0, 0]).unwrap();
@@ -179,14 +184,14 @@ mod tests {
             Sw::OK
         );
 
-        assert!(!fs.has_data(EF_PK_SIG), "imported key must be wiped");
+        assert!(!fs.has_data(EF_PK_SIG.get()), "imported key must be wiped");
         assert!(!fs.has_data(EF_LOGIN_DATA), "login data must be wiped");
         assert!(
             fs.has_data(0x1080),
             "FIDO file must survive an OpenPGP terminate"
         );
         // Defaults re-seeded.
-        assert!(fs.has_data(EF_DEK_PW1));
+        assert!(fs.has_data(EF_DEK_PW1.get()));
         let mut pw = [0u8; 7];
         fs.read(EF_PW_PRIV, &mut pw);
         assert_eq!(pw[0], 0x01);
@@ -200,7 +205,7 @@ mod tests {
             terminate_df(&dev(), &mut fs, &mut CountRng(0), false, &apdu()),
             Sw::SECURITY_STATUS_NOT_SATISFIED
         );
-        assert!(fs.has_data(EF_DEK_PW1), "nothing wiped on refusal");
+        assert!(fs.has_data(EF_DEK_PW1.get()), "nothing wiped on refusal");
     }
 
     #[test]

--- a/crates/rsk-piv/src/auth.rs
+++ b/crates/rsk-piv/src/auth.rs
@@ -118,7 +118,7 @@ pub(crate) fn general_authenticate<S: Storage>(
     }
 
     let mut meta = [0u8; 8];
-    let Some(_meta_len) = fs.meta_find(key_fid(key_ref), &mut meta) else {
+    let Some(_meta_len) = fs.meta_find(key_fid(key_ref).get(), &mut meta) else {
         mgm_key.zeroize();
         return Sw::REFERENCE_NOT_FOUND;
     };

--- a/crates/rsk-piv/src/files.rs
+++ b/crates/rsk-piv/src/files.rs
@@ -7,7 +7,7 @@
 //! byte of the `5FC1xx` object id) — the wire slot is the fid low byte everywhere.
 
 use rsk_crypto::Device;
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Storage};
 use rsk_openpgp::Rng;
 use rsk_openpgp::keys::{Curve, PrivKey};
 use rsk_sdk::Sw;
@@ -67,9 +67,11 @@ pub fn is_key(slot: u8) -> bool {
     is_active(slot) || is_retired(slot)
 }
 
-/// Private-key file for a wire slot (also 9B and F9).
-pub fn key_fid(slot: u8) -> u16 {
-    0xD100 | slot as u16
+/// Private-key file for a wire slot (also 9B and F9). A [`KeyFid`]: its contents
+/// are AES-256-GCM-sealed ([`seal`]), so the slot can only be reached through the
+/// typed key API, never the plaintext `Fs::put`/`read`.
+pub fn key_fid(slot: u8) -> KeyFid {
+    KeyFid::new(0xD100 | slot as u16)
 }
 
 /// PIN / PUK verifier files: `[len, format=0x01, verifier(32)]`.
@@ -163,7 +165,7 @@ pub fn scan_files<S: Storage>(dev: &Device, fs: &mut Fs<S>, rng: &mut dyn Rng) -
         fs.put(EF_RETRIES, &[d, d, d, d])
             .map_err(|_| Sw::MEMORY_FAILURE)?;
     }
-    if !fs.has_data(key_fid(SLOT_CARDMGM)) {
+    if !fs.has_key(key_fid(SLOT_CARDMGM)) {
         let mut key = DEFAULT_MGM;
         let r = seal::seal_put(dev, fs, rng, key_fid(SLOT_CARDMGM), &key);
         key.zeroize();
@@ -172,12 +174,12 @@ pub fn scan_files<S: Storage>(dev: &Device, fs: &mut Fs<S>, rng: &mut dyn Rng) -
         // (admin provisioning isn't touch-gated) while still enforcing it if a
         // host raises it via SET MGM KEY. Slot keys keep their ALWAYS default.
         fs.meta_add(
-            key_fid(SLOT_CARDMGM),
+            key_fid(SLOT_CARDMGM).get(),
             &[ALGO_AES192, PINPOLICY_ALWAYS, TOUCHPOLICY_NEVER],
         )
         .map_err(|_| Sw::MEMORY_FAILURE)?;
     }
-    if !fs.has_data(key_fid(SLOT_ATTESTATION)) {
+    if !fs.has_key(key_fid(SLOT_ATTESTATION)) {
         let key = PrivKey::generate(Curve::P384, rng).ok_or(Sw::EXEC_ERROR)?;
         seal::store_ec_key(dev, fs, rng, key_fid(SLOT_ATTESTATION), &key)?;
         let mut point = [0u8; 97];

--- a/crates/rsk-piv/src/keygen.rs
+++ b/crates/rsk-piv/src/keygen.rs
@@ -143,7 +143,10 @@ pub(crate) fn generate_ec<S: Storage>(
     }
     let pol = resolved_policies(slot, req.pin_policy, req.touch_policy);
     if fs
-        .meta_add(key_fid(slot), &[req.algo, pol[0], pol[1], ORIGIN_GENERATED])
+        .meta_add(
+            key_fid(slot).get(),
+            &[req.algo, pol[0], pol[1], ORIGIN_GENERATED],
+        )
         .is_err()
     {
         return Sw::MEMORY_FAILURE;
@@ -186,7 +189,10 @@ pub(crate) fn finish_rsa<S: Storage>(
         return sw;
     }
     if fs
-        .meta_add(key_fid(slot), &[algo, pol[0], pol[1], ORIGIN_GENERATED])
+        .meta_add(
+            key_fid(slot).get(),
+            &[algo, pol[0], pol[1], ORIGIN_GENERATED],
+        )
         .is_err()
     {
         return Sw::MEMORY_FAILURE;
@@ -292,7 +298,10 @@ pub(crate) fn import<S: Storage>(
     }
     let pol = resolved_policies(slot, pin_policy, touch_policy);
     if fs
-        .meta_add(key_fid(slot), &[algo, pol[0], pol[1], ORIGIN_IMPORTED])
+        .meta_add(
+            key_fid(slot).get(),
+            &[algo, pol[0], pol[1], ORIGIN_IMPORTED],
+        )
         .is_err()
     {
         return Sw::MEMORY_FAILURE;
@@ -313,11 +322,11 @@ pub(crate) fn attest<S: Storage>(
     if !is_key(slot) {
         return Sw::REFERENCE_NOT_FOUND;
     }
-    if !fs.has_data(key_fid(slot)) {
+    if !fs.has_key(key_fid(slot)) {
         return Sw::REFERENCE_NOT_FOUND;
     }
     let mut meta = [0u8; 8];
-    let Some(meta_len) = fs.meta_find(key_fid(slot), &mut meta) else {
+    let Some(meta_len) = fs.meta_find(key_fid(slot).get(), &mut meta) else {
         return Sw::REFERENCE_NOT_FOUND;
     };
     if meta_len < 4 || meta[3] != ORIGIN_GENERATED {

--- a/crates/rsk-piv/src/lib.rs
+++ b/crates/rsk-piv/src/lib.rs
@@ -21,7 +21,7 @@ mod x509;
 use core::cell::RefCell;
 
 use rsk_crypto::Device;
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, Sealed, Storage};
 pub use rsk_openpgp::Rng;
 use rsk_openpgp::keys::make_rsa_response;
 // PIV reuses the OpenPGP user-presence trait, so the firmware's existing
@@ -587,7 +587,7 @@ impl PivApplet<'_> {
             }
             SLOT_CARDMGM => {
                 let mut meta = [0u8; 8];
-                let Some(n) = fs.meta_find(key_fid(SLOT_CARDMGM), &mut meta) else {
+                let Some(n) = fs.meta_find(key_fid(SLOT_CARDMGM).get(), &mut meta) else {
                     return Sw::REFERENCE_NOT_FOUND;
                 };
                 if n < 3 {
@@ -606,11 +606,11 @@ impl PivApplet<'_> {
                 Sw::OK
             }
             s if is_key(s) => {
-                if !fs.has_data(key_fid(s)) {
+                if !fs.has_key(key_fid(s)) {
                     return Sw::REFERENCE_NOT_FOUND;
                 }
                 let mut meta = [0u8; 8];
-                let Some(n) = fs.meta_find(key_fid(s), &mut meta) else {
+                let Some(n) = fs.meta_find(key_fid(s).get(), &mut meta) else {
                     return Sw::REFERENCE_NOT_FOUND;
                 };
                 if n < 4 {
@@ -715,14 +715,14 @@ impl PivApplet<'_> {
             return Sw::MEMORY_FAILURE;
         }
         let mut meta = [0u8; 8];
-        let Some(n) = fs.meta_find(key_fid(SLOT_CARDMGM), &mut meta) else {
+        let Some(n) = fs.meta_find(key_fid(SLOT_CARDMGM).get(), &mut meta) else {
             return Sw::REFERENCE_NOT_FOUND;
         };
         if n < 3 {
             return Sw::REFERENCE_NOT_FOUND;
         }
         if fs
-            .meta_add(key_fid(SLOT_CARDMGM), &[algo, meta[1], touch])
+            .meta_add(key_fid(SLOT_CARDMGM).get(), &[algo, meta[1], touch])
             .is_err()
         {
             return Sw::MEMORY_FAILURE;
@@ -749,12 +749,15 @@ impl PivApplet<'_> {
         // The sealed blob is bound to the device, not the fid, so it moves
         // verbatim.
         let mut blob = [0u8; 300];
-        let Some(blob_n) = fs.read(key_fid(from), &mut blob) else {
+        let Some(blob_n) = fs.read_key(key_fid(from), &mut blob) else {
             return Sw::FILE_NOT_FOUND;
         };
         let (cert_from, cert_to) = (cert_fid_for_slot(from), cert_fid_for_slot(to));
         if to != 0xFF {
-            if fs.put(key_fid(to), &blob[..blob_n]).is_err() {
+            if fs
+                .put_key(key_fid(to), Sealed::wrap(&blob[..blob_n]))
+                .is_err()
+            {
                 blob.zeroize();
                 return Sw::MEMORY_FAILURE;
             }
@@ -769,24 +772,24 @@ impl PivApplet<'_> {
                 let _ = fs.delete(tofid);
             }
             let mut meta = [0u8; 8];
-            match fs.meta_find(key_fid(from), &mut meta) {
+            match fs.meta_find(key_fid(from).get(), &mut meta) {
                 Some(n) => {
-                    if fs.meta_add(key_fid(to), &meta[..n]).is_err() {
+                    if fs.meta_add(key_fid(to).get(), &meta[..n]).is_err() {
                         blob.zeroize();
                         return Sw::MEMORY_FAILURE;
                     }
                 }
                 None => {
-                    let _ = fs.meta_delete(key_fid(to));
+                    let _ = fs.meta_delete(key_fid(to).get());
                 }
             }
         }
         blob.zeroize();
-        let _ = fs.delete(key_fid(from));
+        let _ = fs.delete_key(key_fid(from));
         if let Some(f) = cert_from {
             let _ = fs.delete(f);
         }
-        let _ = fs.meta_delete(key_fid(from));
+        let _ = fs.meta_delete(key_fid(from).get());
         Sw::OK
     }
 }
@@ -2080,7 +2083,7 @@ mod tests {
         assert_eq!(sw, Sw::OK);
         // The raw file must not contain the scalar (GCM-sealed).
         let mut blob = [0u8; 300];
-        let n = fs.read(key_fid(0x9D), &mut blob).unwrap();
+        let n = fs.read_key(key_fid(0x9D), &mut blob).unwrap();
         assert!(n > 32);
         assert!(!blob[..n].windows(32).any(|w| w == scalar));
     }

--- a/crates/rsk-piv/src/seal.rs
+++ b/crates/rsk-piv/src/seal.rs
@@ -11,7 +11,7 @@
 use rsa::traits::PrivateKeyParts;
 use rsa::{BigUint, RsaPrivateKey};
 use rsk_crypto::{Device, aes256gcm_decrypt, aes256gcm_encrypt, hkdf_sha256};
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Sealed, Storage};
 use rsk_openpgp::Rng;
 use rsk_openpgp::keys::{Curve, PrivKey};
 use rsk_sdk::Sw;
@@ -40,7 +40,7 @@ pub fn seal_put<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
     rng: &mut dyn Rng,
-    fid: u16,
+    fid: KeyFid,
     plain: &[u8],
 ) -> Result<(), Sw> {
     if plain.len() > MAX_PLAIN {
@@ -61,7 +61,9 @@ pub fn seal_put<S: Storage>(
     );
     key.zeroize();
     blob[NONCE_LEN + plain.len()..n].copy_from_slice(&tag);
-    let r = fs.put(fid, &blob[..n]).map_err(|_| Sw::MEMORY_FAILURE);
+    let r = fs
+        .put_key(fid, Sealed::wrap(&blob[..n]))
+        .map_err(|_| Sw::MEMORY_FAILURE);
     blob.zeroize();
     r
 }
@@ -71,11 +73,11 @@ pub fn seal_put<S: Storage>(
 pub fn seal_read<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
-    fid: u16,
+    fid: KeyFid,
     out: &mut [u8],
 ) -> Result<usize, Sw> {
     let mut blob = [0u8; MAX_BLOB];
-    let n = fs.read(fid, &mut blob).ok_or(Sw::REFERENCE_NOT_FOUND)?;
+    let n = fs.read_key(fid, &mut blob).ok_or(Sw::REFERENCE_NOT_FOUND)?;
     if !(NONCE_LEN + TAG_LEN..=MAX_BLOB).contains(&n) {
         return Err(Sw::MEMORY_FAILURE);
     }
@@ -120,7 +122,7 @@ pub fn migrate_kbase<S: Storage>(dev: &Device, fs: &mut Fs<S>, rng: &mut dyn Rng
     let slots = (0x82..=0x95).chain(0x9A..=0x9E).chain([0xF9u8]);
     for slot in slots {
         let fid = crate::files::key_fid(slot);
-        if !fs.has_data(fid) {
+        if !fs.has_key(fid) {
             continue;
         }
         let mut plain = [0u8; MAX_PLAIN];
@@ -140,7 +142,7 @@ pub fn store_ec_key<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
     rng: &mut dyn Rng,
-    fid: u16,
+    fid: KeyFid,
     key: &PrivKey,
 ) -> Result<(), Sw> {
     let scalar = key.scalar();
@@ -153,7 +155,7 @@ pub fn store_ec_key<S: Storage>(
 }
 
 /// Load an EC key sealed by [`store_ec_key`].
-pub fn load_ec_key<S: Storage>(dev: &Device, fs: &mut Fs<S>, fid: u16) -> Result<PrivKey, Sw> {
+pub fn load_ec_key<S: Storage>(dev: &Device, fs: &mut Fs<S>, fid: KeyFid) -> Result<PrivKey, Sw> {
     let mut plain = [0u8; 1 + 66];
     let n = seal_read(dev, fs, fid, &mut plain)?;
     let r = (|| {
@@ -172,7 +174,7 @@ pub fn store_rsa_key<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
     rng: &mut dyn Rng,
-    fid: u16,
+    fid: KeyFid,
     key: &RsaPrivateKey,
 ) -> Result<(), Sw> {
     let primes = key.primes();
@@ -202,7 +204,7 @@ pub fn store_rsa_key<S: Storage>(
 pub fn load_rsa_key<S: Storage>(
     dev: &Device,
     fs: &mut Fs<S>,
-    fid: u16,
+    fid: KeyFid,
 ) -> Result<RsaPrivateKey, Sw> {
     let mut plain = [0u8; MAX_PLAIN];
     let n = seal_read(dev, fs, fid, &mut plain)?;

--- a/crates/rsk-rescue/src/keydev.rs
+++ b/crates/rsk-rescue/src/keydev.rs
@@ -9,13 +9,13 @@
 use k256::ecdsa::signature::hazmat::PrehashSigner;
 use k256::ecdsa::{Signature, SigningKey};
 use rsk_crypto::{Device, Mode, aes_decrypt, aes_encrypt};
-use rsk_fs::{Fs, Storage};
+use rsk_fs::{Fs, KeyFid, Sealed, Storage};
 use zeroize::Zeroize;
 
 use crate::Rng;
 
 /// The sealed device key. Outside every applet reset scope, like `EF_PHY`.
-pub const EF_DEVCERT_KEY: u16 = 0xE0C1;
+pub const EF_DEVCERT_KEY: KeyFid = KeyFid::new(0xE0C1);
 /// The uploaded device attestation certificate.
 pub const EF_DEVCERT: u16 = 0x2F02;
 
@@ -41,7 +41,7 @@ pub fn load_or_generate<S: Storage>(
 
     let mut buf = [0u8; 33];
     let mut scalar = [0u8; 32];
-    let key = match fs.read(EF_DEVCERT_KEY, &mut buf) {
+    let key = match fs.read_key(EF_DEVCERT_KEY, &mut buf) {
         // Bare 32 bytes: sealed under the pre-OTP kbase arm.
         Some(32) => {
             scalar.copy_from_slice(&buf[..32]);
@@ -100,11 +100,16 @@ fn put_sealed<S: Storage>(dev: &Device, fs: &mut Fs<S>, sealed: &[u8; 32]) -> Re
         let mut rec = [0u8; 33];
         rec[0] = TAG_OTP;
         rec[1..].copy_from_slice(sealed);
-        let r = fs.put(EF_DEVCERT_KEY, &rec).map(|_| ()).map_err(|_| ());
+        let r = fs
+            .put_key(EF_DEVCERT_KEY, Sealed::wrap(&rec))
+            .map(|_| ())
+            .map_err(|_| ());
         rec.zeroize();
         r
     } else {
-        fs.put(EF_DEVCERT_KEY, sealed).map(|_| ()).map_err(|_| ())
+        fs.put_key(EF_DEVCERT_KEY, Sealed::wrap(sealed))
+            .map(|_| ())
+            .map_err(|_| ())
     }
 }
 
@@ -116,7 +121,7 @@ pub fn migrate_kbase<S: Storage>(dev: &Device, fs: &mut Fs<S>) {
         return;
     }
     let mut buf = [0u8; 33];
-    if fs.read(EF_DEVCERT_KEY, &mut buf) != Some(32) {
+    if fs.read_key(EF_DEVCERT_KEY, &mut buf) != Some(32) {
         return;
     }
     let mut iv = [0u8; 16];
@@ -214,13 +219,13 @@ mod tests {
         let mut fs = fs();
         let mut rng = LcgRng(5);
         let key = load_or_generate(&dev(), None, &mut fs, &mut rng).unwrap();
-        assert_eq!(fs.size(EF_DEVCERT_KEY), Some(32));
+        assert_eq!(fs.size(EF_DEVCERT_KEY.get()), Some(32));
 
         // Boot pass re-seals as the tagged 33-byte form; idempotent.
         migrate_kbase(&otp_dev(), &mut fs);
-        assert_eq!(fs.size(EF_DEVCERT_KEY), Some(33));
+        assert_eq!(fs.size(EF_DEVCERT_KEY.get()), Some(33));
         migrate_kbase(&otp_dev(), &mut fs);
-        assert_eq!(fs.size(EF_DEVCERT_KEY), Some(33));
+        assert_eq!(fs.size(EF_DEVCERT_KEY.get()), Some(33));
 
         // The OTP device loads the SAME key; a pre-OTP device fails cleanly.
         let migrated = load_or_generate(&otp_dev(), None, &mut fs, &mut rng).unwrap();
@@ -233,7 +238,7 @@ mod tests {
         let mut fs = fs();
         let mut rng = LcgRng(7);
         let key = load_or_generate(&otp_dev(), None, &mut fs, &mut rng).unwrap();
-        assert_eq!(fs.size(EF_DEVCERT_KEY), Some(33));
+        assert_eq!(fs.size(EF_DEVCERT_KEY.get()), Some(33));
         let again = load_or_generate(&otp_dev(), None, &mut fs, &mut rng).unwrap();
         assert_eq!(key.to_bytes(), again.to_bytes());
     }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,7 @@
 
 # Using the device
 
+- [The `rsk` CLI](guides/cli.md)
 - [FIDO2 / WebAuthn / U2F](guides/fido2.md)
 - [SSH keys (`-sk`)](guides/ssh.md)
 - [Git: signing + auth](guides/git.md)

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,0 +1,179 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+<!-- Copyright (C) 2026 RS-Key contributors -->
+
+# rsk — the device CLI
+
+`rsk` is the host-side command-line tool for an RS-Key. It consolidates every
+day-to-day and production task into one command — device status, seed backup,
+secure-boot provisioning, OTP fuses, FIDO2 management, OpenPGP reset, audit
+verification, fleet inventory, offboarding — and talks to the device directly:
+CTAPHID over hidapi for the FIDO interface, and the CCID applets over PC/SC.
+
+It is the canonical interface; the [terminal cockpit (`rsk-tui`)](tui.md) is a
+read-mostly companion that points you back here for anything irreversible. Most
+other guides in this section assume `rsk` is on your `PATH` and show the exact
+`rsk <group> …` command for the task.
+
+```mermaid
+flowchart LR
+    cli["rsk (host CLI)"] -->|hidapi / CTAPHID| fido["Device — FIDO<br/>backup · audit · lock · attestation"]
+    cli -->|PC/SC / pcscd| ccid["Device — CCID applets<br/>OpenPGP · PIV · OATH · rescue"]
+    cli -->|USB BOOTSEL / picotool| boot["Device — bootloader<br/>secure-boot · OTP fuses"]
+```
+
+## Running it
+
+In the Nix dev shell, `rsk` is already on `PATH` with every dependency pinned:
+
+```sh
+nix develop
+rsk status            # FIDO getInfo + secure-boot + backup state
+rsk --help            # all command groups
+rsk <group> --help    # a group's subcommands and flags
+```
+
+### Without Nix
+
+`rsk` also runs on any host with Python ≥ 3.9, packaged at `tools/`. With
+[uv](https://docs.astral.sh/uv/) (no install step — an ephemeral environment),
+from the repo root:
+
+```sh
+uvx --from ./tools rsk status
+uvx --from ./tools rsk --help
+```
+
+Or install it as a persistent tool, so plain `rsk` is on your `PATH`:
+
+```sh
+uv tool install ./tools        # then: rsk status
+pipx install ./tools           # or pipx
+pip install ./tools            # or a venv + pip
+```
+
+Two dependencies wrap system libraries — `hidapi` (the CTAPHID transport) and
+`pyscard` (PC/SC, for the CCID applets). macOS ships both frameworks and the
+wheels work out of the box; on Linux install `pcsclite` and run `pcscd` for the
+CCID half, plus udev rules for non-root HID. The full setup and the Apple-Silicon
+`pyscard` rebuild note are in [tools/README.md](https://github.com/TheMaxMur/RS-Key/blob/main/tools/README.md)
+and [Linux host setup](../linux.md).
+
+The Nix shell stays the primary, reproducible path (it also carries `picotool`,
+`ykman`, `gpg`, and the test suites); the uv/pip path is for hosts without Nix.
+
+## Command groups
+
+| Group | What it does | Guide |
+|---|---|---|
+| `status` | one-shot device overview (FIDO getInfo + secure-boot + backup) | [quickstart](../quickstart.md) |
+| `inventory` | fleet enumeration (`list`) + identity proof (`verify`) | [Fleet tooling](fleet.md) |
+| `backup` | wallet-style seed export / restore / finalize (BIP-39, SLIP-39) | [Seed backup](seed-backup.md) |
+| `pair` | guided primary + backup (two independent keys) enrollment | [Backup key](backup-key.md) |
+| `lock` | at-rest soft-lock of the FIDO seed (`enable`/`unlock`/`disable`) | [Soft-lock](soft-lock.md) |
+| `secure-boot` | secure-boot provisioning + key rotation **(irreversible)** | [Production](../production.md), [OTP fuses](../otp-fuses.md) |
+| `otp` | burn + lock the at-rest master key (MKEK) into OTP **(irreversible)** | [OTP fuses](../otp-fuses.md) |
+| `fido` | FIDO2 management: `set-pin`, `list-passkeys`, `attestation` | [FIDO2](fido2.md), [Attestation](attestation.md) |
+| `led` | LED color / brightness per device state | [LED](led.md) |
+| `openpgp` | OpenPGP applet utilities (e.g. `reset` to factory PINs) | [OpenPGP card](openpgp.md) |
+| `reboot` | reboot to the app or to BOOTSEL, over CCID | — |
+| `audit` | read + cryptographically verify the tamper-evident journal | [Audit journal](audit.md) |
+| `offboard` | guided full wipe + signed receipt **(destructive)** | [Fleet tooling](fleet.md) |
+
+> Note the two distinct "OTP"s: **`rsk otp`** burns the device's at-rest master
+> key into RP2350 one-time-programmable fuses (a production ritual), while the
+> Yubico-style **[OTP slots](otp.md)** feature (touch-to-type codes) is a runtime
+> applet managed with `ykman`. They share a name, not a mechanism.
+
+## Conventions
+
+These hold across the whole CLI, so each group's guide does not repeat them.
+
+### Entering a PIN
+
+Every command that needs the **FIDO2 clientPIN** accepts it the same way: pass
+`--pin <value>` for scripting, **or** omit it and `rsk` prompts interactively
+(hidden input). You never have to remember which form a given command supports.
+
+```sh
+rsk backup export --pin 1234     # explicit, for scripts / CI
+rsk backup export                # prompts:  FIDO2 PIN:
+```
+
+The prompt is **only** shown when the device actually has a clientPIN set — a
+touch-only key is never asked, so the plug-and-touch flow is unchanged. If stdin
+is not a terminal (a pipe) and no `--pin` was given, `rsk` skips the prompt and
+lets the device report `device requires a PIN` rather than hanging. The
+PIN-gated commands are:
+
+- `backup export` / `backup restore`
+- `audit log` / `audit verify`
+- `lock enable` / `lock disable`
+- `inventory verify`
+- `fido list-passkeys`, `fido attestation import` / `clear`
+- `fido set-pin` — `--pin` is the *current* PIN when changing; `--new-pin` sets
+  the new one (prompted, with confirmation, if omitted)
+
+This is always the FIDO2 clientPIN — the one `rsk fido set-pin` manages — never
+an OpenPGP PW1/PW3 or a PIV PIN. Those are entered only in their own tools
+(`gpg`, `ykman`).
+
+### Touch
+
+Operations that release or sign over a secret require a **physical touch** — a
+press of the BOOTSEL button while the LED blinks, within a 30-second window.
+`rsk` prints `touch the device …` to stderr before blocking. Touch-gated
+commands include `backup export`/`restore`/`finalize`, `audit verify`,
+`inventory verify`, `lock enable`/`disable`, and `fido attestation import`/
+`clear`. Read-only commands (`status`, `inventory list`, `*/status`,
+`audit log`) need no touch.
+
+### Machine-readable output
+
+`status` and `inventory list` take `--json` for scripting — a stable object you
+can pipe to `jq`. Everything else is human-formatted text.
+
+```sh
+rsk status --json | jq '.secure_boot, .fido.clientPin'
+rsk inventory list --json        # one JSON object per connected key, per line
+```
+
+### Irreversible actions
+
+Destructive or fuse-burning commands (`offboard`, `secure-boot`, `otp`,
+`lock enable`, `openpgp reset`) require a **typed confirmation** — you type an
+exact token (e.g. `LOCK-SEED`) rather than pressing a single key; anything else
+aborts. The OTP and secure-boot rituals burn one-time-programmable fuses and
+cannot be undone — read [Production setup](../production.md) before running them.
+
+### Errors and exit codes
+
+On failure `rsk` prints `error: <message>` to stderr and exits non-zero (`1`),
+so it composes in scripts. A device-reported status is surfaced with its CTAP
+code where it helps (e.g. a wrong PIN, a sealed export window, a missing OTP
+DEVK) instead of a bare stack trace.
+
+## Where next
+
+- A linear first-run walkthrough: [Quick start](../quickstart.md).
+- The read-mostly TUI companion: [Terminal cockpit](tui.md).
+- Each task in depth via the [Command groups](#command-groups) table above.
+
+## For contributors
+
+The CLI lives in `tools/rsk/` — one module per group, each exposing a
+`register(sub)` that adds its argparse subparser, wired together in
+`__main__.py`. Shared helpers (error exit, the `--pin` flag + PIN resolution,
+the picotool runner, the FIDO HID connect) live in `common.py`; the raw CTAPHID
+transport and CBOR codec are in `ctaphid.py`.
+
+PIN entry goes through one chokepoint — `common.resolve_pin` (flag-or-prompt)
+and `common.add_pin_arg` (the shared flag) — so consistency is structural, not
+per-command discipline. The pure-logic unit tests need no device:
+
+```sh
+# from tools/ (or: uv run --extra test python -m pytest …)
+nix develop -c bash -c 'cd tools && python -m pytest rsk/'
+```
+
+Host-tool changes like these do **not** bump the firmware `bcdDevice`; see
+[Versions](../versioning.md).

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -104,6 +104,25 @@ nix develop -c cargo vet suggest      # diffs to review next
 The host `tools/tui` workspace is separate and not yet under cargo-vet; it is
 covered by Dependabot and `cargo-deny`.
 
+## Transparency-log monitoring
+
+The Rekor log that backs every signature above is tamper-*evident*, not
+tamper-*proof*: it records misuse, but only if someone looks. A scheduled
+workflow,
+[`rekor-monitor.yml`](https://github.com/TheMaxMur/RS-Key/blob/main/.github/workflows/rekor-monitor.yml),
+does the looking — every hour it runs
+[`sigstore/rekor-monitor`](https://github.com/sigstore/rekor-monitor) and files
+a GitHub issue listing any Rekor entry signed as an RS-Key GitHub-Actions
+identity (any `…/RS-Key/.github/workflows/*` subject under the GitHub OIDC
+issuer).
+
+This is the **detection** half that complements the **verification** above: the
+attestations prove a *legitimate* release is genuine, while the monitor surfaces
+an *illegitimate* signature — one made with our identity by something we didn't
+run (a compromised OIDC token, repo, or runner). Each real release adds a couple
+of expected entries from `release-build.yml`, so a known issue or two per release
+is normal; the alarm is an entry you don't recognise.
+
 ## What's deliberately *not* here
 
 - **No `cargo-vet` of a fully line-reviewed tree.** See the honest scope above.

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -234,6 +234,7 @@ async fn main(_spawner: Spawner) {
     rsk_rescue::keydev::migrate_kbase(&dev, &mut fs);
     rsk_piv::migrate_kbase(&dev, &mut fs, &mut rng);
     rsk_oath::migrate_seal(&dev, &mut fs, &mut rng);
+    rsk_fido::credential::migrate_rp_seal(&dev, &mut fs);
     let _ = rsk_fido::seed::ensure_seed(&dev, &mut fs, &mut rng);
     let _ = rsk_openpgp::scan_files(&dev, &mut fs, &mut rng);
     vendor::load_led_config(&mut fs);
@@ -251,7 +252,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x0766; // bcdDevice: our build counter
+    config.device_release = 0x0767; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -233,6 +233,7 @@ async fn main(_spawner: Spawner) {
     let _ = rsk_fido::seed::migrate_keydev_boot(&dev, &mut fs);
     rsk_rescue::keydev::migrate_kbase(&dev, &mut fs);
     rsk_piv::migrate_kbase(&dev, &mut fs, &mut rng);
+    rsk_oath::migrate_seal(&dev, &mut fs, &mut rng);
     let _ = rsk_fido::seed::ensure_seed(&dev, &mut fs, &mut rng);
     let _ = rsk_openpgp::scan_files(&dev, &mut fs, &mut rng);
     vendor::load_led_config(&mut fs);
@@ -250,7 +251,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x0765; // bcdDevice: our build counter
+    config.device_release = 0x0766; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,53 @@
+# `rsk` — RS-Key device CLI
+
+The host-side CLI for [RS-Key](https://github.com/TheMaxMur/RS-Key): device
+status, wallet-style seed backup, secure-boot provisioning, OTP/MKEK burn, FIDO2
+management, OpenPGP reset, audit-journal verification, and more.
+
+Inside the repo's Nix dev shell `rsk` is already on `PATH`. This package exists
+so you can run it **without Nix** on any host with Python ≥ 3.9.
+
+## Run without Nix
+
+With [uv](https://docs.astral.sh/uv/) (no install step — ephemeral env), from
+the repo root:
+
+```sh
+uvx --from ./tools rsk status
+uvx --from ./tools rsk --help
+```
+
+Or install it as a persistent tool:
+
+```sh
+uv tool install ./tools      # then: rsk status
+# or, classic pip / pipx:
+pipx install ./tools
+pip install ./tools
+```
+
+For repeated use during development, `cd tools && uv run rsk status` reuses one
+environment.
+
+### Native dependencies
+
+Two wheels wrap system libraries:
+
+- **`hidapi`** (CTAPHID transport) and **`pyscard`** (PC/SC, the CCID applets).
+- macOS ships both frameworks; wheels work out of the box. On Apple Silicon, if
+  pip pulls a universal2 `pyscard` that crashes, force an arm64 rebuild:
+  `ARCHFLAGS="-arch arm64" pip install --no-binary pyscard pyscard`.
+- On Linux install `pcsclite`/`libpcsclite-dev` and a running `pcscd` for the
+  CCID half (PIV/OATH); see [docs/linux.md](../docs/linux.md). HID needs udev
+  rules for non-root access.
+
+## Tests
+
+The pure-logic unit tests need no device:
+
+```sh
+uv run --with pytest --extra test python -m pytest rsk/test_common.py rsk/test_secureboot.py
+```
+
+The on-device test suites under [`../tests/`](../tests) need real hardware and
+run from the Nix dev shell.

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+#
+# Packaging for the `rsk` device CLI so it runs WITHOUT Nix on any host with a
+# Python toolchain — `uvx --from ./tools rsk …`, `uv run`, `pipx install`, or a
+# plain `pip install`. The Nix dev shell (nix/host-tools.nix) stays the primary
+# path; this mirrors its runtime deps for everyone else. The package lives in
+# tools/rsk, so this file sits in tools/ and the import name stays `rsk`.
+
+[project]
+name = "rsk"
+description = "RS-Key device CLI — status, seed backup, secure boot, OTP, FIDO, OpenPGP, audit."
+readme = "README.md"
+requires-python = ">=3.9"
+license = "AGPL-3.0-only"
+authors = [{ name = "RS-Key contributors" }]
+keywords = ["fido2", "webauthn", "rp2350", "security-key", "openpgp", "piv"]
+dynamic = ["version"]
+
+# Mirrors the `rskPython` runtime set in nix/host-tools.nix (the CLI half — the
+# test-only extras like pytest/dilithium live under [optional-dependencies]).
+dependencies = [
+  "hidapi>=0.14",         # CTAPHID transport (`import hid`)
+  "cryptography>=42",     # P-256 ECDH / AES / HMAC — clientPIN + MSE seed backup
+  "pyscard>=2.0",         # PC/SC for the CCID applets (PIV / OATH / rescue)
+  "fido2>=1.1",           # `rsk fido` set-pin / list-passkeys
+  "mnemonic>=0.21",       # BIP-39 seed rendering
+  "shamir-mnemonic>=0.3", # SLIP-39 Shamir shares
+]
+
+[project.optional-dependencies]
+test = ["pytest>=8"]
+
+[project.scripts]
+rsk = "rsk.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/TheMaxMur/RS-Key"
+Documentation = "https://github.com/TheMaxMur/RS-Key/tree/main/docs"
+Source = "https://github.com/TheMaxMur/RS-Key"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+# Single source of truth for the version: rsk/__init__.py's __version__.
+[tool.hatch.version]
+path = "rsk/__init__.py"
+
+# tools/ also holds the Rust `tui/` workspace — package only the `rsk` Python
+# module, nothing else under tools/.
+[tool.hatch.build.targets.wheel]
+packages = ["rsk"]
+
+[tool.hatch.build.targets.sdist]
+include = ["rsk", "README.md"]

--- a/tools/rsk/audit.py
+++ b/tools/rsk/audit.py
@@ -23,7 +23,7 @@ import os
 import sys
 
 from .backup import _gated, _vendor
-from .common import connect_fido, die
+from .common import add_pin_arg, connect_fido, device_has_pin, die, resolve_pin
 
 AUDIT_READ, AUDIT_CHECKPOINT = 7, 8
 ENTRY_LEN = 20
@@ -57,11 +57,11 @@ def register(sub):
     g = p.add_subparsers(dest="cmd", required=True)
 
     lg = g.add_parser("log", help="export and print the journal")
-    lg.add_argument("--pin", help="FIDO2 PIN (required if one is set)")
+    add_pin_arg(lg)
     lg.set_defaults(func=cmd_log)
 
     v = g.add_parser("verify", help="log + DEVK-signed chain checkpoint (touch)")
-    v.add_argument("--pin", help="FIDO2 PIN (required if one is set)")
+    add_pin_arg(v)
     v.add_argument("--expect-key", help="pin the attestation pubkey (hex SEC1, from a prior verify)")
     v.set_defaults(func=cmd_verify)
 
@@ -77,7 +77,7 @@ def read_journal(dev, cid, pin):
     """AUDIT_READ → (start, seq_next, epoch, entries bytes)."""
     st, m = _vendor(dev, cid, _gated(AUDIT_READ, None, dev, cid, pin))
     if st == 0x36:
-        die("device requires a PIN — pass --pin")
+        die("device requires a PIN — pass --pin or enter it when prompted")
     if st != 0:
         die(f"audit read failed: {st:#x}")
     start, seq_next, epoch, entries = m[1], m[2], m[3], m[4]
@@ -99,7 +99,8 @@ def print_entries(entries):
 
 def cmd_log(args):
     dev, cid = connect_fido()
-    start, seq_next, epoch, entries = read_journal(dev, cid, args.pin)
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid))
+    start, seq_next, epoch, entries = read_journal(dev, cid, pin)
     print(f"window [{start}, {seq_next})  —  {seq_next - start} entries, "
           f"{start} folded into the epoch")
     print(f"epoch : {epoch.hex()}")
@@ -109,13 +110,14 @@ def cmd_log(args):
 
 def cmd_verify(args):
     dev, cid = connect_fido()
-    start, seq_next, epoch, entries = read_journal(dev, cid, args.pin)
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid))
+    start, seq_next, epoch, entries = read_journal(dev, cid, pin)
     head_local = _fold(epoch, entries)
 
     challenge = os.urandom(16)
     print("touch the device (BOOTSEL) to sign the checkpoint…", file=sys.stderr)
     st, m = _vendor(dev, cid,
-                    _gated(AUDIT_CHECKPOINT, {1: challenge}, dev, cid, args.pin))
+                    _gated(AUDIT_CHECKPOINT, {1: challenge}, dev, cid, pin))
     if st == 0x30:
         die("checkpoint refused — no OTP DEVK provisioned (see docs/production.md)")
     if st == 0x27:

--- a/tools/rsk/backup.py
+++ b/tools/rsk/backup.py
@@ -21,7 +21,7 @@ import os
 import sys
 
 from . import ctaphid
-from .common import connect_fido, die
+from .common import add_pin_arg, connect_fido, device_has_pin, die, resolve_pin
 
 CTAP_VENDOR = 0x41
 VENDOR_MSE, EXPORT, LOAD, FINALIZE, STATE = 1, 2, 3, 4, 5
@@ -39,7 +39,7 @@ def register(sub):
 
     def scheme(sp):
         sp.add_argument("--scheme", choices=["bip39", "slip39"], default="bip39")
-        sp.add_argument("--pin", help="FIDO2 PIN (required if one is set)")
+        add_pin_arg(sp)
 
     e = g.add_parser("export", help="read the seed and print a mnemonic")
     scheme(e)
@@ -108,7 +108,7 @@ def read_seed(dev, cid, pin):
     key, aad = mse_handshake(dev, cid)
     st, m = _vendor(dev, cid, _gated(EXPORT, None, dev, cid, pin))
     if st == 0x36:
-        die("device requires a PIN — pass --pin")
+        die("device requires a PIN — pass --pin or enter it when prompted")
     if st == 0x30:
         die("export refused — already sealed (run after a reset)")
     if st != 0:
@@ -126,7 +126,7 @@ def write_seed(dev, cid, pin, seed):
     blob = nonce + ChaCha20Poly1305(key).encrypt(nonce, seed, aad)
     st, _ = _vendor(dev, cid, _gated(LOAD, {1: blob}, dev, cid, pin))
     if st == 0x36:
-        die("device requires a PIN — pass --pin")
+        die("device requires a PIN — pass --pin or enter it when prompted")
     if st != 0:
         die(f"restore failed: {st:#x}")
 
@@ -166,8 +166,9 @@ def cmd_status(args):
 
 def cmd_export(args):
     dev, cid = connect_fido()
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid))
     print("touch the device (BOOTSEL) to authorise the export…", file=sys.stderr)
-    seed = read_seed(dev, cid, args.pin)
+    seed = read_seed(dev, cid, pin)
     mnemonics = to_bip39(seed) if args.scheme == "bip39" else to_slip39(seed, args.threshold, args.shares)
     print("\n=== WRITE THIS DOWN — the only backup of your FIDO seed ===")
     for i, mn in enumerate(mnemonics, 1):
@@ -191,8 +192,9 @@ def cmd_restore(args):
     if len(seed) != 32:
         die(f"reconstructed secret is {len(seed)} bytes, expected 32")
     dev, cid = connect_fido()
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid))
     print("touch the device (BOOTSEL) to authorise the restore…", file=sys.stderr)
-    write_seed(dev, cid, args.pin, seed)
+    write_seed(dev, cid, pin, seed)
     print("seed restored ✓ — the FIDO identity now matches the backup")
 
 

--- a/tools/rsk/common.py
+++ b/tools/rsk/common.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright (C) 2026 RS-Key contributors
 
-"""Shared helpers: error exit, picotool runner, FIDO HID connect."""
+"""Shared helpers: error exit, PIN resolution, picotool runner, FIDO HID connect."""
 import subprocess
 import sys
+from getpass import getpass
 
 
 def die(msg):
@@ -16,6 +17,55 @@ def confirm(token):
     print(f"\nThis is irreversible. Type exactly  {token}  to proceed.")
     if input("> ").strip() != token:
         die("confirmation mismatch")
+
+
+# --- FIDO2 PIN entry ----------------------------------------------------------
+# One way in for every command: the `--pin` flag OR an interactive prompt, never
+# one without the other. `add_pin_arg` declares the flag identically everywhere;
+# `resolve_pin` turns it (or a getpass prompt) into the PIN string, and only
+# prompts when the device actually has a PIN so the touch-only flow is untouched.
+
+def add_pin_arg(parser, help="FIDO2 PIN (prompted if the device has one and --pin is omitted)"):
+    """Declare the shared --pin flag so every command spells it the same way."""
+    parser.add_argument("--pin", help=help)
+
+
+def device_has_pin(dev, cid):
+    """Tri-state: does the open FIDO device have a clientPin set? (authenticator-
+    GetInfo, touch-free). True / False, or None when getInfo can't be read."""
+    from . import ctaphid
+
+    r = ctaphid.send_cbor(dev, cid, bytes([0x04]))  # authenticatorGetInfo
+    if not r or r[0] != 0:
+        return None
+    opts = ctaphid.decode(r[1:]).get(4) or {}
+    return bool(opts.get("clientPin"))
+
+
+def resolve_pin(args, *, has_pin=None, prompt="FIDO2 PIN: ", required=False):
+    """Resolve the FIDO2 PIN uniformly: the --pin flag if given, else an
+    interactive getpass prompt.
+
+    `has_pin` (from device_has_pin) gates the prompt so a PIN-free device is
+    never asked: True -> prompt when no flag; False -> None (or die if
+    `required`); None -> prompt when no flag. A non-TTY stdin with no flag
+    returns None (the caller's device-side 'PIN required' path then reports the
+    actionable error), unless `required`, where it dies up front."""
+    pin = getattr(args, "pin", None)
+    if pin:
+        return pin
+    if has_pin is False:
+        if required:
+            die("no FIDO2 PIN set — set one first: rsk fido set-pin")
+        return None
+    if not sys.stdin.isatty():
+        if required:
+            die("device requires a PIN — pass --pin (stdin is not a terminal)")
+        return None
+    entered = getpass(prompt) or None
+    if entered is None and required:
+        die("a PIN is required")
+    return entered
 
 
 def picotool(*args, check=True):

--- a/tools/rsk/fido.py
+++ b/tools/rsk/fido.py
@@ -9,7 +9,7 @@ list-passkeys: list discoverable credentials via credentialManagement (needs PIN
 import sys
 from getpass import getpass
 
-from .common import die
+from .common import add_pin_arg, device_has_pin, die, resolve_pin
 
 try:
     from fido2.hid import CtapHidDevice
@@ -23,18 +23,23 @@ except ImportError:
 def register(sub):
     p = sub.add_parser("fido", help="FIDO2 management (set PIN, list passkeys, attestation)")
     g = p.add_subparsers(dest="cmd", required=True)
-    g.add_parser("set-pin", help="set or change the FIDO2 clientPIN").set_defaults(func=set_pin)
-    g.add_parser("list-passkeys", help="list discoverable credentials").set_defaults(func=list_passkeys)
+    sp = g.add_parser("set-pin", help="set or change the FIDO2 clientPIN")
+    add_pin_arg(sp, help="current FIDO2 PIN, when changing (prompted if omitted)")
+    sp.add_argument("--new-pin", help="new FIDO2 PIN (prompted, with confirmation, if omitted)")
+    sp.set_defaults(func=set_pin)
+    lp = g.add_parser("list-passkeys", help="list discoverable credentials")
+    add_pin_arg(lp)
+    lp.set_defaults(func=list_passkeys)
 
     a = g.add_parser("attestation", help="org attestation key/chain (enterprise)")
     ga = a.add_subparsers(dest="acmd", required=True)
     i = ga.add_parser("import", help="install an org attestation key + cert chain")
     i.add_argument("--key", required=True, help="P-256 private key (PEM)")
     i.add_argument("--chain", required=True, help="cert chain, leaf first (PEM or concatenated DER)")
-    i.add_argument("--pin", help="FIDO2 PIN (required if one is set)")
+    add_pin_arg(i)
     i.set_defaults(func=att_import)
     c = ga.add_parser("clear", help="remove the org attestation")
-    c.add_argument("--pin", help="FIDO2 PIN (required if one is set)")
+    add_pin_arg(c)
     c.set_defaults(func=att_clear)
     ga.add_parser("status", help="show whether an org attestation is installed").set_defaults(
         func=att_status)
@@ -58,13 +63,16 @@ def set_pin(args):
     if has_pin is None:
         die("device does not support clientPin")
     cp = ClientPin(ctap)
-    new = getpass("New FIDO2 PIN (4-63 chars): ")
+    new = args.new_pin
+    if new is None:  # interactive: enter twice; a --new-pin is trusted as typed
+        new = getpass("New FIDO2 PIN (4-63 chars): ")
+        if getpass("Repeat new PIN: ") != new:
+            die("PINs do not match")
     if len(new) < 4:
         die("PIN too short (min 4)")
-    if getpass("Repeat new PIN: ") != new:
-        die("PINs do not match")
     if has_pin:
-        cp.change_pin(getpass("Current PIN: "), new)
+        current = resolve_pin(args, has_pin=True, prompt="Current PIN: ", required=True)
+        cp.change_pin(current, new)
         print("FIDO2 PIN changed.")
     else:
         cp.set_pin(new)
@@ -79,7 +87,8 @@ def list_passkeys(args):
     if not ctap.info.options.get("clientPin"):
         die("no FIDO2 PIN set — set one first (rsk fido set-pin)")
     cp = ClientPin(ctap)
-    token = cp.get_pin_token(getpass("FIDO2 PIN: "), ClientPin.PERMISSION.CREDENTIAL_MGMT)
+    pin = resolve_pin(args, has_pin=True, required=True)
+    token = cp.get_pin_token(pin, ClientPin.PERMISSION.CREDENTIAL_MGMT)
     cm = CM(ctap, cp.protocol, token)
     meta = cm.get_metadata()
     existing = meta[CM.RESULT.EXISTING_CRED_COUNT]
@@ -138,13 +147,14 @@ def att_import(args):
     if len(chain) > 2048:
         die(f"chain too large ({len(chain)} B, max 2048)")
     dev, cid = connect_fido()
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid))
     key, aad = mse_handshake(dev, cid)
     nonce = os.urandom(12)
     blob = nonce + ChaCha20Poly1305(key).encrypt(nonce, scalar, aad)
     print("touch the device (BOOTSEL) to authorise the import…", file=sys.stderr)
-    st, _ = _vendor(dev, cid, _gated(ATT_IMPORT, {1: blob, 2: chain}, dev, cid, args.pin))
+    st, _ = _vendor(dev, cid, _gated(ATT_IMPORT, {1: blob, 2: chain}, dev, cid, pin))
     if st == 0x36:
-        die("device requires a PIN — pass --pin")
+        die("device requires a PIN — pass --pin or enter it when prompted")
     if st != 0:
         die(f"import failed: {st:#x}")
     print("org attestation installed ✓ — EA makeCredential and U2F now use the org chain")
@@ -155,11 +165,12 @@ def att_clear(args):
     from .common import connect_fido
 
     dev, cid = connect_fido()
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid))
     mse_handshake(dev, cid)
     print("touch the device (BOOTSEL) to remove the attestation…", file=sys.stderr)
-    st, _ = _vendor(dev, cid, _gated(ATT_CLEAR, None, dev, cid, args.pin))
+    st, _ = _vendor(dev, cid, _gated(ATT_CLEAR, None, dev, cid, pin))
     if st == 0x36:
-        die("device requires a PIN — pass --pin")
+        die("device requires a PIN — pass --pin or enter it when prompted")
     if st != 0:
         die(f"clear failed: {st:#x}")
     print("org attestation removed ✓ (back to the self-signed device cert)")

--- a/tools/rsk/inventory.py
+++ b/tools/rsk/inventory.py
@@ -26,7 +26,7 @@ import sys
 from . import ccid, ctaphid
 from .audit import AUDIT_CHECKPOINT, CKPT_TAG
 from .backup import _gated, _vendor
-from .common import connect_fido, die
+from .common import add_pin_arg, connect_fido, device_has_pin, die, resolve_pin
 from .status import RESCUE_AID, VENDOR_STATE, _fw
 
 ATT_STATE = 11  # vendor: org-attestation state (ungated)
@@ -41,7 +41,7 @@ def register(sub):
     ls.set_defaults(func=cmd_list)
 
     v = g.add_parser("verify", help="challenge-response vs the enrolled attestation key")
-    v.add_argument("--pin", help="FIDO2 PIN (required if one is set)")
+    add_pin_arg(v)
     v.add_argument("--expect-key",
                    help="expected identity: 16-hex fingerprint or full hex SEC1 pubkey")
     v.set_defaults(func=cmd_verify)
@@ -189,12 +189,13 @@ def cmd_list(args):
 
 def cmd_verify(args):
     dev, cid = connect_fido()
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid))
     challenge = os.urandom(16)
     print("touch the device (BOOTSEL) to sign the challenge…", file=sys.stderr)
     st, m = _vendor(dev, cid,
-                    _gated(AUDIT_CHECKPOINT, {1: challenge}, dev, cid, args.pin))
+                    _gated(AUDIT_CHECKPOINT, {1: challenge}, dev, cid, pin))
     if st == 0x36:
-        die("device requires a PIN — pass --pin")
+        die("device requires a PIN — pass --pin or enter it when prompted")
     if st == 0x30:
         die("refused — no OTP DEVK provisioned (see docs/production.md)")
     if st == 0x27:

--- a/tools/rsk/lock.py
+++ b/tools/rsk/lock.py
@@ -21,7 +21,7 @@ import sys
 from . import ctaphid
 from .backup import (from_bip39, from_slip39, mse_handshake, to_bip39,
                      to_slip39, _acfg_token, _vendor)
-from .common import connect_fido, die
+from .common import add_pin_arg, connect_fido, device_has_pin, die, resolve_pin
 
 CTAP_CONFIG = 0x0D
 CONFIG_VENDOR = 0xFF
@@ -41,7 +41,7 @@ def register(sub):
 
     def key_args(sp):
         sp.add_argument("--scheme", choices=["bip39", "slip39", "hex"], default="bip39")
-        sp.add_argument("--pin", help="FIDO2 PIN (authenticatorConfig requires one)")
+        add_pin_arg(sp, help="FIDO2 PIN (authenticatorConfig requires one; prompted if omitted)")
 
     e = g.add_parser("enable", help="engage the lock (shows the lock key ONCE)")
     key_args(e)
@@ -81,10 +81,8 @@ def _wrap_for_channel(key, aad, secret):
 
 
 def _config_vendor(dev, cid, pin, vendor_id, param=None):
-    """authenticatorConfig {1: 0xFF, 2: {1: id, 2: param?}, 3, 4} with the acfg MAC."""
-    if pin is None:
-        die("authenticatorConfig needs the acfg pinUvAuthToken — pass --pin "
-            "(no FIDO2 PIN set? set one first: rsk fido set-pin)")
+    """authenticatorConfig {1: 0xFF, 2: {1: id, 2: param?}, 3, 4} with the acfg MAC.
+    `pin` is resolved by the caller (resolve_pin, required=True), so it is set."""
     subpara = {1: vendor_id}
     if param is not None:
         subpara[2] = param
@@ -138,6 +136,7 @@ def cmd_enable(args):
         die("already locked")
     if not s["has_seed"]:
         die("no seed on the device")
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid), required=True)
 
     key = os.urandom(32)
     if args.scheme == "bip39":
@@ -171,7 +170,7 @@ After enabling:
     chan_key, aad = mse_handshake(dev, cid)
     blob = _wrap_for_channel(chan_key, aad, key)
     print(AUT_TOUCH_HINT, file=sys.stderr)
-    st = _config_vendor(dev, cid, args.pin, AUT_ENABLE, blob)
+    st = _config_vendor(dev, cid, pin, AUT_ENABLE, blob)
     if st != 0:
         die(f"AUT_ENABLE failed: {st:#x}")
     s = _state(dev, cid)
@@ -192,10 +191,11 @@ def cmd_disable(args):
     s = _state(dev, cid)
     if not s["locked"]:
         die("not locked")
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid), required=True)
     if not s["unlocked"]:
         _unlock(dev, cid, _read_lock_key(args))
     print(AUT_TOUCH_HINT, file=sys.stderr)
-    st = _config_vendor(dev, cid, args.pin, AUT_DISABLE)
+    st = _config_vendor(dev, cid, pin, AUT_DISABLE)
     if st != 0:
         die(f"AUT_DISABLE failed: {st:#x}")
     s = _state(dev, cid)

--- a/tools/rsk/secureboot.py
+++ b/tools/rsk/secureboot.py
@@ -139,8 +139,12 @@ def _revoke_leaves_valid(key_valid, key_invalid, slot):
 
 
 def pages_locked(s):
-    """Key/flag pages bootloader-read-only (after `lock`) ⇒ BOOTSEL can't write keys."""
-    return bool(s["page1_lock"]) or bool(s["page2_lock"])
+    """Key/flag pages bootloader-read-only (after `lock`) ⇒ BOOTSEL can't write keys.
+    Only LOCK_BL (bits 4-5 of each RBIT-3 byte, mask 0x303030) blocks bootloader
+    writes; a pre-existing LOCK_NS/LOCK_S in the row does not, so mask to LOCK_BL
+    rather than testing the whole row (else a chip with LOCK_NS set false-positives)."""
+    bl = 0x303030
+    return bool((s["page1_lock"] or 0) & bl) or bool((s["page2_lock"] or 0) & bl)
 
 
 # --- device state -------------------------------------------------------------

--- a/tools/rsk/test_common.py
+++ b/tools/rsk/test_common.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+"""Unit tests for rsk.common.resolve_pin — the one PIN-entry chokepoint.
+
+Run from tools/:  python -m pytest rsk/test_common.py
+Every gated command routes its PIN through resolve_pin, so the precedence
+(flag > prompt), the PIN-free skip, and the required/non-TTY guards are the
+behaviour the whole CLI's consistency rests on — pin them here. No device.
+"""
+import argparse
+
+import pytest
+
+from rsk import common
+
+
+def _args(pin=None):
+    return argparse.Namespace(pin=pin)
+
+
+def _stub_tty(monkeypatch, *, tty=True, entered="hunter2"):
+    """Force isatty() and capture/script the getpass prompt; returns the call log."""
+    calls = []
+
+    class _Stdin:
+        def isatty(self):
+            return tty
+
+    def _getpass(prompt="FIDO2 PIN: "):
+        calls.append(prompt)
+        return entered
+
+    monkeypatch.setattr(common.sys, "stdin", _Stdin())
+    monkeypatch.setattr(common, "getpass", _getpass)
+    return calls
+
+
+def test_flag_wins_and_never_prompts(monkeypatch):
+    calls = _stub_tty(monkeypatch, entered="from-prompt")
+    # --pin given: returned verbatim, the prompt is never reached…
+    assert common.resolve_pin(_args("1234"), has_pin=True) == "1234"
+    # …even when the device is PIN-free or a PIN is "required" (flag is explicit).
+    assert common.resolve_pin(_args("1234"), has_pin=False, required=True) == "1234"
+    assert calls == []
+
+
+def test_pin_free_device_skips_the_prompt(monkeypatch):
+    calls = _stub_tty(monkeypatch)
+    assert common.resolve_pin(_args(), has_pin=False) is None
+    assert calls == []  # a touch-only device is never asked for a PIN
+
+
+def test_has_pin_prompts_interactively(monkeypatch):
+    calls = _stub_tty(monkeypatch, entered="s3cret")
+    assert common.resolve_pin(_args(), has_pin=True) == "s3cret"
+    assert len(calls) == 1
+
+
+def test_unknown_has_pin_still_prompts_on_a_tty(monkeypatch):
+    _stub_tty(monkeypatch, entered="abcd")
+    assert common.resolve_pin(_args(), has_pin=None) == "abcd"
+
+
+def test_custom_prompt_is_used(monkeypatch):
+    calls = _stub_tty(monkeypatch, entered="old")
+    common.resolve_pin(_args(), has_pin=True, prompt="Current PIN: ")
+    assert calls == ["Current PIN: "]
+
+
+def test_empty_input_is_none(monkeypatch):
+    _stub_tty(monkeypatch, entered="")
+    assert common.resolve_pin(_args(), has_pin=True) is None
+
+
+def test_required_dies_when_device_has_no_pin(monkeypatch):
+    _stub_tty(monkeypatch)
+    with pytest.raises(SystemExit):
+        common.resolve_pin(_args(), has_pin=False, required=True)
+
+
+def test_required_dies_on_empty_input(monkeypatch):
+    _stub_tty(monkeypatch, entered="")
+    with pytest.raises(SystemExit):
+        common.resolve_pin(_args(), has_pin=True, required=True)
+
+
+def test_non_tty_returns_none_without_prompting(monkeypatch):
+    calls = _stub_tty(monkeypatch, tty=False)
+    assert common.resolve_pin(_args(), has_pin=True) is None
+    assert calls == []  # piped stdin: fall through to the device-side error path
+
+
+def test_non_tty_required_dies(monkeypatch):
+    _stub_tty(monkeypatch, tty=False)
+    with pytest.raises(SystemExit):
+        common.resolve_pin(_args(), has_pin=True, required=True)

--- a/tools/rsk/test_secureboot.py
+++ b/tools/rsk/test_secureboot.py
@@ -63,6 +63,16 @@ def test_revoke_leaves_valid_guard():
 
 
 def test_pages_locked():
-    assert sb.pages_locked({"page1_lock": sb.PAGE_LOCK_BL_RO, "page2_lock": None}) is True
-    assert sb.pages_locked({"page1_lock": None, "page2_lock": sb.PAGE_LOCK_BL_RO}) is True
+    p = sb.PAGE_LOCK_BL_RO  # 0x141414 — what `secure-boot lock` writes (LOCK_BL set)
+    # LOCK_BL set on either page ⇒ BOOTSEL can no longer write boot keys.
+    assert sb.pages_locked({"page1_lock": p, "page2_lock": None}) is True
+    assert sb.pages_locked({"page1_lock": None, "page2_lock": p}) is True
+    # Unwritten / fully-unlocked pages are not a lock.
     assert sb.pages_locked({"page1_lock": None, "page2_lock": 0}) is False
+    # Regression: a benign pre-existing LOCK_NS=1 with LOCK_BL=0 (0x040404) must
+    # NOT read as bootloader-locked — masking the whole row would false-positive
+    # and wrongly refuse `load-key` on a chip whose non-secure page is read-only.
+    assert sb.pages_locked({"page1_lock": 0x040404, "page2_lock": 0x040404}) is False
+    assert sb.pages_locked({"page1_lock": 0x040404, "page2_lock": None}) is False
+    # LOCK_NS on one page but LOCK_BL on the other ⇒ still locked (LOCK_BL wins).
+    assert sb.pages_locked({"page1_lock": 0x040404, "page2_lock": p}) is True

--- a/tools/tui/src/app.rs
+++ b/tools/tui/src/app.rs
@@ -30,15 +30,14 @@ pub enum Flow {
 #[derive(Clone, Copy, Debug)]
 pub enum Step {
     ExportConfirmed,
-    ExportPin,
     RestorePhrase,
     RestoreConfirmed,
-    RestorePin,
     FinalizeConfirmed,
     RebootApp,
     RebootBootsel,
-    AuditPin,
-    VerifyPin,
+    /// PIN collected (or skipped) — now run this action. The single continuation
+    /// for every PIN-gated action; opened via `App::gate_pin`.
+    PinThenRun(Action),
 }
 
 pub enum Modal {
@@ -260,22 +259,8 @@ impl App {
     pub fn begin_action(&mut self, action: Action) -> Flow {
         match action {
             Action::Refresh | Action::LedGet | Action::LedCycle => Flow::Run(action),
-            Action::Verify => {
-                if self.pin_set() {
-                    self.open_pin(Step::VerifyPin);
-                    Flow::Continue
-                } else {
-                    Flow::Run(Action::Verify)
-                }
-            }
-            Action::AuditRead => {
-                if self.pin_set() {
-                    self.open_pin(Step::AuditPin);
-                    Flow::Continue
-                } else {
-                    Flow::Run(Action::AuditRead)
-                }
-            }
+            Action::Verify => self.gate_pin(Action::Verify),
+            Action::AuditRead => self.gate_pin(Action::AuditRead),
             Action::RebootApp => {
                 self.mode = AppMode::Modal(Modal::YesNo {
                     title: "reboot to app".into(),
@@ -375,8 +360,9 @@ impl App {
             Modal::Input { mut buf, then, .. } => {
                 match then {
                     Step::RestorePhrase => self.staging.phrase = Some(Zeroizing::new(buf.clone())),
-                    // every other Input step collects a PIN
-                    _ => self.staging.pin = Some(Zeroizing::new(buf.clone())),
+                    Step::PinThenRun(_) => self.staging.pin = Some(Zeroizing::new(buf.clone())),
+                    // Input modals only ever collect a restore phrase or a PIN.
+                    other => debug_assert!(false, "unexpected Input step: {other:?}"),
                 }
                 buf.zeroize();
                 self.advance(then)
@@ -387,15 +373,7 @@ impl App {
     /// Advance a confirmation flow to its next modal or to the run.
     fn advance(&mut self, step: Step) -> Flow {
         match step {
-            Step::ExportConfirmed => {
-                if self.pin_set() {
-                    self.open_pin(Step::ExportPin);
-                    Flow::Continue
-                } else {
-                    Flow::Run(Action::BackupExport)
-                }
-            }
-            Step::ExportPin => Flow::Run(Action::BackupExport),
+            Step::ExportConfirmed => self.gate_pin(Action::BackupExport),
             Step::RestorePhrase => {
                 self.open_confirm(
                     "restore seed".into(),
@@ -407,24 +385,28 @@ impl App {
                 );
                 Flow::Continue
             }
-            Step::RestoreConfirmed => {
-                if self.pin_set() {
-                    self.open_pin(Step::RestorePin);
-                    Flow::Continue
-                } else {
-                    Flow::Run(Action::BackupRestore)
-                }
-            }
-            Step::RestorePin => Flow::Run(Action::BackupRestore),
+            Step::RestoreConfirmed => self.gate_pin(Action::BackupRestore),
             Step::FinalizeConfirmed => Flow::Run(Action::BackupFinalize),
             Step::RebootApp => Flow::Run(Action::RebootApp),
             Step::RebootBootsel => Flow::Run(Action::RebootBootsel),
-            Step::AuditPin => Flow::Run(Action::AuditRead),
-            Step::VerifyPin => Flow::Run(Action::Verify),
+            Step::PinThenRun(action) => Flow::Run(action),
         }
     }
 
     // ---- modal helpers ----
+
+    /// The single PIN chokepoint: if the device has a clientPIN, open the masked
+    /// PIN prompt and run `action` once it is entered; otherwise run `action`
+    /// straight away. Every PIN-gated action routes through here, so "does this
+    /// need a PIN?" lives in exactly one place (mirrors the CLI's `resolve_pin`).
+    fn gate_pin(&mut self, action: Action) -> Flow {
+        if self.pin_set() {
+            self.open_pin(Step::PinThenRun(action));
+            Flow::Continue
+        } else {
+            Flow::Run(action)
+        }
+    }
 
     fn open_pin(&mut self, then: Step) {
         self.mode = AppMode::Modal(Modal::Input {
@@ -763,6 +745,32 @@ mod tests {
             panic!("expected confirm");
         }
         assert_eq!(a.submit_modal(), Flow::Run(Action::BackupExport));
+    }
+
+    #[test]
+    fn verify_gates_pin_through_the_chokepoint() {
+        let mut a = app(); // mock has client_pin = true
+        // A directly-gated action (no typed confirm first) opens the masked PIN.
+        assert_eq!(a.begin_action(Action::Verify), Flow::Continue);
+        match &mut a.mode {
+            AppMode::Modal(Modal::Input { mask, buf, .. }) => {
+                assert!(*mask);
+                *buf = "1234".into();
+            }
+            _ => panic!("expected PIN input"),
+        }
+        // The single PinThenRun continuation routes back to the right action.
+        assert_eq!(a.submit_modal(), Flow::Run(Action::Verify));
+        assert_eq!(a.staging.pin.as_deref().map(String::as_str), Some("1234"));
+    }
+
+    #[test]
+    fn verify_without_pin_runs_directly() {
+        let mut a = app();
+        a.snapshot.fido.client_pin = Some(false);
+        // No clientPIN → the chokepoint runs the action with no prompt.
+        assert_eq!(a.begin_action(Action::Verify), Flow::Run(Action::Verify));
+        assert!(matches!(a.mode, AppMode::Normal));
     }
 
     #[test]

--- a/tools/tui/src/device.rs
+++ b/tools/tui/src/device.rs
@@ -970,7 +970,7 @@ pub fn backup_export(pin: Option<&str>) -> Result<String, String> {
     let r = send_cbor(&dev, cid, &payload, 20000);
     match r.first() {
         Some(&0) => {}
-        Some(&0x36) => return Err("device requires a PIN".into()),
+        Some(&0x36) => return Err("device requires a PIN (set one and retry)".into()),
         Some(&0x30) => return Err("export refused — already sealed".into()),
         Some(s) => return Err(format!("export failed: {s:#x}")),
         None => return Err("no response (timeout / no touch)".into()),
@@ -1057,7 +1057,7 @@ pub fn backup_restore(phrase: &str, pin: Option<&str>) -> Result<String, String>
     let (st, _) = vendor(&dev, cid, Value::Map(req), 20000);
     match st {
         0 => Ok("seed restored — FIDO identity matches the backup".into()),
-        0x36 => Err("device requires a PIN".into()),
+        0x36 => Err("device requires a PIN (set one and retry)".into()),
         s => Err(format!("restore failed: {s:#x}")),
     }
 }

--- a/tools/uv.lock
+++ b/tools/uv.lock
@@ -1,0 +1,609 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'PyPy'" },
+    { name = "pycparser", version = "3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/08ed5a43f2996a16b462f64a7055c6e962803534924b9b2f1371d8c00b7b/cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf", size = 184288, upload-time = "2025-09-08T23:23:48.404Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/de/38d9726324e127f727b4ecc376bc85e505bfe61ef130eaf3f290c6847dd4/cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7", size = 180509, upload-time = "2025-09-08T23:23:49.73Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/13/c92e36358fbcc39cf0962e83223c9522154ee8630e1df7c0b3a39a8124e2/cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c", size = 208813, upload-time = "2025-09-08T23:23:51.263Z" },
+    { url = "https://files.pythonhosted.org/packages/15/12/a7a79bd0df4c3bff744b2d7e52cc1b68d5e7e427b384252c42366dc1ecbc/cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165", size = 216498, upload-time = "2025-09-08T23:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/5c51c1c7600bdd7ed9a24a203ec255dccdd0ebf4527f7b922a0bde2fb6ed/cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534", size = 203243, upload-time = "2025-09-08T23:23:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f2/81b63e288295928739d715d00952c8c6034cb6c6a516b17d37e0c8be5600/cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f", size = 203158, upload-time = "2025-09-08T23:23:55.169Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/74/cc4096ce66f5939042ae094e2e96f53426a979864aa1f96a621ad128be27/cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63", size = 216548, upload-time = "2025-09-08T23:23:56.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/be/f6424d1dc46b1091ffcc8964fa7c0ab0cd36839dd2761b49c90481a6ba1b/cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2", size = 218897, upload-time = "2025-09-08T23:23:57.825Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e0/dda537c2309817edf60109e39265f24f24aa7f050767e22c98c53fe7f48b/cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65", size = 211249, upload-time = "2025-09-08T23:23:59.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e7/7c769804eb75e4c4b35e658dba01de1640a351a9653c3d49ca89d16ccc91/cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322", size = 218041, upload-time = "2025-09-08T23:24:00.496Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d9/6218d78f920dcd7507fc16a766b5ef8f3b913cc7aa938e7fc80b9978d089/cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a", size = 172138, upload-time = "2025-09-08T23:24:01.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8f/a1e836f82d8e32a97e6b29cc8f641779181ac7363734f12df27db803ebda/cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9", size = 182794, upload-time = "2025-09-08T23:24:02.943Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "44.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+dependencies = [
+    { name = "cffi", marker = "python_full_version < '3.10' and platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/d6/1411ab4d6108ab167d06254c5be517681f1e331f90edf1379895bcb87020/cryptography-44.0.3.tar.gz", hash = "sha256:fe19d8bc5536a91a24a8133328880a41831b6c5df54599a8417b62fe015d3053", size = 711096, upload-time = "2025-05-02T19:36:04.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/53/c776d80e9d26441bb3868457909b4e74dd9ccabd182e10b2b0ae7a07e265/cryptography-44.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:962bc30480a08d133e631e8dfd4783ab71cc9e33d5d7c1e192f0b7c06397bb88", size = 6670281, upload-time = "2025-05-02T19:34:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/06/af2cf8d56ef87c77319e9086601bef621bedf40f6f59069e1b6d1ec498c5/cryptography-44.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ffc61e8f3bf5b60346d89cd3d37231019c17a081208dfbbd6e1605ba03fa137", size = 3959305, upload-time = "2025-05-02T19:34:53.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/01/80de3bec64627207d030f47bf3536889efee8913cd363e78ca9a09b13c8e/cryptography-44.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58968d331425a6f9eedcee087f77fd3c927c88f55368f43ff7e0a19891f2642c", size = 4171040, upload-time = "2025-05-02T19:34:54.675Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/48/bb16b7541d207a19d9ae8b541c70037a05e473ddc72ccb1386524d4f023c/cryptography-44.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e28d62e59a4dbd1d22e747f57d4f00c459af22181f0b2f787ea83f5a876d7c76", size = 3963411, upload-time = "2025-05-02T19:34:56.61Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b2/7d31f2af5591d217d71d37d044ef5412945a8a8e98d5a2a8ae4fd9cd4489/cryptography-44.0.3-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af653022a0c25ef2e3ffb2c673a50e5a0d02fecc41608f4954176f1933b12359", size = 3689263, upload-time = "2025-05-02T19:34:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/25/50/c0dfb9d87ae88ccc01aad8eb93e23cfbcea6a6a106a9b63a7b14c1f93c75/cryptography-44.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:157f1f3b8d941c2bd8f3ffee0af9b049c9665c39d3da9db2dc338feca5e98a43", size = 4196198, upload-time = "2025-05-02T19:35:00.988Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c9/55c6b8794a74da652690c898cb43906310a3e4e4f6ee0b5f8b3b3e70c441/cryptography-44.0.3-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:c6cd67722619e4d55fdb42ead64ed8843d64638e9c07f4011163e46bc512cf01", size = 3966502, upload-time = "2025-05-02T19:35:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f7/7cb5488c682ca59a02a32ec5f975074084db4c983f849d47b7b67cc8697a/cryptography-44.0.3-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b424563394c369a804ecbee9b06dfb34997f19d00b3518e39f83a5642618397d", size = 4196173, upload-time = "2025-05-02T19:35:05.018Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0b/2f789a8403ae089b0b121f8f54f4a3e5228df756e2146efdf4a09a3d5083/cryptography-44.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c91fc8e8fd78af553f98bc7f2a1d8db977334e4eea302a4bfd75b9461c2d8904", size = 4087713, upload-time = "2025-05-02T19:35:07.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/aa/330c13655f1af398fc154089295cf259252f0ba5df93b4bc9d9c7d7f843e/cryptography-44.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:25cd194c39fa5a0aa4169125ee27d1172097857b27109a45fadc59653ec06f44", size = 4299064, upload-time = "2025-05-02T19:35:08.879Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a8/8c540a421b44fd267a7d58a1fd5f072a552d72204a3f08194f98889de76d/cryptography-44.0.3-cp37-abi3-win32.whl", hash = "sha256:3be3f649d91cb182c3a6bd336de8b61a0a71965bd13d1a04a0e15b39c3d5809d", size = 2773887, upload-time = "2025-05-02T19:35:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0d/c4b1657c39ead18d76bbd122da86bd95bdc4095413460d09544000a17d56/cryptography-44.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:3883076d5c4cc56dbef0b898a74eb6992fdac29a7b9013870b34efe4ddb39a0d", size = 3209737, upload-time = "2025-05-02T19:35:12.12Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a3/ad08e0bcc34ad436013458d7528e83ac29910943cea42ad7dd4141a27bbb/cryptography-44.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:5639c2b16764c6f76eedf722dbad9a0914960d3489c0cc38694ddf9464f1bb2f", size = 6673501, upload-time = "2025-05-02T19:35:13.775Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f0/7491d44bba8d28b464a5bc8cc709f25a51e3eac54c0a4444cf2473a57c37/cryptography-44.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3ffef566ac88f75967d7abd852ed5f182da252d23fac11b4766da3957766759", size = 3960307, upload-time = "2025-05-02T19:35:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/e5c5d0e1364d3346a5747cdcd7ecbb23ca87e6dea4f942a44e88be349f06/cryptography-44.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:192ed30fac1728f7587c6f4613c29c584abdc565d7417c13904708db10206645", size = 4170876, upload-time = "2025-05-02T19:35:18.138Z" },
+    { url = "https://files.pythonhosted.org/packages/73/96/025cb26fc351d8c7d3a1c44e20cf9a01e9f7cf740353c9c7a17072e4b264/cryptography-44.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7d5fe7195c27c32a64955740b949070f21cba664604291c298518d2e255931d2", size = 3964127, upload-time = "2025-05-02T19:35:19.864Z" },
+    { url = "https://files.pythonhosted.org/packages/01/44/eb6522db7d9f84e8833ba3bf63313f8e257729cf3a8917379473fcfd6601/cryptography-44.0.3-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3f07943aa4d7dad689e3bb1638ddc4944cc5e0921e3c227486daae0e31a05e54", size = 3689164, upload-time = "2025-05-02T19:35:21.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fb/d61a4defd0d6cee20b1b8a1ea8f5e25007e26aeb413ca53835f0cae2bcd1/cryptography-44.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cb90f60e03d563ca2445099edf605c16ed1d5b15182d21831f58460c48bffb93", size = 4198081, upload-time = "2025-05-02T19:35:23.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/50/457f6911d36432a8811c3ab8bd5a6090e8d18ce655c22820994913dd06ea/cryptography-44.0.3-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ab0b005721cc0039e885ac3503825661bd9810b15d4f374e473f8c89b7d5460c", size = 3967716, upload-time = "2025-05-02T19:35:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6e/dca39d553075980ccb631955c47b93d87d27f3596da8d48b1ae81463d915/cryptography-44.0.3-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3bb0847e6363c037df8f6ede57d88eaf3410ca2267fb12275370a76f85786a6f", size = 4197398, upload-time = "2025-05-02T19:35:27.678Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/9d/d1f2fe681eabc682067c66a74addd46c887ebacf39038ba01f8860338d3d/cryptography-44.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b0cc66c74c797e1db750aaa842ad5b8b78e14805a9b5d1348dc603612d3e3ff5", size = 4087900, upload-time = "2025-05-02T19:35:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f5/3599e48c5464580b73b236aafb20973b953cd2e7b44c7c2533de1d888446/cryptography-44.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6866df152b581f9429020320e5eb9794c8780e90f7ccb021940d7f50ee00ae0b", size = 4301067, upload-time = "2025-05-02T19:35:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/d2c48c8137eb39d0c193274db5c04a75dab20d2f7c3f81a7dcc3a8897701/cryptography-44.0.3-cp39-abi3-win32.whl", hash = "sha256:c138abae3a12a94c75c10499f1cbae81294a6f983b3af066390adee73f433028", size = 2775467, upload-time = "2025-05-02T19:35:33.805Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ad/51f212198681ea7b0deaaf8846ee10af99fba4e894f67b353524eab2bbe5/cryptography-44.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:5d186f32e52e66994dce4f766884bcb9c68b8da62d61d9d215bfe5fb56d21334", size = 3210375, upload-time = "2025-05-02T19:35:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/10/abcf7418536df1eaba70e2cfc5c8a0ab07aa7aa02a5cbc6a78b9d8b4f121/cryptography-44.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:cad399780053fb383dc067475135e41c9fe7d901a97dd5d9c5dfb5611afc0d7d", size = 3393192, upload-time = "2025-05-02T19:35:37.468Z" },
+    { url = "https://files.pythonhosted.org/packages/06/59/ecb3ef380f5891978f92a7f9120e2852b1df6f0a849c277b8ea45b865db2/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:21a83f6f35b9cc656d71b5de8d519f566df01e660ac2578805ab245ffd8523f8", size = 3898419, upload-time = "2025-05-02T19:35:39.065Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d0/35e2313dbb38cf793aa242182ad5bc5ef5c8fd4e5dbdc380b936c7d51169/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fc3c9babc1e1faefd62704bb46a69f359a9819eb0292e40df3fb6e3574715cd4", size = 4117892, upload-time = "2025-05-02T19:35:40.839Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c8/31fb6e33b56c2c2100d76de3fd820afaa9d4d0b6aea1ccaf9aaf35dc7ce3/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:e909df4053064a97f1e6565153ff8bb389af12c5c8d29c343308760890560aff", size = 3900855, upload-time = "2025-05-02T19:35:42.599Z" },
+    { url = "https://files.pythonhosted.org/packages/43/2a/08cc2ec19e77f2a3cfa2337b429676406d4bb78ddd130a05c458e7b91d73/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:dad80b45c22e05b259e33ddd458e9e2ba099c86ccf4e88db7bbab4b747b18d06", size = 4117619, upload-time = "2025-05-02T19:35:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/02/68/fc3d3f84022a75f2ac4b1a1c0e5d6a0c2ea259e14cd4aae3e0e68e56483c/cryptography-44.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:479d92908277bed6e1a1c69b277734a7771c2b78633c224445b5c60a9f4bc1d9", size = 3136570, upload-time = "2025-05-02T19:35:46.94Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4b/c11ad0b6c061902de5223892d680e89c06c7c4d606305eb8de56c5427ae6/cryptography-44.0.3-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:896530bc9107b226f265effa7ef3f21270f18a2026bc09fed1ebd7b66ddf6375", size = 3390230, upload-time = "2025-05-02T19:35:49.062Z" },
+    { url = "https://files.pythonhosted.org/packages/58/11/0a6bf45d53b9b2290ea3cec30e78b78e6ca29dc101e2e296872a0ffe1335/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:9b4d4a5dbee05a2c390bf212e78b99434efec37b17a4bff42f50285c5c8c9647", size = 3895216, upload-time = "2025-05-02T19:35:51.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/27/b28cdeb7270e957f0077a2c2bfad1b38f72f1f6d699679f97b816ca33642/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:02f55fb4f8b79c1221b0961488eaae21015b69b210e18c386b69de182ebb1259", size = 4115044, upload-time = "2025-05-02T19:35:53.044Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b0/ec4082d3793f03cb248881fecefc26015813199b88f33e3e990a43f79835/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dd3db61b8fe5be220eee484a17233287d0be6932d056cf5738225b9c05ef4fff", size = 3898034, upload-time = "2025-05-02T19:35:54.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7f/adf62e0b8e8d04d50c9a91282a57628c00c54d4ae75e2b02a223bd1f2613/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:978631ec51a6bbc0b7e58f23b68a8ce9e5f09721940933e9c217068388789fe5", size = 4114449, upload-time = "2025-05-02T19:35:57.139Z" },
+    { url = "https://files.pythonhosted.org/packages/87/62/d69eb4a8ee231f4bf733a92caf9da13f1c81a44e874b1d4080c25ecbb723/cryptography-44.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:5d20cc348cca3a8aa7312f42ab953a56e15323800ca3ab0706b8cd452a3a056c", size = 3134369, upload-time = "2025-05-02T19:35:58.907Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "cffi", marker = "python_full_version >= '3.10' and platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
+    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/27/728c77876f12b000820b69ae490f3c4083775e79e07827e9e60be07ad209/cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471", size = 3278498, upload-time = "2026-06-09T22:31:29.154Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/79a612c6d7b1e6ee0edd43633d53035bec2cfb78c82b76f7864f39e36f34/cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2", size = 3798790, upload-time = "2026-06-09T22:31:56.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
+    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
+    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d3/eb4e394e587341fdad09a09101fa76478ead3a78b0ad63e55c22f0d75c02/cryptography-48.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:08a597acce1ff37f347400087776599e2348a3a8bc53b44120e463cd274efe4a", size = 3951747, upload-time = "2026-06-09T22:31:23.871Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/3f43451b4f858bfceaaaffc649e6e787e8d4fb332a1d443af39ab02cc8f1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:735824ec41b7f74a7c45fb1591349333e4c696cb6c044e5f46356e560143e4cd", size = 4641226, upload-time = "2026-06-09T22:31:02.532Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/855584c2c23b09e4ce2d3b9c30e983e679cd60b068c513c6bbdb91e11782/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:92a46e1d638daa264ba2971c0b0489c9409787943efae4d60ffda3d091ef832c", size = 4668958, upload-time = "2026-06-09T22:32:06.213Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3b/d35750e41d803d1e516fd6d6011f065424924da7af1748cef4cc9cb3ede1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:7e234ac052af99f2700826a5c29ea99d9c1b1f80341cde62d11c8154dc8e0bd9", size = 4640793, upload-time = "2026-06-09T22:32:26.331Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/aa/cdb7181fe865285e87e96825aaab239400f1de0c3bfba9bd9769b79f1a92/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:33842cf0888951cef5bc7ac724ab844a42044c1727b967b7f8997289a0464f92", size = 4668505, upload-time = "2026-06-09T22:31:27.534Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8c/ce3823c06c2804f194f9e64f0d67fa3f4094a39f2bb1a990cd03603af8fc/cryptography-48.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6184ca7b174f28d7c703f1290d4b297217c45355f77a98f67e9b7f14549ac54a", size = 3742204, upload-time = "2026-06-09T22:31:34.773Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fido2"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+dependencies = [
+    { name = "cryptography", version = "44.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/cc/4529123364d41f342145f2fd775307eaed817cd22810895dea10e15a4d06/fido2-1.2.0.tar.gz", hash = "sha256:e39f95920122d64283fda5e5581d95a206e704fa42846bfa4662f86aa0d3333b", size = 266369, upload-time = "2024-11-27T09:08:21.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/48/e9b99d66f27d3416a619324568739fd6603e093b2f79138d6f47ccf727b6/fido2-1.2.0-py3-none-any.whl", hash = "sha256:f7c8ee62e359aa980a45773f9493965bb29ede1b237a9218169dbfe60c80e130", size = 219418, upload-time = "2024-11-27T09:08:18.932Z" },
+]
+
+[[package]]
+name = "fido2"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/34/4837e2f5640baf61d8abd6125ccb6cc60b4b2933088528356ad6e781496f/fido2-2.2.0.tar.gz", hash = "sha256:0d8122e690096ad82afde42ac9d6433a4eeffda64084f36341ea02546b181dd1", size = 294167, upload-time = "2026-04-15T06:42:50.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/82/f3c5dd87b0977f5547cc132b7969e6f5075a8c2f5881cf4b6df6378505f9/fido2-2.2.0-py3-none-any.whl", hash = "sha256:3587ccf0af7b71b5dd73f17e1dbec9f0fd157292f9163f02e7778f46d0d25fe5", size = 234025, upload-time = "2026-04-15T06:42:51.813Z" },
+]
+
+[[package]]
+name = "hidapi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/f6/caad9ed701fbb9223eb9e0b41a5514390769b4cb3084a2704ab69e9df0fe/hidapi-0.15.0.tar.gz", hash = "sha256:ecbc265cbe8b7b88755f421e0ba25f084091ec550c2b90ff9e8ddd4fcd540311", size = 184995, upload-time = "2025-12-09T09:48:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/5a/46620fc194f3fa728dce1966ce977334b080fc33b8b525018ad0e0324b91/hidapi-0.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b0e1781f7fb8b4015e318d839d66fa79e98900d53900e31d04edb336e0103846", size = 70517, upload-time = "2025-12-09T09:44:47.751Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/97/bcbcb89f9461c29d3b12dd32affd29e6312fd521154ee7f394496d0039a9/hidapi-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fa3e792987d4b7ed66d785491307e23d4f09d3636f8a23665a9694c43e92409", size = 70181, upload-time = "2025-12-09T09:44:49.321Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/19/b9f1cd2bce226ed43afa7e7649caeee5552e7ea844e997521d747f0da184/hidapi-0.15.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:75c2d3b83a8300953653ddd7f5190d5ee6072d4a6ee5944db47e92d97344ed92", size = 1039531, upload-time = "2025-12-09T09:44:55.735Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b9/5a6a1a4219ada2da251225c706d450076fd2b3d624000699ff4d329326ab/hidapi-0.15.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:91b43099b123363c8935a264acffb4c7e5c8dba3390f9b2bf19ff76597677a31", size = 1573936, upload-time = "2025-12-09T09:44:51.193Z" },
+    { url = "https://files.pythonhosted.org/packages/42/7c/a2df1c993db58f9337d5ee64d3c58f5b9c5127f3ef68907d0c50070d1e50/hidapi-0.15.0-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:cea09ccc3efa5b92ab18d3ae8636836edce2c421d67ed4409761da090e230e5a", size = 1654515, upload-time = "2025-12-09T09:44:54.166Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ca/341b3f5c713f72a7e61a942859b003a507f4a7d7cf5135a20da519bbcf05/hidapi-0.15.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b2de66142cf780ee7c797b7c35e488d67bccdf2de98178ac12a4038c490c44ea", size = 669173, upload-time = "2025-12-09T09:44:57.545Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/55/e5922d48b59959820d976c8e232b14c1f57d65742e416831ce53fda32f6b/hidapi-0.15.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e283c3e9255850d66152adbf580744d38c840d399141b98d64d359cb97cbc128", size = 664906, upload-time = "2025-12-09T09:44:58.893Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b2/87683617901cbc5232a1d99cb8e51a967792aae48d462a8e2a842d63ec25/hidapi-0.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5b9f6d2f3bc15c718d8e2ce349d2d019a0fcc343ed1a705a91d0f1c7e792d6ea", size = 671123, upload-time = "2025-12-09T09:45:00.828Z" },
+    { url = "https://files.pythonhosted.org/packages/26/cc/03f7d56b82a9dc2abcfcd8d55915504e156b6558fb66926629836e551595/hidapi-0.15.0-cp310-cp310-win32.whl", hash = "sha256:81de6b5fcb4fbbbfc71c6d201a2ac6914d1d86e51930ffde5f96faf50e922473", size = 60160, upload-time = "2025-12-09T09:45:04.472Z" },
+    { url = "https://files.pythonhosted.org/packages/35/20/a39e33a9088d76f98f80d9320f8413bdaeaa0458b42470e63a47ac4ccf94/hidapi-0.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:c36895abaef3a4004af6c5020ca214fcdacb2a491e4cde5576afbb1dad903548", size = 67063, upload-time = "2025-12-09T09:45:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c5/3cfa157e7d1fd6af5ad52ea6ea031b1c8da141c61a2506ad5cb3420afa7f/hidapi-0.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:53d018e6ac639a217c019c6dcd79a1d30c2401ac7a8147eedd11f2aa29307661", size = 70578, upload-time = "2025-12-09T09:45:05.497Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7e/a43efc66b3b0a68058e76ad0cb2267ce9b30d9006dce10824f3c8b314b08/hidapi-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a11ef4b5ab0a2f36e35f44af394bff41cb645b03ce36c5b2f2c00873f112661f", size = 70233, upload-time = "2025-12-09T09:45:06.826Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/30/d8551d99528e0b7b2962cc76fb9a2b5990ea16aeb1457d1c3c61015d020f/hidapi-0.15.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e47d4fe13ddfc63fd1961974e10f3c7d50a57ae0bb73974e465cfe95dad5da18", size = 1070472, upload-time = "2025-12-09T09:45:16.322Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/26/433fc4e9efdfb9d1beb52e39ccdec265ae02003b1d2f8395aba3022b665b/hidapi-0.15.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f39917c9e9bea895384b1a8869159d808b4a53561af9b4f7c3148bdf6bfd97a0", size = 1602092, upload-time = "2025-12-09T09:45:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/13/911b757f6847a197ab5c978fe8dd55181035096a5659cf7183e013ed1ea2/hidapi-0.15.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f4d294fcd2551fb5b41d5f478a08e8945382e1d86d7d40320d02594922d6b667", size = 1677973, upload-time = "2025-12-09T09:45:10.357Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3f/cd92833886a15b34225bbd765ed1eb0270bc78b4cf6385e302c0e4bae494/hidapi-0.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:68cb85467151a3d4aa6ab4e11ca89a87c2404a778dbccb8fb5ae51e998133bb3", size = 699789, upload-time = "2025-12-09T09:45:18.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0e/9cdad5783bf1b2aea6667da37f2435b286750d650071dcc50b42834c8810/hidapi-0.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:06fbcd7696ad768d7e9500b64e2ae742b5d90a2531b5aa8d355c0f049516a09d", size = 695983, upload-time = "2025-12-09T09:45:20.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ac/a57bc6e28d0dc1a0aed3dcc24302262ecbf2b723f9c4ba1af4ea51add5b4/hidapi-0.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:221e3a0c181503061bfc4a672eccd9f86b1da1167b31914be00d919edfd6e1bf", size = 697710, upload-time = "2025-12-09T09:45:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/53/40/6a45375a52027d8142e7acdaeab182a44ff6b818df41384019662eb4f351/hidapi-0.15.0-cp311-cp311-win32.whl", hash = "sha256:2c35bd9cc62227ec91047e36b260f75bdbf50814f3cf3c3b28648ac3ffabd9d7", size = 60070, upload-time = "2025-12-09T09:45:24.745Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a9/8ad4e6423c7416eb8dd765327f3be67f083c985b41b9b48ef3061a64c5f2/hidapi-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c5f7ee9ce8e3373fdb7002497f16bc652d9d4acf20c91275877f55165caf6f0c", size = 67296, upload-time = "2025-12-09T09:45:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/fd/9076aba0736f339b71bda5ee26cb678c02420bf96c7ea5bd9ebcbaf0aa3c/hidapi-0.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0b7eb950214191c936b5bdabaeaf1cab99c0dfc3ae3edc220e3c6d4547296053", size = 70157, upload-time = "2025-12-09T09:45:25.77Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/9335957cb7e1ca1be997e97afe850f62a9ff0708015048b3871b553eed5c/hidapi-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27933e7f3da7007e5e8d0b25bcf48a79a74e802555e496bba2c7d87f8a77cd61", size = 69597, upload-time = "2025-12-09T09:45:26.707Z" },
+    { url = "https://files.pythonhosted.org/packages/de/bc/0eb92f4f238adc8edc3decb859662cf87e302b0a6ecdabe0e4d0560eb5fd/hidapi-0.15.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cfdbc74d5c4b5fdeef58a246d80f7dbf4ca33fe741c889505a4a350dd2eb54fb", size = 1082139, upload-time = "2025-12-09T09:45:32.799Z" },
+    { url = "https://files.pythonhosted.org/packages/03/04/856827cfecaa89091ed470f697e3f9cfb172fc852960e6b902e765d7d650/hidapi-0.15.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4b7b6207c1c7df3524e9d4019c7196547327636e9924010b9b0bf0c40029e329", size = 1620074, upload-time = "2025-12-09T09:45:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/63/1338cf0e273d95e07202e391b17198f27bd2cfef71348707eac98cd8db2b/hidapi-0.15.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:908e4b8c35041aa800b51094fd9fbaa5d6161bfb71e55821f43c6433f54e2865", size = 1689689, upload-time = "2025-12-09T09:45:31.195Z" },
+    { url = "https://files.pythonhosted.org/packages/84/08/28ce99698e14bb6bdf9d0dcf7ab45ab86d8bade894885aa15bb3fa43bcc1/hidapi-0.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f9356fffebf723ccfbf0f9370d3725de37b3e2f1f6bffc40c3466f854542861c", size = 713596, upload-time = "2025-12-09T09:45:34.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/16/23e446e2d0ad0d75de149d94f8e6313329aec4d7c18d027e56f5a386779e/hidapi-0.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:fd082e13ca92bbd7a4ec65d9fbd9ef06ecd71798ce9f036b7144b3d498623a7e", size = 697243, upload-time = "2025-12-09T09:45:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ef/e2fa4d795235eb09951f806bbfdbd766d1be805df448d67918e828b7cb31/hidapi-0.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35eb5797d86306bd67aee80ad8973ab0a0b4e6d54018d3efb328767d0e8c9373", size = 717599, upload-time = "2025-12-09T09:45:37.825Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a7/9b7fe9acd09ed90d702f8cc01190ab53e01d5022c21808b079144bc9017d/hidapi-0.15.0-cp312-cp312-win32.whl", hash = "sha256:ce6f99554dae15c48cd89a12d5aede77a92a8bd184b45d0b257a17c97e053cdb", size = 60136, upload-time = "2025-12-09T09:45:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/35/f9e2d3ead60b573140546b041dd41c78a48c0e6b573d61a03130adccd32e/hidapi-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:9abc71a62bf8a8f1d70a6fd3613f86feb37ddb67e05ed934e734df79e27bf4f6", size = 67073, upload-time = "2025-12-09T09:45:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/19/bda2dce4af8b8028e6d611d5caf60e223a4d32a638d1155eefdc6d8f2462/hidapi-0.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f336dd2dc308928d54a6fdce137814a941a3633ad6722919d7a3142dd99005c2", size = 69045, upload-time = "2025-12-09T09:45:41.534Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/9b7d6b6a7561654b9b0d7b22fba9c5c971b36f5fc541b04e02d71928349d/hidapi-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8017f2213810c3e57d9ab64c2328c593a1129b25804240108a6451fe35cde193", size = 68755, upload-time = "2025-12-09T09:45:42.464Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/f144cee5ce9e45518d234fd07c7a4f9a66de3a78ed42bf9f3f4083165e10/hidapi-0.15.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:208c7fc89f78c3448d55957c3e12893778aa91218ed7dc22697e554f091fe4fe", size = 1072286, upload-time = "2025-12-09T09:45:47.236Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bf/7fee015cc48b719bd40c6416f65084a900e7889f0cf52fcfedb9be107b10/hidapi-0.15.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:90f8bd963ae43a44036af5d689d090fab0e3eb52861186e4d2b863dd910a2726", size = 1609789, upload-time = "2025-12-09T09:45:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b6/ac33532711c2ecda5a22d8b2db3223c8a13f16db6d2793ee73a809cca5b6/hidapi-0.15.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:cd6edc7af885755163f4ffb29639c14f8a4ad5cca13ed641e47aa11f9646d8b6", size = 1680636, upload-time = "2025-12-09T09:45:45.67Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e1/5b4426b8a77f9efbef70c0dbc1d64602d36ea8878f76c3607959901c978c/hidapi-0.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6ef0f80b2ff32ba446c9a2d4bfca6623ab5f0c05d742a0161ea1f7af2dc33b12", size = 708617, upload-time = "2025-12-09T09:45:48.874Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a6/1ecdadc3e19f6755eed40f2111f447ec071e3d4f5f4f99b95d26a6d67219/hidapi-0.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6106d10873c1e465a2764e979fb96ec0d16bb926eedac829310830f90816cc76", size = 689589, upload-time = "2025-12-09T09:45:50.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/02/579af4220acdde5ab76d091edaa92f62e110f89131a56b11856f77779607/hidapi-0.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f7a710df215ea3b53a81029488f78e7303b83f01a2e8478db20d7c9756588dd", size = 710213, upload-time = "2025-12-09T09:45:51.747Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c7/52f2d903a607f024086829349383dcc7f0c22533fc242f26f9754eba2f06/hidapi-0.15.0-cp313-cp313-win32.whl", hash = "sha256:e4ddb57e71e2b8aca2c685b94b8587dc7d7cfae3c529a7c4076ba0775eb28d4a", size = 59749, upload-time = "2025-12-09T09:45:53.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/00/7dd3f866a748b0c9eb4adedaa025ec8c533ed1946e9e918661c948a5c0f4/hidapi-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:04e0c1ed6d742bc6e1d00599394bec6b2afb8ee2fc5a0a183d3c4c2d4e315c34", size = 66362, upload-time = "2025-12-09T09:45:52.797Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/e9c70deb396f5baea92cd2ea7803914a55d455c3982367bae4390483e6cc/hidapi-0.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0a6bb079bcd5152dd8968893aecdcbde3954b849896078f54df2254c0d1f301e", size = 69532, upload-time = "2025-12-09T09:45:55.269Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/d006a7e28ec63b5db76340e4aca6ff077ad336f8fbe64ac804b968927011/hidapi-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d80c745d285dfc9889e856226daa8eee6f9e83025ef2cb97e5fe0b1396f7818a", size = 69350, upload-time = "2025-12-09T09:45:56.695Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/95e7595eb61982c651ed2b3ecd9bae05a0298b668c801a992e4e814b22f2/hidapi-0.15.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0f4411fd479345ca86742d9dda77200476a902749d8e47ed438f31ec98af418", size = 1065210, upload-time = "2025-12-09T09:46:02.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a5/0344a7c223c3610510ec7f91f7220b0e5852c92d52aff23377f1c2888880/hidapi-0.15.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:d93f7173dcbec61b928f4cf800bf26535f81ef3b7bd89199237207f6ca7e4f43", size = 1610362, upload-time = "2025-12-09T09:45:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/96/781212cf852705bc1db26edd4340b01b9ce04cadd5d327c00b64f7324978/hidapi-0.15.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:dacf0b9e5d776fde69b92d68c09ab878a09486629e1fe8e6ae851252b0f33ce5", size = 1680942, upload-time = "2025-12-09T09:46:00.971Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/48/6d51a37d3a81355740a82cd265d4fc8485a0a279e4b545cbf790bd106f51/hidapi-0.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bda6ce04a77662e77a4b6b2598211935ca281e1cf663248d54bce75bd684fed8", size = 707550, upload-time = "2025-12-09T09:46:03.993Z" },
+    { url = "https://files.pythonhosted.org/packages/86/77/175efa84ecea161c70948dc67b412b7444c2a196e4def8b305cb756077c6/hidapi-0.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:74900b5c7e884e0e4316d4deb746e5dd294b5aaaf90eac056c4f9f19cf2c8097", size = 689865, upload-time = "2025-12-09T09:46:05.976Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/29/0e513390a8d686448672fabd30385f9cda6e01663765851d0cef88e6f0b1/hidapi-0.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:76236468509dfcb256fa0fbd5a73708c598b3819695b7d08499ae489c82116b6", size = 706809, upload-time = "2025-12-09T09:46:07.309Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d6/c0b9d8568fdb38eebb9caaa56643a81d92cccb5d59a5b44e0d975a0f3808/hidapi-0.15.0-cp314-cp314-win32.whl", hash = "sha256:901c03817306eac7edd589f09e0e07467871b45f665949cc4caa645b54abc97b", size = 61089, upload-time = "2025-12-09T09:46:09.59Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/14/3b27516b2867e53545164ebd8ef45d0c36857d2a062036e788e56e2e34ce/hidapi-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:df0dd435562654e27ad0c7d045074eb1e1e016b09167dd48a258dec1ce4b9127", size = 67710, upload-time = "2025-12-09T09:46:08.677Z" },
+    { url = "https://files.pythonhosted.org/packages/97/8f/ff034661faf99acaabe8954fb7db87c5242c79bf763dd972b23b1be5f104/hidapi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2f16e9ea8a1d24ac7a6bf316905823eafd58f78ec815a93118d4710faf95a224", size = 70893, upload-time = "2025-12-09T09:46:10.625Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/44/617666a0919d06521d732ef07998306b8ddcbd96038e19348c831acd76e8/hidapi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:77f0965ca81a9be44694e84aa18e501d5cda49e372202a38a52d22acc38deadd", size = 71430, upload-time = "2025-12-09T09:46:11.648Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/129aed49fa45b6a5e2fd955618eebe93ff7e3889f05237da6b45051c77bb/hidapi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:541c85b8225ce19b38ceacd404283ca1857345ccfa7ca12f54131203ff2d7f75", size = 1094257, upload-time = "2025-12-09T09:46:17.529Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ca/266ca521ff643957823a7f04a67030f6d2917e86e31c60c3d4878cd6b913/hidapi-0.15.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:89f909a6783307c2f067e8e7948f38ec43386f15d04759d11e5b32e3b2fdf3d8", size = 1663756, upload-time = "2025-12-09T09:46:13.403Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/eb9d0fe6d9ccd2645e993930cc7fdeb6e12ddcdec086f3ef7dec947286ca/hidapi-0.15.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:fd32f311633fad21a52e750775cd4ea23da912199c63d1331f4d8ae00ab0874b", size = 1710998, upload-time = "2025-12-09T09:46:15.68Z" },
+    { url = "https://files.pythonhosted.org/packages/07/43/e5c0cd80df4a65a468b7a9fc6891ea77435a75e64bb273104c37f12e05b3/hidapi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8f7ca38699557ab057333f1628a346073ae6088c09897b2cd9fbc68f4896780c", size = 751383, upload-time = "2025-12-09T09:46:19.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8f/033e19857bcc3ad1b9880b5c0dfbaa7c945e577b7dee18919c1b2478484d/hidapi-0.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:1c4e707c82629637a311fa1a7adc1ae1386de7b539e84b4e37125e52e449318d", size = 722837, upload-time = "2025-12-09T09:46:20.707Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/f0/2b4e7ff42cdc6a6bf7def0591dfd3854af81038a1925ac1ed7a96578e834/hidapi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc99bb16b359023190bf857297f6492a1c8441ccacff66dac881c9e278f5c262", size = 750923, upload-time = "2025-12-09T09:46:23.161Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/eb/c0676ff1f7e9ec9d99eaa428c66745cdab5b1742808f0c16061c85bd0b18/hidapi-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:005c84c74c940a314b211674edc763a931ace0b63685ace88148496f563e25f9", size = 66288, upload-time = "2025-12-09T09:46:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5b/f22dbf886824559d3e66d84710c5fb48c09856e6816885da97f2f51700eb/hidapi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e384430363d400c4ffb33fe65f22a61c9f288a870158dc5a9f5c9d917b7250c7", size = 74723, upload-time = "2025-12-09T09:46:24.36Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/dc8d3fa85a5a4feb6ed8d79da9f5fefdd3b1607ce9220e1b54faa95927e5/hidapi-0.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3d220314975b99a083f4ee21abfd796a9ceeb99cbf3487a41c5eb80269102a4a", size = 71079, upload-time = "2025-12-09T09:46:40.112Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c0/73d0b576332467e1ff84c51bef3eb21f07125835a7a580f4047919a67d1d/hidapi-0.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bc61ab7f45dddbb2df2fca93565c575c0b035337d1e13ce2868c092ff24e9c47", size = 70800, upload-time = "2025-12-09T09:46:41.021Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/9819036af3a3f6ab58570c4292c28bfd42ac9898e04070f598e92939ac51/hidapi-0.15.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aefc2afd146733e3ec8b33474bfb832c9281dd106309a216a20bade19dc0e95f", size = 1039182, upload-time = "2025-12-09T09:46:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/f696f62702b75eccc4dbcf619e82cf773b0d892d2bcc7e9cf85aefb3d9f2/hidapi-0.15.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:ef3b43b1a4d4df8ea542487cda888138eaac4707db46bbca0f7bb78d97a06323", size = 1572449, upload-time = "2025-12-09T09:46:43.048Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/7c/e58643470288fc6132933475ba810482616ad08c333770f23e9d4c9f31ca/hidapi-0.15.0-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:0608a882f06d7f37e0f1786e255e9a8b1e2386fdb8f9fb9d209b82682551f4b8", size = 1654806, upload-time = "2025-12-09T09:46:46.53Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a0/021d8f40ebed1f21a90c0f6c794657e3e9e9fe013788e2467bc5ce3b42f2/hidapi-0.15.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:788e16711a4530a2a7a8a4cd942f7250fa7f907a3be892b11d8eb51ec697739a", size = 667407, upload-time = "2025-12-09T09:46:50.51Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a5/4c7355b133be152d1e085190e37880230a47575a853752a06a824cd37951/hidapi-0.15.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:48e79274384c23b250bc95016c8aa6497cf0a23b3a112d05376cbf5ace266886", size = 665330, upload-time = "2025-12-09T09:46:51.848Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/02/24656533d5b7d0047ca70f9abaeae8fd9fe694c32e91a88a5885652aa605/hidapi-0.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c49aa659ecfe46a93a7057bca42208bfd123c2fcbdfd4a28eb1f9b8189260b68", size = 669911, upload-time = "2025-12-09T09:46:53.202Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4e/7dd283c34d85898b4a259b8ea1116800de2b603256b20d19fad31bf88be4/hidapi-0.15.0-cp39-cp39-win32.whl", hash = "sha256:27d288d405bd4abedd047eefb9c4ab797d232454b35e17e7b61a03edf70c64e8", size = 60498, upload-time = "2025-12-09T09:46:55.587Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/8c/b51934ac6dd24409d94b949c143bb55207a3a8213a520671cbdd95f24f42/hidapi-0.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:cb835b81624a72830e5ebebde26b93ab5ee812de648386a47d13dfbf64b348c7", size = 67432, upload-time = "2025-12-09T09:46:54.653Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "mnemonic"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/77/e6232ed59fbd7b90208bb8d4f89ed5aabcf30a524bc2fb8f0dafbe8e7df9/mnemonic-0.21.tar.gz", hash = "sha256:1fe496356820984f45559b1540c80ff10de448368929b9c60a2b55744cc88acf", size = 152462, upload-time = "2024-01-05T10:46:14.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/48/5abb16ce7f9d97b728e6b97c704ceaa614362e0847651f379ed0511942a0/mnemonic-0.21-py3-none-any.whl", hash = "sha256:72dc9de16ec5ef47287237b9b6943da11647a03fe7cf1f139fc3d7c4a7439288", size = 92701, upload-time = "2024-01-05T10:46:12.703Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyscard"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/c9/65c68738a94b44b67b3c5e68a815890bbd225f2ae11ef1ace9b61fa9d5f3/pyscard-2.3.1.tar.gz", hash = "sha256:a24356f57a0a950740b6e54f51f819edd5296ee8892a6625b0da04724e9e6c13", size = 160650, upload-time = "2025-10-29T15:49:08.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ec/aab3e2e95e9d9cfdc3ff81d571b8e2de30c6763bf7529512d21d379dfadf/pyscard-2.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5bd277142644441cba8fe71bc991fe83108147f3ba22c01e8b9a5a3f41a31f69", size = 171263, upload-time = "2025-10-29T15:53:21.734Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d1/47f641a2f2edf80a2e1885a3c049caacf67bf1674852b3902d6ad5ce2f33/pyscard-2.3.1-cp310-cp310-win32.whl", hash = "sha256:717ea958ee77d7d4514ff0a6eb238082f9437e7882479ee6f742bb9db54419d4", size = 139159, upload-time = "2025-10-29T15:53:23.834Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e5/d9da97370b0d59dd5b0a001a91367c406c64d5a72134bdea4603cf50e16e/pyscard-2.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:91b27548eddcd6c21f115d5e6151ced9b348aae989b0e4fcc1ad4c479e61610c", size = 145501, upload-time = "2025-10-29T15:53:22.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/da/15893ec870e9939f07c5260861286e62de7edaab178e66d9d024a6810278/pyscard-2.3.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:341eca9151318093d5543fa812736546de19020d214e01aff9bbc231d1429949", size = 171262, upload-time = "2025-10-29T15:53:25.03Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c2/e9897a29b4c10fabcb2144f046837d47cf043943b31740c58a57b6b0dfed/pyscard-2.3.1-cp311-cp311-win32.whl", hash = "sha256:be78734964621b59f8b63c90b822169dc804571df57f574733ccf585a31769af", size = 139147, upload-time = "2025-10-29T15:53:27.675Z" },
+    { url = "https://files.pythonhosted.org/packages/79/00/379433a43deb453bff6f68e3ea36db9fdc5a1df7d41fee305e80573aa034/pyscard-2.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:52da45a3becfb6807dcd9427d763aeb154c9c9e9ad324a13a2bf322fa31baca5", size = 145504, upload-time = "2025-10-29T15:53:25.902Z" },
+    { url = "https://files.pythonhosted.org/packages/96/28/2fd9247066088150762c951515474c7a30be30d24d2415d3eeaa77528a1b/pyscard-2.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:e228c78e028b74e5411a604c765852bdc8fd04321f03e62d25cad8e90de27597", size = 140896, upload-time = "2025-10-29T15:53:26.78Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a5/2d882e8fb35dc3f0e2b76a09d4175b29c17fb69197d02a6d618280c58c68/pyscard-2.3.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:acb9f4842cb08110d916e7e37ef225c755a1da627017364c55df547b6f187dcf", size = 171649, upload-time = "2025-10-29T15:53:28.525Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bc/fb6069f40cd9f38b4e68661a086d9b1ed34ba1bbece33988e027d98b0c4b/pyscard-2.3.1-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:abf5091d5067ac4945eb2a283b60bddce7530595e585868449da12d3b9e885ee", size = 138958, upload-time = "2025-10-29T15:49:04.922Z" },
+    { url = "https://files.pythonhosted.org/packages/37/8d/0e0e5ed1daaa6137fd62614a732a87133404dc16cf8fc90beb1251f12c05/pyscard-2.3.1-cp312-cp312-win32.whl", hash = "sha256:c5d9fde122ffd41a74af72364166e8b23760230163e20c4c130aa0616bf4a786", size = 139441, upload-time = "2025-10-29T15:53:31.194Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/63/8885d91378d921e6aac13d9b44b966e4c07f18c1666dc21e38bd7f11e4d9/pyscard-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:561889413866141b3a44099f043d10344ee64b0604d2fecb275975b54aa584c6", size = 145700, upload-time = "2025-10-29T15:53:29.428Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8e/d32f339b905ff7e76f7d788a05a683b96d6ac02491c39757974015dfd2ca/pyscard-2.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:06ae5e5421a5dd380e8c80046b4242e7b98ed381247117f4cf2c1c8328f74bce", size = 140981, upload-time = "2025-10-29T15:53:30.309Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e2/d8f967fe6fee82c02ee35d736e8707d65ed1e37fa7635f3bdca96bdcd2ff/pyscard-2.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c11a596407e18cdcf16a4ccd8cdeaa55846d4f7ec2eefc529483e201f6906658", size = 170956, upload-time = "2025-10-29T15:53:32.072Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a1/508fc5733e2ce01a71c6abc94dae543311cf9d0962e309b0a78b4cb4031a/pyscard-2.3.1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:72b1ab922fad5e050144ec72762e36741271b09d2389cda9b976b61ee0564e71", size = 138809, upload-time = "2025-10-29T15:49:06.528Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a4/5481cd54f882ea61bfc334667f1e5126ac51124a464297dbe24592288b14/pyscard-2.3.1-cp313-cp313-win32.whl", hash = "sha256:a0b59d1961ff9fb15d980ad64edae13e4512b7e641ea8959e86133f34091aa5c", size = 139294, upload-time = "2025-10-29T15:53:35.805Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2b/c98e7bcf45958905d1bfdab59fe5acd67fe9ff0ad78145c4783886c38c84/pyscard-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:df2b256bc719b701807114bdd179f7b303f309a954d5689188b088adfc33ead2", size = 145501, upload-time = "2025-10-29T15:53:33.549Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a6/74cca0ec3c08f35c1a7468a8508d0e3989e63298d3a4b1f928542719aebc/pyscard-2.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:f58b46cd78455a29a0abceabff21b37da81a385a737b29e6dd5e25acb7e3f3da", size = 140758, upload-time = "2025-10-29T15:53:34.542Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/95/e08326c19a5e9307a16ad37e9abd76ec9796987a8436271fb79ce997c307/pyscard-2.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a36bab071c6f4b1d74a8778a784ccf3cc04bf35a6c677bce15e70fdbeac5b932", size = 139046, upload-time = "2025-10-29T15:49:07.453Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+]
+
+[[package]]
+name = "rsk"
+source = { editable = "." }
+dependencies = [
+    { name = "cryptography", version = "44.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "fido2", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "fido2", version = "2.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "hidapi" },
+    { name = "mnemonic" },
+    { name = "pyscard" },
+    { name = "shamir-mnemonic" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cryptography", specifier = ">=42" },
+    { name = "fido2", specifier = ">=1.1" },
+    { name = "hidapi", specifier = ">=0.14" },
+    { name = "mnemonic", specifier = ">=0.21" },
+    { name = "pyscard", specifier = ">=2.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
+    { name = "shamir-mnemonic", specifier = ">=0.3" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "shamir-mnemonic"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/9f5b305b5280795209817efe6b0cd6017f4714e3f36d160b2d4dfcc78c02/shamir_mnemonic-0.3.0.tar.gz", hash = "sha256:bc04886a1ddfe2a64d8a3ec51abf0f664d98d5b557cc7e78a8ad2d10a1d87438", size = 21757, upload-time = "2024-05-16T10:08:51.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/38/2124e565afe40993949dbc89da6c654a2c9a1b24dd80039812ef7cdbaef3/shamir_mnemonic-0.3.0-py3-none-any.whl", hash = "sha256:188c6b5bd00d5e756e12e2b186c3cb7c98ff7ff44df608d4c1d2077f6b6e730f", size = 23159, upload-time = "2024-05-16T10:08:49.154Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Release v0.2.4

Ships **firmware bcdDevice 0x0767** (already flashed + HW-verified) plus host-tool work.

### Security
- **OATH secrets sealed at rest** (`0x0765`→`0x0766`) — TOTP/HOTP shared secrets + SET CODE key now AES-256-GCM device-sealed; one-time boot migration re-seals existing creds.
- **Type-enforced seal chokepoint** — a sealed slot is a `KeyFid`; `fs.put(key_fid, raw)` no longer compiles (`compile_fail` doctest).
- **Resident-credential RP domains boxed at rest** (`0x0766`→`0x0767`) — `EF_RP` domains ChaCha20-Poly1305-boxed under the device seed; rpId hash kept cleartext as the O(1) key.
- **Transparency-log monitoring** — scheduled `sigstore/rekor-monitor` watches Rekor for misuse of the release signing identity (CI only).

### Changed
- **Uniform FIDO2 PIN entry in the `rsk` CLI** — every PIN-gated command takes `--pin` *or* an interactive prompt, via one `resolve_pin` chokepoint that only prompts when the device has a PIN.
- **Same PIN chokepoint in `rsk-tui`** — four per-action steps collapsed into one `gate_pin` + `Step::PinThenRun`; explicit PIN-vs-phrase collection.

### Added
- **Run the `rsk` CLI without Nix** — `tools/pyproject.toml` (`uvx --from ./tools rsk`, `uv tool install`, pipx, pip); new `docs/guides/cli.md`.

### Fixed
- **`rsk secure-boot`** no longer refuses provisioning on a chip with a benign `LOCK_NS` (now masks `LOCK_BL` specifically).

---
Firmware change since v0.2.3 is `0x0766`+`0x0767`, both HW-verified; the rest is host-tools only. Local `./scripts/check.sh` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
