### PR TITLE
Release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **`ssh-keygen -t ed25519-sk` (and any Ed25519 FIDO2 credential) failed on
+  Windows — EdDSA is now advertised in `authenticatorGetInfo`.** The device has
+  always *supported* EdDSA (COSE `-8`): `makeCredential` negotiates it from a
+  request's `pubKeyCredParams` and signs with Ed25519. But `-8` was omitted from
+  the advertised `algorithms` (0x0A) list, kept out alongside ES256K (`-47`) so
+  the FIDO Conformance tool — whose `verifySignatureCOSE` only maps `-7/-35/-36` —
+  wouldn't fail trying to verify an EdDSA self-attestation. The Windows WebAuthn
+  API (the path Windows OpenSSH takes) **intersects the requested algorithms with
+  the advertised list**, so it silently dropped `-8` and the credential create
+  failed; macOS/Linux OpenSSH go through libfido2, which sends `-8` directly, so
+  it worked there. The shipping/default build now advertises `-8`. The capability
+  is unchanged — only the advertisement was added. ES256K (`-47`) stays
+  unadvertised (still negotiable from a request). For the conformance run, the new
+  `fido-conformance` build feature suppresses `-8` again and
+  `metadata/rs-key.conformance.metadata.json` is the matching EdDSA-free Metadata
+  Statement (verified by `tests/62` to be the shipping statement minus EdDSA).
+  `bcdDevice` `0x077C` → `0x077D`.
+
 - **Two power-cut data-durability bugs in the flash file system, both surfaced by
   the `power_cut` / `fs_ops` fuzz targets (deep-checks) and latent since the
   present-cache landed in v0.2.3.** Neither affects the shipped, verified v0.2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,31 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.2.6] — 2026-06-21
+
 ### Fixed
+
+- **ML-DSA-44 (COSE `-48`) FIDO `getAssertion` hard-wedged the device — the
+  post-quantum credential key is now heap-boxed off the worker stack.** The
+  optional ML-DSA-44 signature scheme (negotiable from a request's
+  `pubKeyCredParams`, unadvertised by default) held fips204's ~16.6 KiB of
+  NTT-form keys *inline* on the worker stack, directly below the stack-heavy
+  rejection-sampling `sign`. A `.bss` growth since v0.2.5 (the power-cut
+  tri-state present-cache + the hybrid ML-KEM-768 seed-backup) had lowered the
+  RP2350 worker-stack ceiling from ~238 KiB to ~222 KiB, so an ML-DSA-44
+  `getAssertion` overflowed it → memory corruption → `panic-halt`, leaving FIDO
+  dark until a USB replug. Reachable as a denial of service: an explicit `-48`
+  `makeCredential` followed by `getAssertion` wedges the authenticator even
+  though `-48` is unadvertised. `makeCredential` survived because key generation
+  is a shallower frame than signing. The keypair is now `Box`-ed onto the
+  firmware heap — idle during a FIDO request, since applet keys are reconstructed
+  per-operation — freeing ~16.6 KiB at signing depth and restoring a measured
+  32–64 KiB of stack margin (verified on hardware by flashing deliberately
+  stack-starved builds: passes at −32 KiB, wedges at −64 KiB). The heap stays
+  128 KiB, so there is no RSA impact, and a `size_of::<CredKey>()` guard fails
+  the build if the key ever regresses back inline. HW-verified on RP2350
+  (`tests/60` raw CTAPHID + `tests/61` python-fido2/OpenSSL, ML-DSA-44
+  register+login). `bcdDevice` `0x077D` → `0x077E`.
 
 - **`ssh-keygen -t ed25519-sk` (and any Ed25519 FIDO2 credential) failed on
   Windows — EdDSA is now advertised in `authenticatorGetInfo`.** The device has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two power-cut data-durability bugs in the flash file system, both surfaced by
+  the `power_cut` / `fs_ops` fuzz targets (deep-checks) and latent since the
+  present-cache landed in v0.2.3.** Neither affects the shipped, verified v0.2.5
+  artifacts — both are power-cut-edge, not artifact-integrity.
+  - **`delete` orphaned metadata.** `Fs::delete` dropped a file's `EF_META`
+    record only when the file's *own* data was present, so a file given metadata
+    (`meta_add`) but never written (`put`) kept its metadata after deletion — the
+    record read back alive across a reboot, diverging the live key set from the
+    model. `delete` now drops metadata unconditionally (O(1) when there is none),
+    and `meta_delete` skips the `EF_META` rewrite when the FID had no record, so
+    the absent-slot reset sweep stays write-free.
+  - **The present-cache could go false-absent after a torn migration.** The boot
+    `scan` seeds its negative cache from a bulk `for_each_key`, which can silently
+    under-count a key when a power-cut interrupts a `sequential-storage` page
+    migration — while the per-key `fetch_item` still recovers it. A clear cache
+    bit was trusted as "absent", so committed data/metadata read back lost, and a
+    `meta_add` over a false-absent `EF_META` wiped every existing record. The
+    cache is now tri-state (`present` + a `decided` authority bit): a clear bit is
+    trusted only once a backend probe confirms it, otherwise the reliable
+    `fetch_item` decides and the answer is memoised — a false-absent is now
+    impossible. Cost: a one-time-per-boot first probe per absent FID (the PIV-tab
+    lag returns once after a plug-in, then stays O(1)). `fetch_item` durability is
+    pinned by a new `kv_durability` fuzz target (the storage layer in isolation);
+    `power_cut` and `fs_ops` now run clean. `bcdDevice` `0x077B` → `0x077C`.
+
 ## [0.2.5] — 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ replacement for an audited commercial key.
 ## Project status
 
 A working, single-maintainer hobby project under active development. The latest
-tagged release is **v0.2.5**; day to day the supported version is the tip of
+tagged release is **v0.2.6**; day to day the supported version is the tip of
 `main`, and every behavior change bumps the USB `bcdDevice` build counter so a
 build can be named precisely. Most of the protocol surface works against real host software; what
 has actually been checked on hardware (with dates) is in

--- a/crates/rsk-fido/Cargo.toml
+++ b/crates/rsk-fido/Cargo.toml
@@ -38,9 +38,19 @@ advertise-pqc = []
 # rises to 6 and the vendor seed export is refused. A build profile, not a
 # FIPS validation — see docs/guides/fips.md.
 fips-profile = []
+# FIDO Conformance Tool build profile, OFF by default. Suppresses the EdDSA (-8)
+# advertisement in getInfo `algorithms` (0x0A): the tool's shared
+# verifySignatureCOSE maps only -7/-35/-36, so it cannot verify a packed EdDSA
+# self-attestation (MakeCred-Resp P-06). The shipping build ADVERTISES -8 — the
+# Windows WebAuthn API drops unadvertised algorithms, breaking `ed25519-sk`. The
+# EdDSA capability itself is unchanged; only the advertisement is suppressed. Pair
+# with `metadata/rs-key.conformance.metadata.json`. Conformance ONLY — never ship.
+fido-conformance = []
 # Add the FIDO Conformance Tool's fixed enterprise-attestation test RPID
 # (enterprisetest.certinfra.fidoalliance.org) to the vendor-facilitated (type 1)
 # EA eligibility list, so the tool's Enterprise-Attestation type-1 case can run.
-# Conformance self-validation ONLY — never ship it (it would grant enterprise
-# attestation to a FIDO test domain). Shipping firmware's type-1 list is empty.
-ea-conformance-rpid = []
+# Implies `fido-conformance` (an EA conformance build is a conformance build, so
+# it must also suppress EdDSA). Conformance self-validation ONLY — never ship it
+# (it would grant enterprise attestation to a FIDO test domain). Shipping
+# firmware's type-1 list is empty.
+ea-conformance-rpid = ["fido-conformance"]

--- a/crates/rsk-fido/src/ec.rs
+++ b/crates/rsk-fido/src/ec.rs
@@ -7,6 +7,8 @@
 //! supports it (P-256 / P-384 / secp256k1) and random for P-521 (`p521` 0.13
 //! has no deterministic signer). ECDSA signatures are DER-encoded.
 
+use alloc::boxed::Box;
+
 use minicbor::Encoder;
 use minicbor::encode::{Error as CborError, Write};
 use p256::FieldBytes;
@@ -123,10 +125,6 @@ impl P256Key {
 
 /// A multi-scheme CTAP2 credential signing key, selected by the credential's
 /// stored `curve`.
-// The ML-DSA variant dominates the size (~17 KB vs ≤224 B): boxing is not an
-// option (no alloc in this crate) and the value lives in exactly one frame for
-// one request on the worker stack, which budgets for it.
-#[allow(clippy::large_enum_variant)]
 pub enum CredKey {
     P256(p256::ecdsa::SigningKey),
     P384(p384::ecdsa::SigningKey),
@@ -136,9 +134,16 @@ pub enum CredKey {
     P521(p521::NonZeroScalar),
     K256(k256::ecdsa::SigningKey),
     Ed25519(ed25519_dalek::SigningKey),
-    // ~17 KB expanded keypair; boxed nowhere — the enum lives briefly on the
-    // worker stack during one request. fips204 zeroizes it on drop.
-    MlDsa44(rsk_crypto::MlDsa44),
+    // ~17 KB of fips204 NTT-form keys — HEAP-BOXED, not inline. ML-DSA-44
+    // signing (`getAssertion`) drives fips204's rejection-sampling loop, whose
+    // stack high-water (~well over 100 KiB on thumbv8m) nearly fills the
+    // RP2350's ~222 KiB worker stack on its own. Holding the key inline put
+    // those 17 KB on the same frame, right below that call, and tipped it into
+    // overflow → a hard wedge (panic-halt, FIDO dark until replug). Boxing moves
+    // the key to the firmware heap — idle during a FIDO request, since applet
+    // keys are reconstructed per-op — freeing that headroom. fips204 zeroizes
+    // the keys on drop; the `Box` adds no `Drop` of its own.
+    MlDsa44(Box<rsk_crypto::MlDsa44>),
 }
 
 // The SigningKey variants zeroize themselves on drop; the bare P-521 scalar
@@ -202,9 +207,11 @@ impl CredKey {
                 // The ratchet's first 32 bytes are the FIPS 204 keygen seed ξ;
                 // expansion is deterministic, so the same credential id always
                 // rebuilds the same lattice keypair (as the EC schemes do).
+                // Boxed onto the heap so the ~17 KB keypair is off the worker
+                // stack before the stack-heavy `sign` runs (see the variant doc).
                 let mut xi = [0u8; 32];
                 xi.copy_from_slice(raw.get(..32)?);
-                let key = rsk_crypto::MlDsa44::from_seed(&xi);
+                let key = Box::new(rsk_crypto::MlDsa44::from_seed(&xi));
                 xi.zeroize();
                 Some(Self::MlDsa44(key))
             }
@@ -624,5 +631,23 @@ mod tests {
         let (px, py) = P256Key::from_scalar(&scalar).unwrap().public_xy();
         assert_eq!(x, px);
         assert_eq!(y, py);
+    }
+
+    #[test]
+    fn credkey_stays_compact_so_mldsa_key_is_off_the_stack() {
+        // The ML-DSA-44 keypair is ~17 KB of fips204 NTT-form keys. Held inline in
+        // `CredKey` it rode the worker stack into `sign`, whose fips204
+        // rejection-sampling loop already nearly fills the RP2350's ~222 KiB
+        // stack — the 17 KB tipped getAssertion into overflow → a hard device
+        // wedge. It MUST stay `Box`-ed (heap, idle during a FIDO request). This
+        // guard fails loudly if the key regresses back inline: the boxed enum is a
+        // few hundred bytes (largest inline variant is Ed25519's expanded
+        // `SigningKey`), an inline keypair would be ~16.6 KB.
+        let size = core::mem::size_of::<CredKey>();
+        assert!(
+            size <= 512,
+            "CredKey is {size} bytes — is the ML-DSA-44 keypair still Box-ed? \
+             An inline fips204 keypair (~16.6 KB) overflows the worker stack in sign()."
+        );
     }
 }

--- a/crates/rsk-fido/src/getinfo.rs
+++ b/crates/rsk-fido/src/getinfo.rs
@@ -7,14 +7,22 @@
 //! 2026-06-02) hard-fail the whole getInfo parse on an unknown COSE id, while
 //! makeCredential still negotiates -48 from the request's `pubKeyCredParams`;
 //! the `advertise-pqc` feature opts back into the advertisement.
+//!
+//! EdDSA (-8), by contrast, IS advertised by default: the Windows WebAuthn API
+//! (the path OpenSSH `ssh-keygen -t ed25519-sk` takes) intersects a request's
+//! `pubKeyCredParams` with the advertised set and silently drops -8 when it is
+//! unadvertised, so credential creation fails on Windows (it works on
+//! macOS/Linux libfido2, which sends -8 directly). The `fido-conformance` feature
+//! suppresses it for the FIDO conformance run (its verifySignatureCOSE can only
+//! verify -7/-35/-36 self-attestations).
 
 use minicbor::Encoder;
 use minicbor::encode::{Error, Write};
 
 use crate::consts::{
-    AAGUID, ALG_ES256, ALG_ES384, ALG_ES512, ALG_MLDSA44, FIRMWARE_VERSION, MAX_CRED_ID_LENGTH,
-    MAX_CREDBLOB_LENGTH, MAX_CREDENTIAL_COUNT_IN_LIST, MAX_LARGE_BLOB_SIZE, MAX_MIN_PIN_RPIDS,
-    MAX_MSG_SIZE,
+    AAGUID, ALG_EDDSA, ALG_ES256, ALG_ES384, ALG_ES512, ALG_MLDSA44, FIRMWARE_VERSION,
+    MAX_CRED_ID_LENGTH, MAX_CREDBLOB_LENGTH, MAX_CREDENTIAL_COUNT_IN_LIST, MAX_LARGE_BLOB_SIZE,
+    MAX_MIN_PIN_RPIDS, MAX_MSG_SIZE,
 };
 use crate::cose::cose_public_key;
 use crate::error::{CtapError, CtapResult};
@@ -139,25 +147,39 @@ fn write_info<W: Write>(
     // HID, so the FIDO transport list is just "usb".)
     enc.u8(0x09)?.array(1)?.str("usb")?;
 
-    // 0x0A algorithms — ES256 (-7), ES384 (-35), ES512 (-36); `advertise-pqc`
-    // prepends ML-DSA-44 (off by default: shipped Firefoxes reject the whole
-    // getInfo on an unknown COSE id). EdDSA (-8) and ES256K (-47) are implemented
-    // but deliberately NOT advertised: the FIDO conformance tool's shared
-    // verifySignatureCOSE maps only -7/-35/-36 for elliptic curves (no -8, no -47),
-    // so it throws "hashFunction missing" trying to verify a packed self-attestation
-    // over an EdDSA or secp256k1 credential (MakeCred-Resp P-06). makeCredential
-    // still negotiates -8/-47 from a request's pubKeyCredParams — only the
-    // advertisement is suppressed (like ML-DSA-44). Keep this set in sync with the
-    // metadata (`authenticationAlgorithms` + `authenticatorGetInfo.algorithms`) —
-    // `tests/62` enforces it.
+    // 0x0A algorithms — ES256 (-7), ES384 (-35), ES512 (-36), then EdDSA (-8).
+    // `advertise-pqc` prepends ML-DSA-44 (off by default: shipped Firefoxes reject
+    // the whole getInfo on an unknown COSE id).
+    //
+    // EdDSA (-8) is advertised by DEFAULT. Platforms that intersect a credential
+    // request's `pubKeyCredParams` with the advertised set — notably the Windows
+    // WebAuthn API (`webauthn.dll`), the path OpenSSH `ssh-keygen -t ed25519-sk`
+    // takes — silently drop -8 when it is unadvertised, so the create fails
+    // (macOS/Linux libfido2 sends -8 directly, so it works there). The
+    // `fido-conformance` feature suppresses it: the FIDO conformance tool's shared
+    // verifySignatureCOSE maps only -7/-35/-36 for elliptic curves, so it throws
+    // "hashFunction missing" verifying a packed EdDSA self-attestation
+    // (MakeCred-Resp P-06).
+    //
+    // ES256K (-47) stays unadvertised in EVERY profile for the same P-06 reason.
+    // Both -8 and -47 remain fully implemented — makeCredential negotiates them
+    // from a request regardless of advertisement (like ML-DSA-44). Keep the
+    // advertised set in sync with the metadata (`authenticationAlgorithms` +
+    // `authenticatorGetInfo.algorithms`); `tests/62` enforces it, and
+    // `metadata/rs-key.conformance.metadata.json` is the EdDSA-free variant for
+    // the `fido-conformance` build.
     let pqc = cfg!(feature = "advertise-pqc");
-    enc.u8(0x0A)?.array(3 + u64::from(pqc))?;
+    let eddsa = cfg!(not(feature = "fido-conformance"));
+    enc.u8(0x0A)?.array(3 + u64::from(pqc) + u64::from(eddsa))?;
     if pqc {
         cose_public_key(enc, ALG_MLDSA44)?;
     }
     cose_public_key(enc, ALG_ES256)?;
     cose_public_key(enc, ALG_ES384)?;
     cose_public_key(enc, ALG_ES512)?;
+    if eddsa {
+        cose_public_key(enc, ALG_EDDSA)?;
+    }
 
     // 0x0B maxSerializedLargeBlobArray
     enc.u8(0x0B)?.u64(MAX_LARGE_BLOB_SIZE as u64)?;
@@ -207,18 +229,11 @@ fn write_info<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::consts::{ALG_EDDSA, ALG_ES256K};
+    use crate::consts::ALG_ES256K;
     use minicbor::Decoder;
 
-    /// Conformance regression guard (MakeCred-Resp P-06): the advertised
-    /// `algorithms` (0x0A) must NEVER include EdDSA (-8) or ES256K (-47). The FIDO
-    /// conformance tool's shared `verifySignatureCOSE` maps only -7/-35/-36 for
-    /// elliptic curves and throws "hashFunction missing" on a self-attestation over
-    /// any other curve. Both stay fully implemented (makeCredential negotiates them
-    /// from a request) — only the advertisement is suppressed, so the advertised EC
-    /// set is exactly the tool-verifiable NIST curves.
-    #[test]
-    fn algorithms_never_advertise_eddsa_or_es256k() {
+    /// Decode the advertised `algorithms` (0x0A) COSE ids from a getInfo response.
+    fn advertised_algs() -> std::vec::Vec<i64> {
         let mut out = [0u8; 1024];
         let n = get_info(false, 6, false, false, false, 256, &mut out).unwrap();
         let mut d = Decoder::new(&out[..n]);
@@ -239,16 +254,42 @@ mod tests {
                 d.skip().unwrap();
             }
         }
-        assert!(
-            !algs.contains(&ALG_EDDSA),
-            "EdDSA (-8) must not be advertised"
-        );
+        algs
+    }
+
+    /// Algorithm-advertisement policy (0x0A).
+    ///
+    /// EdDSA (-8) is advertised by DEFAULT — the Windows WebAuthn API filters a
+    /// request's `pubKeyCredParams` by the advertised set, so an unadvertised -8
+    /// breaks `ssh-keygen -t ed25519-sk`. The `fido-conformance` feature suppresses
+    /// it (the conformance tool's shared `verifySignatureCOSE` cannot verify an
+    /// EdDSA self-attestation — MakeCred-Resp P-06). ES256K (-47) is never
+    /// advertised (same P-06 limitation). Both stay implemented: makeCredential
+    /// still negotiates them from a request's `pubKeyCredParams`.
+    #[test]
+    fn algorithms_advertisement_policy() {
+        let algs = advertised_algs();
+        // The NIST ECDSA curves are always advertised.
+        assert!(algs.contains(&ALG_ES256));
+        assert!(algs.contains(&ALG_ES384));
+        assert!(algs.contains(&ALG_ES512));
+        // ES256K is never advertised (FIDO conformance MakeCred-Resp P-06).
         assert!(
             !algs.contains(&ALG_ES256K),
             "ES256K (-47) must not be advertised"
         );
-        // The `ends_with` tolerates an advertise-pqc ML-DSA-44 prefix.
-        assert!(algs.ends_with(&[ALG_ES256, ALG_ES384, ALG_ES512]));
+        // EdDSA is advertised by default, suppressed only under `fido-conformance`.
+        if cfg!(feature = "fido-conformance") {
+            assert!(
+                !algs.contains(&ALG_EDDSA),
+                "EdDSA (-8) must not be advertised in the conformance profile"
+            );
+        } else {
+            assert!(
+                algs.contains(&ALG_EDDSA),
+                "EdDSA (-8) must be advertised by default (Windows WebAuthn / ed25519-sk)"
+            );
+        }
     }
 
     #[test]
@@ -335,17 +376,25 @@ mod tests {
         assert_eq!(d.array().unwrap().unwrap(), 1);
         assert_eq!(d.str().unwrap(), "usb");
 
-        // 0x0A algorithms: [{alg, type:"public-key"} …] — classic ids; the
-        // `advertise-pqc` feature prepends ML-DSA-44 (default stays without it:
-        // Firefox authenticator-rs strict parse).
+        // 0x0A algorithms: [{alg, type:"public-key"} …] — the NIST ECDSA curves,
+        // then EdDSA (-8) unless `fido-conformance` suppresses it; `advertise-pqc`
+        // prepends ML-DSA-44 (default stays without it: Firefox authenticator-rs
+        // strict parse).
         assert_eq!(d.u8().unwrap(), 0x0A);
         let pqc = cfg!(feature = "advertise-pqc");
-        assert_eq!(d.array().unwrap().unwrap(), 3 + u64::from(pqc));
+        let eddsa = cfg!(not(feature = "fido-conformance"));
+        assert_eq!(
+            d.array().unwrap().unwrap(),
+            3 + u64::from(pqc) + u64::from(eddsa)
+        );
         let mut algs = vec![];
         if pqc {
             algs.push(ALG_MLDSA44);
         }
         algs.extend([ALG_ES256, ALG_ES384, ALG_ES512]);
+        if eddsa {
+            algs.push(ALG_EDDSA);
+        }
         for alg in algs {
             assert_eq!(d.map().unwrap().unwrap(), 2);
             assert_eq!(d.str().unwrap(), "alg");

--- a/crates/rsk-fido/src/lib.rs
+++ b/crates/rsk-fido/src/lib.rs
@@ -7,6 +7,12 @@
 //! host-testable: the device seed, serial, RNG and flash come from the caller
 //! ([`Ctx`]), never from globals; `firmware` wires in the RP2350 TRNG and flash.
 
+// Only the ML-DSA-44 credential key is heap-boxed (its ~17 KB of fips204 NTT-form
+// keys would otherwise sit on the worker stack right below the stack-heavy sign;
+// see `ec::CredKey`). The firmware provides the heap; everything else stays
+// no-alloc.
+extern crate alloc;
+
 pub mod cbordec;
 pub mod cert;
 pub mod clientpin;

--- a/crates/rsk-fs/src/fs.rs
+++ b/crates/rsk-fs/src/fs.rs
@@ -50,15 +50,27 @@ pub struct Fs<S: Storage> {
     storage: S,
     table: &'static [FileDesc],
     dynamic: Vec<u16, MAX_DYNAMIC_FILES>,
-    /// Fast-negative cache: bit `fid` is set iff the backend currently stores a
-    /// value for `fid`. Lets `read`/`size` answer "absent" without touching the
-    /// backend — a backend `read` of an absent key scans the whole flash
-    /// partition, so probing a sparse object range (e.g. the ~25 mostly-empty
-    /// PIV certificate slots Yubico Authenticator reads) was O(slots · flash).
-    /// Mirrors the backend exactly: set on every write, cleared on every
-    /// remove, rebuilt from `for_each_key` in [`Fs::scan`]. A fixed bitmap (not
-    /// the bounded `dynamic` Vec) so it can never overflow into a false absent.
+    /// Negative cache (paired with [`decided`](Self#structfield.decided)): bit
+    /// `fid` set iff the backend is KNOWN to hold a value for `fid`. Lets
+    /// `read`/`size` answer "absent" without touching the backend — a backend
+    /// `read` of an absent key scans the whole flash partition, so probing a
+    /// sparse object range (e.g. the ~25 mostly-empty PIV certificate slots
+    /// Yubico Authenticator reads) was O(slots · flash). Set on every write,
+    /// cleared on every remove; `scan` seeds it from `for_each_key`.
+    ///
+    /// A bare clear bit is NOT trusted as "absent": the bulk `for_each_key` can
+    /// silently under-count a key after a torn power-cut migration (the reliable
+    /// per-key `fetch_item` still recovers it), which would turn a clear bit into
+    /// a false-absent — committed data read back as gone. `decided` gates that.
     present: [u8; FID_PRESENT_BYTES],
+    /// Authority bit for [`present`](Self#structfield.present): set iff `fid`'s
+    /// present/absent state is confirmed. `scan` marks only the keys the bulk
+    /// pass actually enumerated; every other FID stays *unknown* until a backend
+    /// probe decides it — never a possibly-wrong fast "absent". `fetch_item` is
+    /// the source of truth and the cache only memoises it, so a false-absent is
+    /// impossible. Cost: the first probe of each absent FID per boot pays one
+    /// backend scan, then it is O(1). See [`known_absent`](Self::known_absent).
+    decided: [u8; FID_PRESENT_BYTES],
     /// Set after user authentication; gates PIN-protected ACL entries.
     pub user_authenticated: bool,
 }
@@ -70,6 +82,7 @@ impl<S: Storage> Fs<S> {
             table,
             dynamic: Vec::new(),
             present: [0u8; FID_PRESENT_BYTES],
+            decided: [0u8; FID_PRESENT_BYTES],
             user_authenticated: false,
         }
     }
@@ -80,22 +93,53 @@ impl<S: Storage> Fs<S> {
         self.storage
     }
 
-    /// Does the present-cache say `fid` has a stored value? Only authoritative
-    /// after [`Fs::scan`] (or when every write went through this `Fs` from an
-    /// empty backend), which is the contract — same as the `dynamic` set.
+    /// Raw present bit (does NOT consult `decided`). Authoritative only for a
+    /// FID known present; for the trustworthy absent test use
+    /// [`known_absent`](Self::known_absent).
     #[inline]
     fn present_bit(&self, fid: u16) -> bool {
         self.present[(fid >> 3) as usize] & (1u8 << (fid & 7)) != 0
     }
 
+    /// Is `fid`'s present/absent state confirmed (vs. unknown-until-probed)?
     #[inline]
-    fn mark_present(&mut self, fid: u16) {
-        self.present[(fid >> 3) as usize] |= 1u8 << (fid & 7);
+    fn decided_bit(&self, fid: u16) -> bool {
+        self.decided[(fid >> 3) as usize] & (1u8 << (fid & 7)) != 0
     }
 
+    /// Trustworthy fast-negative test: true only when `fid` is *confirmed*
+    /// absent. An unknown FID returns false so the caller falls through to the
+    /// reliable backend (and then caches the result) — this is what prevents a
+    /// post-power-cut false-absent. Confirmed-absent stays O(1).
+    #[inline]
+    fn known_absent(&self, fid: u16) -> bool {
+        self.decided_bit(fid) && !self.present_bit(fid)
+    }
+
+    /// Cache the backend's authoritative answer for `fid`.
+    #[inline]
+    fn record(&mut self, fid: u16, present: bool) {
+        if present {
+            self.mark_present(fid);
+        } else {
+            self.mark_absent(fid);
+        }
+    }
+
+    /// Mark `fid` known present (sets the authority bit too).
+    #[inline]
+    fn mark_present(&mut self, fid: u16) {
+        let (i, m) = ((fid >> 3) as usize, 1u8 << (fid & 7));
+        self.present[i] |= m;
+        self.decided[i] |= m;
+    }
+
+    /// Mark `fid` known absent (sets the authority bit, clears present).
     #[inline]
     fn mark_absent(&mut self, fid: u16) {
-        self.present[(fid >> 3) as usize] &= !(1u8 << (fid & 7));
+        let (i, m) = ((fid >> 3) as usize, 1u8 << (fid & 7));
+        self.present[i] &= !m;
+        self.decided[i] |= m;
     }
 
     /// Rebuild the dynamic-file set from what's already in storage (run once
@@ -106,11 +150,18 @@ impl<S: Storage> Fs<S> {
         // while `self.storage` drives the pass.
         let dynamic = &mut self.dynamic;
         let present = &mut self.present;
+        let decided = &mut self.decided;
         dynamic.clear();
         present.fill(0);
+        decided.fill(0);
         self.storage.for_each_key(&mut |fid| {
-            // Every stored key — static, dynamic, or EF_META — feeds the cache.
-            present[(fid >> 3) as usize] |= 1u8 << (fid & 7);
+            // Every enumerated key — static, dynamic, or EF_META — is confirmed
+            // present. Keys the bulk pass does NOT yield stay *undecided* (not
+            // fast-absent), so a torn-migration under-count can't turn one into a
+            // false-absent; it is confirmed against the backend on first access.
+            let (i, m) = ((fid >> 3) as usize, 1u8 << (fid & 7));
+            present[i] |= m;
+            decided[i] |= m;
             if fid == EF_META {
                 return;
             }
@@ -144,26 +195,34 @@ impl<S: Storage> Fs<S> {
 
     /// Copy file contents into `buf`; returns the value's full length, or `None`.
     pub fn read(&mut self, fid: u16, buf: &mut [u8]) -> Option<usize> {
-        if !self.present_bit(fid) {
-            return None; // absent — skip the backend's full-partition scan
+        if self.known_absent(fid) {
+            return None; // confirmed absent — skip the backend's full scan
         }
-        self.storage.read(fid, buf)
+        // Present or unknown: the backend (reliable per-key `fetch_item`) is the
+        // source of truth; cache what it says so the next probe is O(1).
+        let r = self.storage.read(fid, buf);
+        self.record(fid, r.is_some());
+        r
     }
 
     /// Length of the file's contents, or `None` if absent.
     pub fn size(&mut self, fid: u16) -> Option<usize> {
-        if !self.present_bit(fid) {
+        if self.known_absent(fid) {
             return None;
         }
-        self.storage.size(fid)
+        let r = self.storage.size(fid);
+        self.record(fid, r.is_some());
+        r
     }
 
     /// Whether the file exists with non-empty contents.
     pub fn has_data(&mut self, fid: u16) -> bool {
-        if !self.present_bit(fid) {
-            return false; // absent — skip the backend's full-partition scan
+        if self.known_absent(fid) {
+            return false; // confirmed absent — skip the backend's full scan
         }
-        self.storage.size(fid).is_some_and(|n| n > 0)
+        let r = self.storage.size(fid);
+        self.record(fid, r.is_some());
+        r.is_some_and(|n| n > 0)
     }
 
     /// Invoke `f` once per live key in the backend, in a single storage pass.
@@ -194,18 +253,33 @@ impl<S: Storage> Fs<S> {
 
     /// Delete a file: drop its contents, metadata, and any dynamic entry.
     ///
-    /// An absent FID skips the backend `remove` (a full-partition scan, and a
-    /// tombstone write) and the meta read — the present-cache answers in O(1),
-    /// matching [`read`](Self::read) / [`has_data`](Self::has_data). Without
-    /// this guard a blind delete sweep over many absent slots is
-    /// O(slots·partition): the FIDO `authenticatorReset` audit-ring scrub
-    /// (128 slots) measured ~12 s on hardware, overrunning host reset timeouts
-    /// (the FIDO conformance tool gives a reset 10 s) and wedging the suite. The
-    /// dynamic-set cleanup still runs unconditionally so a `new_file` that was
-    /// never `put` is dropped.
+    /// The backend `remove` (a full-partition scan plus a tombstone write) is
+    /// skipped for an absent FID — the present-cache answers in O(1), matching
+    /// [`read`](Self::read) / [`has_data`](Self::has_data). Without that guard a
+    /// blind delete sweep over many absent slots is O(slots·partition): the FIDO
+    /// `authenticatorReset` audit-ring scrub (128 slots) measured ~12 s on
+    /// hardware, overrunning host reset timeouts (the FIDO conformance tool gives
+    /// a reset 10 s) and wedging the suite.
+    ///
+    /// The metadata drop and the dynamic-set cleanup, by contrast, run
+    /// unconditionally: a file can carry metadata (a [`meta_add`](Self::meta_add)
+    /// with no `put`) or a dynamic entry (a [`new_file`](Self::new_file) never
+    /// written) without its contents ever being present, so gating either on the
+    /// file's present bit would orphan it — a deleted file's metadata would read
+    /// back alive. Both stay O(1) when there is nothing to drop: `meta_delete`
+    /// has its own EF_META present-cache guard and skips the rewrite when `fid`
+    /// had no record.
+    ///
+    /// Unlike the read paths, the backend `remove` keys off the *raw* present bit
+    /// rather than `known_absent`: an UNKNOWN FID is skipped, not confirmed. This
+    /// deliberately keeps the cold-boot reset sweep O(1) (confirming 128 unknown
+    /// audit slots would re-introduce the multi-second scan). The cost is only
+    /// that a delete of a (rare) torn-migration false-absent FID no-ops its own
+    /// removal — the file lingers rather than data being lost, and the next read
+    /// of it confirms-and-caches it present, after which delete works normally.
     pub fn delete(&mut self, fid: u16) -> Result<()> {
+        let _ = self.meta_delete(fid);
         if self.present_bit(fid) {
-            let _ = self.meta_delete(fid);
             self.storage.remove(fid)?;
             self.mark_absent(fid);
         }
@@ -263,11 +337,13 @@ impl<S: Storage> Fs<S> {
 
     /// Copy the metadata for `fid` into `out`; returns its full length.
     pub fn meta_find(&mut self, fid: u16, out: &mut [u8]) -> Option<usize> {
-        if !self.present_bit(EF_META) {
+        if self.known_absent(EF_META) {
             return None;
         }
         let mut scratch = [0u8; META_MAX];
-        let n = self.storage.read(EF_META, &mut scratch)?.min(scratch.len());
+        let read = self.storage.read(EF_META, &mut scratch);
+        self.record(EF_META, read.is_some());
+        let n = read?.min(scratch.len());
         let blob = &scratch[..n];
         let mut i = 0;
         while i + 4 <= blob.len() {
@@ -291,13 +367,17 @@ impl<S: Storage> Fs<S> {
     /// Insert or replace the metadata for `fid`.
     pub fn meta_add(&mut self, fid: u16, data: &[u8]) -> Result<()> {
         let mut scratch = [0u8; META_MAX];
-        let n = if self.present_bit(EF_META) {
+        // Read the existing blob unless EF_META is *confirmed* absent. Treating
+        // an UNKNOWN EF_META as empty is the power-cut bug: a torn-migration
+        // false-absent would drop every existing record on this rewrite. The
+        // reliable backend read recovers the real blob.
+        let n = if self.known_absent(EF_META) {
+            0
+        } else {
             self.storage
                 .read(EF_META, &mut scratch)
                 .unwrap_or(0)
                 .min(scratch.len())
-        } else {
-            0
         };
         let mut out = [0u8; META_MAX];
         let w = rebuild_meta(&scratch[..n], fid, Some(data), &mut out)?;
@@ -308,17 +388,26 @@ impl<S: Storage> Fs<S> {
 
     /// Remove the metadata for `fid` (clears EF_META once empty).
     pub fn meta_delete(&mut self, fid: u16) -> Result<()> {
-        if !self.present_bit(EF_META) {
-            return Ok(()); // no meta blob → nothing to drop, no backend scan
+        if self.known_absent(EF_META) {
+            return Ok(()); // confirmed no meta blob → nothing to drop
         }
         let mut scratch = [0u8; META_MAX];
         let n = match self.storage.read(EF_META, &mut scratch) {
             Some(n) => n.min(scratch.len()),
-            None => return Ok(()),
+            None => {
+                self.mark_absent(EF_META);
+                return Ok(());
+            }
         };
+        self.mark_present(EF_META);
         let mut out = [0u8; META_MAX];
         let w = rebuild_meta(&scratch[..n], fid, None, &mut out)?;
-        if w == 0 {
+        if w == n {
+            // `fid` had no record (removing one always shrinks the blob), so the
+            // rebuild is byte-identical — skip the redundant EF_META rewrite.
+            // Keeps a delete sweep over meta-less absent slots write-free.
+            Ok(())
+        } else if w == 0 {
             self.storage.remove(EF_META)?;
             self.mark_absent(EF_META);
             Ok(())
@@ -441,6 +530,7 @@ mod tests {
         read_calls: u32,
         size_calls: u32,
         remove_calls: u32,
+        write_calls: u32,
     }
     impl CountingStorage {
         fn new() -> Self {
@@ -449,6 +539,7 @@ mod tests {
                 read_calls: 0,
                 size_calls: 0,
                 remove_calls: 0,
+                write_calls: 0,
             }
         }
     }
@@ -458,6 +549,7 @@ mod tests {
             self.inner.read(fid, buf)
         }
         fn write(&mut self, fid: u16, data: &[u8]) -> Result<()> {
+            self.write_calls += 1;
             self.inner.write(fid, data)
         }
         fn remove(&mut self, fid: u16) -> Result<()> {
@@ -554,24 +646,59 @@ mod tests {
     }
 
     #[test]
-    fn absent_probes_never_touch_the_backend() {
-        // On device a backend read/size of an absent FID scans the whole flash
-        // partition (~160 ms via sequential-storage `fetch_item`). The present
-        // cache MUST answer every absent probe — `read`, `size`, AND `has_data`
-        // — without the backend. PIV GET METADATA probes ~24 empty key slots, so
-        // a missing guard on `has_data` alone cost ~4 s per `ykman piv info` (the
-        // Yubico Authenticator PIV-tab lag).
+    fn absent_probe_confirms_once_then_caches() {
+        // Tri-state cache: the FIRST probe of an UNKNOWN FID confirms via the
+        // backend (one ~160 ms flash scan on device), then memoises the result so
+        // every later probe — `read`, `size`, `has_data` — is O(1) and never
+        // touches the backend again. Confirming (rather than trusting a bulk-scan
+        // clear bit) is what prevents a post-power-cut false-absent; the PIV-tab
+        // lag returns only as a one-time-per-boot first probe, then stays fast.
         let mut fs = Fs::new(CountingStorage::new(), TABLE);
         let mut buf = [0u8; 8];
+        assert_eq!(fs.read(0xD205, &mut buf), None); // unknown → one confirming read
+        // Now decided-absent — answered from the cache, no backend.
         assert_eq!(fs.read(0xD205, &mut buf), None);
         assert_eq!(fs.size(0xD205), None);
         assert!(!fs.has_data(0xD205));
         let st = fs.into_storage();
-        assert_eq!(st.read_calls, 0, "absent read must not probe the backend");
+        assert_eq!(st.read_calls, 1, "exactly one confirming read, then cached");
         assert_eq!(
             st.size_calls, 0,
-            "absent size/has_data must not probe the backend"
+            "size/has_data answered from the cache after the first read decided it"
         );
+    }
+
+    #[test]
+    fn confirm_on_miss_recovers_unscanned_key() {
+        // A torn-migration false-absent: the backend holds a key the present-cache
+        // never learned (the bulk `scan` under-counted it). `read` MUST confirm
+        // against the reliable backend, not fast-return None — otherwise committed
+        // data reads back lost. Modelled by writing straight to the backend and
+        // building an Fs that never scanned it.
+        let mut backend = RamStorage::new();
+        backend.write(0xCF09, b"resident-cred").unwrap();
+        let mut fs = Fs::new(backend, TABLE);
+        let mut buf = [0u8; 32];
+        assert_eq!(fs.read(0xCF09, &mut buf), Some(13)); // recovered, not false-absent
+        assert_eq!(&buf[..13], b"resident-cred");
+        // A genuinely absent sibling is confirmed absent and then cached.
+        assert_eq!(fs.read(0xCF0A, &mut buf), None);
+    }
+
+    #[test]
+    fn meta_add_keeps_records_when_ef_meta_unknown() {
+        // Bug B at unit scope: EF_META present in the backend but UNKNOWN to the
+        // cache (the torn-migration false-absent). A `meta_add` must read the real
+        // blob and KEEP existing records — the bug was treating an unknown EF_META
+        // as empty and wiping every record on the rewrite.
+        let mut fs = fs();
+        fs.meta_add(0xB000, b"keep-me").unwrap();
+        let backend = fs.into_storage(); // backend now holds EF_META = {B000}
+        // Rebuild without scan() → EF_META is unknown (decided clear).
+        let mut fs2 = Fs::new(backend, TABLE);
+        fs2.meta_add(0xB004, b"new").unwrap();
+        assert_eq!(fs2.meta_find(0xB000, &mut [0u8; 16]), Some(7)); // survived
+        assert_eq!(fs2.meta_find(0xB004, &mut [0u8; 16]), Some(3));
     }
 
     #[test]
@@ -693,6 +820,42 @@ mod tests {
         fs.meta_add(0xCF06, b"m").unwrap();
         fs.delete(0xCF06).unwrap();
         assert_eq!(fs.meta_find(0xCF06, &mut [0u8; 8]), None);
+    }
+
+    #[test]
+    fn delete_drops_meta_even_without_file_data() {
+        // Regression (power_cut / fs_ops fuzz): metadata can be attached to a FID
+        // that was never `put`. `delete` must still drop that metadata; gating the
+        // meta cleanup on the file's own present bit orphaned the record, so a
+        // deleted file's metadata read back alive (after a reboot the stale
+        // EF_META record reappeared, diverging from the model).
+        let mut fs = fs();
+        let fid = 0xB001; // metadata only — the file contents are never present
+        fs.meta_add(fid, b"orphan").unwrap();
+        assert_eq!(fs.meta_find(fid, &mut [0u8; 8]), Some(6));
+        assert!(!fs.has_data(fid));
+        fs.delete(fid).unwrap();
+        assert_eq!(fs.meta_find(fid, &mut [0u8; 8]), None);
+        // That was the only record, so EF_META is gone entirely now.
+        assert_eq!(fs.size(crate::EF_META), None);
+    }
+
+    #[test]
+    fn meta_delete_of_absent_record_does_not_rewrite() {
+        // Deleting a meta-less FID while EF_META holds other records must not
+        // rewrite EF_META: a FIDO-reset sweep deletes many absent slots, and a
+        // redundant rewrite each time is flash churn plus a needless torn-write
+        // window. The sibling record must survive untouched.
+        let mut fs = Fs::new(CountingStorage::new(), TABLE);
+        fs.meta_add(0xCF00, b"keep").unwrap(); // exactly one EF_META write
+        fs.delete(0xB001).unwrap(); // neither data nor a meta record
+        assert_eq!(fs.meta_find(0xCF00, &mut [0u8; 8]), Some(4)); // sibling intact
+        let st = fs.into_storage();
+        assert_eq!(
+            st.write_calls, 1,
+            "deleting a meta-less FID must not rewrite EF_META (only the setup write)"
+        );
+        assert_eq!(st.remove_calls, 0, "absent delete must not hit the backend");
     }
 
     #[test]

--- a/docs/guides/ssh.md
+++ b/docs/guides/ssh.md
@@ -25,6 +25,13 @@ both key types it can use:
 - **Linux:** OpenSSH links `libfido2` almost everywhere; you only need the FIDO
   udev rules — see [linux.md](../linux.md). FIDO is local to wherever `ssh`
   runs, so logging in *to* a remote box needs nothing special there.
+- **Windows:** OpenSSH for Windows routes `-sk` keys through the Windows WebAuthn
+  API (`webauthn.dll`), which only offers algorithms the device *advertises* in
+  its FIDO `getInfo`. `ed25519-sk` therefore needs firmware that advertises EdDSA
+  — RS-Key `bcdDevice 0x077D` or newer (see `rsk status`). On older firmware
+  `ed25519-sk` fails at create with a generic error while `ecdsa-sk` still works,
+  so either reflash or use `ecdsa-sk`. macOS and Linux talk to `libfido2`
+  directly and send the algorithm regardless, so they are unaffected.
 
 ## Enroll
 

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -80,9 +80,15 @@ fips-profile = ["rsk-fido/fips-profile", "rsk-piv/fips-profile"]
 # Keygen microbenchmark vendor command (INS 0x13). Debug/measurement only —
 # never ship it: it exposes a timing oracle over the primality primitives.
 keygen-bench = []
+# FIDO Conformance Tool build profile (see rsk-fido's feature docs): suppresses
+# the EdDSA (-8) advertisement so the tool can verify every advertised algorithm.
+# The shipping build advertises -8 (Windows WebAuthn / `ed25519-sk`). Build
+# `--features fido-conformance` ONLY for the FIDO Conformance run; never ship.
+fido-conformance = ["rsk-fido/fido-conformance"]
 # Add the FIDO Conformance Tool's enterprise-attestation test RPID to the
-# vendor-facilitated (type 1) EA list (see rsk-fido's feature docs). Build
-# `--features ea-conformance-rpid` ONLY for FIDO Conformance EA testing; never ship.
+# vendor-facilitated (type 1) EA list (see rsk-fido's feature docs). Pulls in
+# `fido-conformance` transitively. Build `--features ea-conformance-rpid` ONLY for
+# FIDO Conformance EA testing; never ship.
 ea-conformance-rpid = ["rsk-fido/ea-conformance-rpid"]
 
 [[bin]]

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -292,7 +292,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x077C; // bcdDevice: our build counter
+    config.device_release = 0x077D; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -292,7 +292,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x077D; // bcdDevice: our build counter
+    config.device_release = 0x077E; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -292,7 +292,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x077B; // bcdDevice: our build counter
+    config.device_release = 0x077C; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -302,5 +302,12 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "kv_durability"
+path = "fuzz_targets/kv_durability.rs"
+test = false
+doc = false
+bench = false
+
 # Standalone workspace so the parent (thumbv8m) build never pulls these in.
 [workspace]

--- a/fuzz/fuzz_targets/kv_durability.rs
+++ b/fuzz/fuzz_targets/kv_durability.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+#![no_main]
+
+//! Storage-layer power-cut durability: does `sequential-storage` itself lose (or
+//! roll back) a COMMITTED value across a power-cut during page migration?
+//!
+//! Complements `power_cut` (which torments the whole rsk-fs stack) by driving ONE
+//! `MapStorage` partition DIRECTLY — no `rsk-fs`, no present-cache, no EF_META
+//! meta-blob logic — so a durability failure here pins the fault to the
+//! dependency (or our use of it), not the `Fs` layer. This isolation is what
+//! proved the present-cache false-absent bug (the `0x077B`→`0x077C` fix) lived in
+//! our cache, not the store: this target stays clean while `power_cut` reproduced
+//! it. Key index 0 is rewritten on most ops to mirror EF_META — the hottest key,
+//! rewritten whole on every `meta_add`, and so the one most exposed to a torn
+//! migration. The flash is sized small (8 pages) so reclaim/migration happens
+//! within a single exec.
+//!
+//! Contract asserted (same as the on-device promise): after any number of
+//! power-cuts + reboots, every key whose write/remove returned cleanly reads
+//! back EXACTLY; only the one operation interrupted by the cut may be ambiguous
+//! (its old value or its new value — never a third, older value).
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use embassy_futures::block_on;
+use embedded_storage_async::nor_flash::{ErrorType, MultiwriteNorFlash, NorFlash, ReadNorFlash};
+use libfuzzer_sys::fuzz_target;
+use sequential_storage::cache::KeyPointerCache;
+use sequential_storage::map::{MapConfig, MapStorage};
+use sequential_storage::mock_flash::{MockFlashBase, MockFlashError, Operation, WriteCountCheck};
+
+const WORD: usize = 4;
+const PAGE_WORDS: usize = 1024;
+type Mock = MockFlashBase<8, WORD, PAGE_WORDS>;
+const RANGE: core::ops::Range<u32> = 0..(8 * 4096);
+const KV_BUF: usize = 2048;
+type Cache = KeyPointerCache<8, u16, 16>;
+
+// Key 0 is the "hot" key (EF_META analog); the rest are cold occupants that make
+// migration copy real data.
+const KEYS: [u16; 5] = [0xE010, 0xB000, 0xB001, 0xB002, 0xB003];
+
+#[derive(Clone)]
+struct SharedMock {
+    flash: Rc<RefCell<Mock>>,
+    dead: Rc<Cell<bool>>,
+}
+
+impl ErrorType for SharedMock {
+    type Error = MockFlashError;
+}
+impl ReadNorFlash for SharedMock {
+    const READ_SIZE: usize = <Mock as ReadNorFlash>::READ_SIZE;
+    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        block_on(self.flash.borrow_mut().read(offset, bytes))
+    }
+    fn capacity(&self) -> usize {
+        self.flash.borrow().capacity()
+    }
+}
+impl NorFlash for SharedMock {
+    const WRITE_SIZE: usize = <Mock as NorFlash>::WRITE_SIZE;
+    const ERASE_SIZE: usize = <Mock as NorFlash>::ERASE_SIZE;
+    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        if self.dead.get() {
+            return Err(MockFlashError::EarlyShutoff(from, Operation::Erase));
+        }
+        let r = block_on(self.flash.borrow_mut().erase(from, to));
+        if matches!(r, Err(MockFlashError::EarlyShutoff(..))) {
+            self.dead.set(true);
+        }
+        r
+    }
+    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        if self.dead.get() {
+            return Err(MockFlashError::EarlyShutoff(offset, Operation::Write));
+        }
+        let r = block_on(self.flash.borrow_mut().write(offset, bytes));
+        if matches!(r, Err(MockFlashError::EarlyShutoff(..))) {
+            self.dead.set(true);
+        }
+        r
+    }
+}
+impl MultiwriteNorFlash for SharedMock {}
+
+type Store = MapStorage<u16, SharedMock, Cache>;
+
+fn read_key(store: &mut Store, buf: &mut [u8], k: u16) -> Option<Vec<u8>> {
+    let v = block_on(store.fetch_item::<&[u8]>(buf, &k)).ok()??;
+    Some(v.to_vec())
+}
+
+enum Pending {
+    Write(u16, Vec<u8>),
+    Remove(u16),
+}
+
+fn reboot_verify(
+    shared: &SharedMock,
+    committed: &mut HashMap<u16, Vec<u8>>,
+    mut pending: Option<Pending>,
+) {
+    loop {
+        shared.dead.set(false);
+        let mut store = Store::new(shared.clone(), MapConfig::new(RANGE), Cache::new());
+        let mut buf = [0u8; KV_BUF];
+
+        // Resolve the interrupted op from what the flash actually holds.
+        match &pending {
+            Some(Pending::Write(k, new)) => {
+                let got = read_key(&mut store, &mut buf, *k);
+                if shared.dead.get() {
+                    continue;
+                }
+                let old = committed.get(k).cloned();
+                assert!(
+                    got == old || got.as_ref() == Some(new),
+                    "torn write: neither old nor new (rollback past committed)"
+                );
+                match got {
+                    Some(v) => committed.insert(*k, v),
+                    None => committed.remove(k),
+                };
+            }
+            Some(Pending::Remove(k)) => {
+                let got = read_key(&mut store, &mut buf, *k);
+                if shared.dead.get() {
+                    continue;
+                }
+                let old = committed.get(k).cloned();
+                assert!(got == old || got.is_none(), "torn remove: garbage");
+                match got {
+                    Some(v) => committed.insert(*k, v),
+                    None => committed.remove(k),
+                };
+            }
+            None => {}
+        }
+        if shared.dead.get() {
+            continue;
+        }
+        pending = None;
+
+        // Durability sweep: every committed key reads back exactly.
+        let mut clean = true;
+        for (k, v) in committed.iter() {
+            let got = read_key(&mut store, &mut buf, *k);
+            if shared.dead.get() {
+                clean = false;
+                break;
+            }
+            assert_eq!(
+                got.as_deref(),
+                Some(v.as_slice()),
+                "committed value lost or rolled back after cut"
+            );
+        }
+        if clean {
+            return;
+        }
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    let flash = Rc::new(RefCell::new(Mock::new(
+        WriteCountCheck::Disabled,
+        None,
+        true,
+    )));
+    let dead = Rc::new(Cell::new(false));
+    let shared = SharedMock { flash, dead };
+    let mut store = Store::new(shared.clone(), MapConfig::new(RANGE), Cache::new());
+    let mut buf = [0u8; KV_BUF];
+
+    let mut committed: HashMap<u16, Vec<u8>> = HashMap::new();
+    let mut tag: u8 = 0;
+
+    let mut it = data.iter().copied();
+    while let Some(b) = it.next() {
+        // Bias key selection hard toward index 0 (the hot EF_META analog).
+        let ki = if b & 0x80 != 0 {
+            0
+        } else {
+            ((b >> 3) % 5) as usize
+        };
+        let key = KEYS[ki];
+        tag = tag.wrapping_add(0x35);
+
+        if b & 0x40 != 0
+            && !shared.dead.get()
+            && shared.flash.borrow().bytes_until_shutoff.is_none()
+        {
+            let hi = it.next().unwrap_or(0);
+            let lo = it.next().unwrap_or(64);
+            shared.flash.borrow_mut().bytes_until_shutoff =
+                Some(u32::from_be_bytes([0, 0, hi & 0x0F, lo]));
+        }
+
+        let mut pending = None;
+        match b & 3 {
+            0 | 1 => {
+                let len = (it.next().unwrap_or(0) as usize).min(96);
+                let v: Vec<u8> = (0..len).map(|j| (j as u8) ^ tag).collect();
+                let r = block_on(store.store_item::<&[u8]>(&mut buf, &key, &v.as_slice()));
+                if !shared.dead.get() {
+                    r.expect("clean store must succeed");
+                    committed.insert(key, v);
+                } else {
+                    pending = Some(Pending::Write(key, v));
+                }
+            }
+            2 => {
+                let r = block_on(store.remove_item(&mut buf, &key));
+                if !shared.dead.get() {
+                    r.expect("clean remove must succeed");
+                    committed.remove(&key);
+                } else {
+                    pending = Some(Pending::Remove(key));
+                }
+            }
+            _ => {
+                // Clean reboot — full re-mount and durability check.
+                reboot_verify(&shared, &mut committed, None);
+                store = Store::new(shared.clone(), MapConfig::new(RANGE), Cache::new());
+                continue;
+            }
+        }
+
+        if shared.dead.get() {
+            reboot_verify(&shared, &mut committed, pending);
+            store = Store::new(shared.clone(), MapConfig::new(RANGE), Cache::new());
+        }
+    }
+});

--- a/metadata/rs-key.conformance.metadata.json
+++ b/metadata/rs-key.conformance.metadata.json
@@ -13,8 +13,7 @@
   "authenticationAlgorithms": [
     "secp256r1_ecdsa_sha256_raw",
     "secp384r1_ecdsa_sha384_raw",
-    "secp521r1_ecdsa_sha512_raw",
-    "ed25519_eddsa_sha512_raw"
+    "secp521r1_ecdsa_sha512_raw"
   ],
   "publicKeyAlgAndEncodings": [
     "cose"
@@ -80,8 +79,7 @@
     "algorithms": [
       { "alg": -7, "type": "public-key" },
       { "alg": -35, "type": "public-key" },
-      { "alg": -36, "type": "public-key" },
-      { "alg": -8, "type": "public-key" }
+      { "alg": -36, "type": "public-key" }
     ],
     "maxSerializedLargeBlobArray": 2048,
     "forcePINChange": false,

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -37,6 +37,9 @@ run "fmt (fuzz)"               cargo fmt --manifest-path fuzz/Cargo.toml --check
 run "test (host)"              cargo test -p rsk-sdk -p rsk-fs -p rsk-usb -p rsk-crypto -p rsk-fido -p rsk-openpgp -p rsk-rsa-asm -p rsk-mgmt -p rsk-oath -p rsk-otp -p rsk-piv -p rsk-rescue --target "$HOST"
 # The PQC-advertisement opt-in changes the getInfo shape — test both forms.
 run "test (advertise-pqc)"     cargo test -p rsk-fido --features advertise-pqc --target "$HOST" getinfo
+# fido-conformance suppresses the default EdDSA (-8) advertisement — verify that
+# path too (the shipping/default build advertises -8; this drops it for the tool).
+run "test (fido-conformance)"  cargo test -p rsk-fido --features fido-conformance --target "$HOST" getinfo
 # The FIPS-style profile changes algorithm menus / PIN floor / export policy;
 # run its tests (name-filtered: the regular fixtures assume the 4-char PIN
 # floor) and type-check the locked firmware image.

--- a/tests/26_signing_curves.py
+++ b/tests/26_signing_curves.py
@@ -8,10 +8,15 @@
 
 For each of EdDSA (Ed25519), ES256K (secp256k1), ES384 (P-384) and ES512 (P-521),
 in roughly fastest-to-slowest order:
-  1. getInfo                  -> the algorithm is advertised in 0x0A
-  2. makeCredential(alg)      -> a credential with the matching COSE public key
-  3. getAssertion(credId)     -> sign authData ‖ clientDataHash
-  4. verify the signature under the credential public key (host `cryptography`)
+  1. makeCredential(alg)      -> a credential with the matching COSE public key
+  2. getAssertion(credId)     -> sign authData ‖ clientDataHash
+  3. verify the signature under the credential public key (host `cryptography`)
+
+getInfo's advertised set (0x0A) is checked once up front: ES256/ES384/ES512 and
+EdDSA (-8) are advertised (EdDSA so the Windows WebAuthn API offers `ed25519-sk`);
+ES256K (-47) is implemented but intentionally NOT advertised (the FIDO conformance
+tool cannot verify a secp256k1 self-attestation). makeCredential still negotiates
+ES256K from a request, so the per-curve loop exercises it all the same.
 
 A no-PIN device is assumed (resets at the start). Needs `cryptography`. Uses a
 generous response timeout because the pure-Rust P-384/P-521 arithmetic is slow
@@ -122,7 +127,11 @@ def main():
         assert rst[0] == 0x00, f"reset status {rst[0]:#x}"
         gi = decode(send_cbor_t(dev, cid, bytes([0x04]))[1:])
         algs = {a["alg"] for a in gi[0x0A]}
-        assert {-7, -8, -35, -36, -47} <= algs, f"getInfo algorithms = {sorted(algs)}"
+        # ES256/384/512 and EdDSA (-8) are advertised; ES256K (-47) is implemented
+        # but intentionally unadvertised (FIDO conformance MakeCred-Resp P-06) —
+        # makeCredential still negotiates it, so the loop below still tests it.
+        assert {-7, -8, -35, -36} <= algs, f"getInfo algorithms = {sorted(algs)}"
+        assert -47 not in algs, f"ES256K (-47) must not be advertised: {sorted(algs)}"
         print(f"getInfo: algorithms {sorted(algs, reverse=True)}")
 
         passed = []

--- a/tests/60_pqc_mldsa.py
+++ b/tests/60_pqc_mldsa.py
@@ -105,11 +105,13 @@ def main():
         status, gi = ctap(dev, cid, 0x04)
         assert status == 0x00
         algs = [e["alg"] for e in gi[10]]
+        # Advertised set/order: ES256, ES384, ES512, then EdDSA (-8); advertise-pqc
+        # prepends ML-DSA-44 (-48). ES256K (-47) is implemented but never advertised.
         if -48 in algs:
-            assert algs == [-48, -7, -8, -35, -36, -47], f"algorithms list changed: {algs}"
+            assert algs == [-48, -7, -35, -36, -8], f"algorithms list changed: {algs}"
             print("getInfo: ML-DSA-44 advertised (advertise-pqc build)")
         else:
-            assert algs == [-7, -8, -35, -36, -47], f"classic algorithms list changed: {algs}"
+            assert algs == [-7, -35, -36, -8], f"classic algorithms list changed: {algs}"
             print("getInfo: classic algorithms only (Firefox-safe default build)")
         assert gi[5] == 7609, f"maxMsgSize {gi[5]}, want 7609"
 

--- a/tests/61_pqc_thirdparty_client.py
+++ b/tests/61_pqc_thirdparty_client.py
@@ -54,7 +54,7 @@ def main():
     # hard-fails on unknown COSE ids); the advertise-pqc build prepends it. The
     # capability is proven either way by the -48 pick below.
     algs = [a["alg"] for a in info.algorithms]
-    assert algs in ([-7, -8, -35, -36, -47], [-48, -7, -8, -35, -36, -47]), f"unexpected algorithms: {algs}"
+    assert algs in ([-7, -35, -36, -8], [-48, -7, -35, -36, -8]), f"unexpected algorithms: {algs}"
     print(f"getInfo algorithms: {algs}")
     Ctap2(dev).reset()  # idempotent clean slate, like the raw PQC tool
 

--- a/tests/62_metadata_statement.py
+++ b/tests/62_metadata_statement.py
@@ -24,11 +24,15 @@ Part B (runs only if a FIDO HID device is plugged in):
     one, IGNORING the stateful fields (options.ep / options.clientPin /
     forcePINChange / minPINLength) which depend on PIN/enterprise state.
 
-The statement describes the DEFAULT build profile. ES256K (-47) and EdDSA (-8)
-are never advertised in any profile (the FIDO conformance tool cannot verify a
-self-attestation over those curves). `advertise-pqc` adds COSE -48 to algorithms
-and `fips-profile` raises minPINLength — if the live device is one of those,
-Part B says so instead of failing blindly.
+The statement describes the DEFAULT (shipping) build profile, which advertises
+EdDSA (-8): the Windows WebAuthn API drops unadvertised algorithms, breaking
+`ssh-keygen -t ed25519-sk`. ES256K (-47) is never advertised (the FIDO
+conformance tool cannot verify a secp256k1 self-attestation). The
+`fido-conformance` build suppresses -8 too; its EdDSA-free metadata variant
+`metadata/rs-key.conformance.metadata.json` is checked here to be exactly the
+shipping statement minus EdDSA. `advertise-pqc` adds COSE -48 to algorithms and
+`fips-profile` raises minPINLength — if the live device is one of those, Part B
+says so instead of failing blindly.
 """
 import json
 import os
@@ -37,6 +41,7 @@ import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 META = os.path.join(ROOT, "metadata", "rs-key.metadata.json")
+CONF_META = os.path.join(ROOT, "metadata", "rs-key.conformance.metadata.json")
 CONSTS = os.path.join(ROOT, "crates", "rsk-fido", "src", "consts.rs")
 
 # FIDO Registry (v2.2) sign-algorithm string <-> COSE alg id, classic set only.
@@ -117,6 +122,41 @@ def part_a(stmt):
     print(f"Part A OK — aaguid {dashed}, algs {sorted(want)}, fw {gi.get('firmwareVersion')}")
 
 
+def check_conformance_variant(stmt):
+    """The conformance metadata must equal the shipping statement minus EdDSA.
+
+    The `fido-conformance` build drops EdDSA (-8) from getInfo (the conformance
+    tool cannot verify an EdDSA self-attestation), so the operator feeds the tool
+    `rs-key.conformance.metadata.json`. Deriving it as "shipping minus EdDSA"
+    guarantees the two never disagree on anything else.
+    """
+    if not os.path.exists(CONF_META):
+        print("conformance variant: absent (skipped)")
+        return
+    conf = json.load(open(CONF_META))
+    expected = json.loads(json.dumps(stmt))  # deep copy
+    expected["authenticationAlgorithms"] = [
+        a for a in expected["authenticationAlgorithms"]
+        if a != "ed25519_eddsa_sha512_raw"
+    ]
+    expected["authenticatorGetInfo"]["algorithms"] = [
+        a for a in expected["authenticatorGetInfo"]["algorithms"] if a["alg"] != -8
+    ]
+    gi = conf.get("authenticatorGetInfo", {})
+    fails = []
+    if "ed25519_eddsa_sha512_raw" in conf.get("authenticationAlgorithms", []):
+        fails.append("conformance variant must not list ed25519_eddsa_sha512_raw")
+    if any(a["alg"] == -8 for a in gi.get("algorithms", [])):
+        fails.append("conformance variant must not advertise COSE -8")
+    if conf != expected:
+        fails.append("conformance variant must equal the shipping statement minus EdDSA (-8)")
+    if fails:
+        for f in fails:
+            print(f"  FAIL: {f}")
+        sys.exit(f"conformance variant: {len(fails)} failure(s)")
+    print("conformance variant OK — shipping statement minus EdDSA (-8)")
+
+
 def _norm(gi):
     """Drop stateful fields so the static surface can be compared."""
     out = {k: v for k, v in gi.items() if k not in STATEFUL}
@@ -171,12 +211,22 @@ def part_b(stmt):
         "maxPINLength": m[0x1D],
         "authenticatorConfigCommands": m[0x1F],
     }
-    if COSE_MLDSA44 in {a["alg"] for a in live["algorithms"]}:
+    live_algs = {a["alg"] for a in live["algorithms"]}
+    if COSE_MLDSA44 in live_algs:
         print("NOTE: live device is an advertise-pqc build (COSE -48 present); "
               "the statement targets the DEFAULT profile — comparison skipped.")
         return
 
-    want = _norm(stmt["authenticatorGetInfo"])
+    # Pick the metadata profile matching the live device: the default build
+    # advertises EdDSA (-8); the fido-conformance build drops it (and pairs with
+    # the EdDSA-free variant).
+    ref = stmt
+    if -8 not in live_algs and os.path.exists(CONF_META):
+        ref = json.load(open(CONF_META))
+        print("NOTE: live device is a fido-conformance build (no EdDSA -8); "
+              "comparing against the conformance variant.")
+
+    want = _norm(ref["authenticatorGetInfo"])
     got = _norm(live)
     if want != got:
         for k in sorted(set(want) | set(got)):
@@ -190,6 +240,7 @@ def part_b(stmt):
 def main():
     stmt = json.load(open(META))
     part_a(stmt)
+    check_conformance_variant(stmt)
     part_b(stmt)
 
 

--- a/tests/85_rescue.py
+++ b/tests/85_rescue.py
@@ -105,7 +105,7 @@ def main():
         fail(f"flash info is {len(fi)} bytes, want 20")
     free, used, total, nfiles, size = (int.from_bytes(fi[i:i + 4], "big") for i in range(0, 20, 4))
     print(f"  free={free} used={used} total={total} nfiles={nfiles} flash={size}")
-    if free + used != total or nfiles == 0 or size != 4 * 1024 * 1024:
+    if free + used != total or nfiles == 0 or size not in (4 * 1024 * 1024, 16 * 1024 * 1024):
         fail("flash info inconsistent")
 
     # ---- phy write/read (inert fields only: brightness + opts) ----


### PR DESCRIPTION
## RS-Key v0.2.6

Firmware **bcdDevice `0x077B` → `0x077E`**. Three fixes since v0.2.5 (all HW-verified on RP2350):

- **fix(fido): ML-DSA-44 (`-48`) getAssertion wedge** (`0x077D`→`0x077E`) — the post-quantum credential key is now heap-boxed off the worker stack; an inline ~16.6 KiB fips204 keypair overflowed the stack during `sign` (reachable DoS). Restores a measured 32–64 KiB margin; heap unchanged (no RSA impact); `size_of::<CredKey>()` regression guard. Verified `tests/60` + `tests/61`.
- **fix(fido): advertise EdDSA (`-8`) in getInfo** (`0x077C`→`0x077D`) — `ssh-keygen -t ed25519-sk` now works on Windows (WebAuthn intersects requested algs with the advertised set).
- **fix(fs): two power-cut data-durability bugs** (`0x077B`→`0x077C`) — orphaned metadata on `delete` + a present-cache false-absent after a torn migration; cache is now tri-state. New `kv_durability` fuzz target.

Host gate (`check.sh`) green; fuzz workspace builds; full HW sweep (FIDO 00–26, PQC 60–62, OpenPGP 32–41, pico-fido 189✓, openpgp-card 166✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)