### PR TITLE
v0.2.7 — at-rest pre-OTP seed remnant scrub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Security
+
+- **A pre-OTP seed remnant survived OTP provisioning, readable from a flash
+  dump without the fused key — now physically scrubbed at the first OTP boot.**
+  RS-Key seals the FIDO seed under the device root (`kbase`): chip-serial-only
+  before OTP provisioning, the fused MKEK after. Burning OTP re-seals the seed
+  from the weaker root to the fused one (`migrate_keydev_boot`), but the
+  `sequential-storage` flash log is append-only — an overwrite leaves the prior
+  value in place and `remove_item` only flips a header CRC, so the superseded
+  *chip-serial-sealed* copy lingered in flash until natural compaction (rare on
+  the cold credential partition). Because that root derives from the chip id
+  alone — no fuse secret — an attacker with a flash dump plus the chip id could
+  recover the seed, and with it every derived FIDO credential, **bypassing the
+  OTP hardening entirely.** This is the same class of issue as the upstream
+  pico-fido/pico-keys-sdk `flash_clear_file` finding (their "clear" zeroes only
+  the length field, leaving the payload); here `sequential-storage`'s logical
+  delete is the equivalent, and the device-root seal is the only thing that made
+  the steady state safe. Fix: the first boot with the OTP key present now runs a
+  one-shot `Fs::compact` — a full garbage-collection lap over the credential
+  partition that migrates live records forward and sector-erases every page,
+  physically destroying the superseded pre-OTP copies. It is gated by a new
+  `EF_HARDENED` flash marker (runs once, before USB attach) and is crash-safe
+  (an interrupted lap leaves the marker unset and re-runs next boot). A device
+  provisioned OTP-first never creates the remnant and the pass finds nothing to
+  scrub. A host-side proof on the real `sequential-storage` + mock-flash stack
+  scans raw flash to confirm the remnant is present before the lap and gone
+  after (`fuzz/tests/churn_compaction.rs`, mutation-checked). `production.md`
+  now documents the pass and recommends burning OTP before enrolling; the
+  threat-model/limitations caveats are corrected (the lingering record was
+  described as "moot against anything but a fused-key compromise", true only for
+  the already-fused soft-lock case, not this one). bcdDevice 0x077E → 0x077F.
+
 ## [0.2.6] — 2026-06-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.2.7] — 2026-06-21
+
 ### Security
 
 - **A pre-OTP seed remnant survived OTP provisioning, readable from a flash

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ replacement for an audited commercial key.
 ## Project status
 
 A working, single-maintainer hobby project under active development. The latest
-tagged release is **v0.2.6**; day to day the supported version is the tip of
+tagged release is **v0.2.7**; day to day the supported version is the tip of
 `main`, and every behavior change bumps the USB `bcdDevice` build counter so a
 build can be named precisely. Most of the protocol surface works against real host software; what
 has actually been checked on hardware (with dates) is in

--- a/crates/rsk-fido/src/consts.rs
+++ b/crates/rsk-fido/src/consts.rs
@@ -186,6 +186,13 @@ pub const EF_ATT_CHAIN: u16 = 0xCE11; // packed DER chain: count ‖ (len LE ‖
 pub const EF_EA_ENABLED: u16 = 0xCE12;
 /// `alwaysUv` state — present = enabled. Persists until reset (CTAP 2.1), flash.
 pub const EF_ALWAYS_UV: u16 = 0xCE13;
+/// Set (`[1]`) once the post-OTP-provisioning at-rest hardening pass has run:
+/// the seal migrations re-key secrets from the chip-serial root to the OTP root
+/// and the log-structured store keeps the superseded chip-serial copies until
+/// compaction, so a one-shot [`Fs::compact`](rsk_fs::Fs::compact) scrubs them.
+/// This marker gates that lap to the first OTP boot and makes it crash-safe
+/// (absent ⇒ re-run; the lap is idempotent). See `boot`/`main` wiring.
+pub const EF_HARDENED: u16 = 0xCE14;
 pub const EF_COUNTER: u16 = 0xC000; // global signature counter
 pub const EF_CRED: u16 = 0xCF00; // resident credentials, 0xCF00..0xCFFF
 pub const EF_RP: u16 = 0xD000; // relying-party metadata, 0xD000..0xD0FF

--- a/crates/rsk-fs/src/fs.rs
+++ b/crates/rsk-fs/src/fs.rs
@@ -241,6 +241,15 @@ impl<S: Storage> Fs<S> {
         Ok(())
     }
 
+    /// Physically scrub superseded records from the backing store (a full
+    /// garbage-collection lap). See [`Storage::compact`]. No-op on backends that
+    /// overwrite in place and accumulate no remnants. Used once, after the
+    /// post-OTP-provisioning seal migrations, to erase the chip-serial-sealed
+    /// copies those migrations supersede.
+    pub fn compact(&mut self) -> Result<()> {
+        self.storage.compact()
+    }
+
     /// Store file contents, registering a dynamic file if new.
     pub fn put(&mut self, fid: u16, data: &[u8]) -> Result<()> {
         self.storage.write(fid, data)?;

--- a/crates/rsk-fs/src/storage.rs
+++ b/crates/rsk-fs/src/storage.rs
@@ -24,6 +24,21 @@ pub trait Storage {
     /// Invoke `f` once per stored key (used to rebuild the dynamic-file set and to
     /// probe credential slots without a per-slot `read` of every absent FID).
     fn for_each_key(&mut self, f: &mut dyn FnMut(u16));
+    /// Physically reclaim superseded records so that *overwritten* and *deleted*
+    /// payloads are erased from the medium, not merely unlinked.
+    ///
+    /// A log-structured backend ([`crate::Storage`] over `sequential-storage`)
+    /// only appends: an overwrite leaves the prior value in the log and a delete
+    /// flips a header flag, so the old bytes survive a raw flash dump until the
+    /// page is naturally reclaimed. That is fine for the device-root seal in the
+    /// steady state, but it means a record re-sealed under a *stronger* root (the
+    /// pre-OTP → OTP seed migration) leaves a copy sealed under the *weaker*
+    /// chip-serial-only root readable until compaction. This drives that
+    /// compaction on demand. Default: no-op (backends, like the test RAM map,
+    /// that overwrite in place and keep no remnants).
+    fn compact(&mut self) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(any(test, feature = "test-util"))]

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -138,7 +138,11 @@ covers the security boundary, this page covers feature and hardware gaps.
 
 - **The flash log heals lazily**: deleting/superseding a record (e.g.
   enabling the soft-lock) leaves the old record in the log until compaction
-  naturally overwrites it. At-rest guarantees harden over time rather than
-  instantly. *(The superseded record is still sealed to the device root.)*
+  naturally overwrites it, so most at-rest guarantees harden over time rather
+  than instantly. *(On a provisioned device the superseded copy is sealed to
+  the fused root.)* The one record that is **not** left to lazy healing is the
+  pre-OTP seed superseded by the OTP-burn migration — it is sealed under the
+  chip-serial-only root, so the first boot after provisioning scrubs it eagerly
+  with a one-shot full-GC-lap compaction.
 - **The board is the security boundary** — anyone with the device and your
   PIN is you. Same as every security key.

--- a/docs/production.md
+++ b/docs/production.md
@@ -66,6 +66,21 @@ locks the page. On the next boot the firmware notices the provisioned key and
 key wraps, PIN verifiers — under the new root. Your enrolled credentials
 survive; that is the point of the migration layer.
 
+> **At-rest hardening pass.** The migration re-seals each secret under the new
+> root, but the flash store is append-only, so the old chip-serial-sealed
+> copies linger until their page is reclaimed. To stop a flash dump from
+> recovering them, that same first post-burn boot runs a one-shot compaction
+> that physically scrubs the credential partition. It is a multi-second stall
+> that runs **before** the device re-attaches to USB, so on that one boot the
+> device stays dark a little longer than usual — **don't cut power during it.**
+> It runs once (a flash marker gates it) and re-runs if interrupted.
+>
+> **New deployments — burn OTP _before_ you enroll.** A seed generated after the
+> burn is sealed under the fused root from birth, so no chip-serial-sealed copy
+> ever exists and the hardening pass has nothing to scrub. The
+> migrate-in-place path above is for hardening a device you have *already* been
+> using.
+
 ```sh
 rsk reboot bootsel               # picotool needs the chip in BOOTSEL
 rsk otp burn --dry-run           # preview every step

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -62,10 +62,20 @@ bulk stream, ISO-7816 APDUs, CTAP2 CBOR. Defenses:
   key only you hold (BIP-39/SLIP-39 words). A stolen device — even running
   genuine firmware — refuses every FIDO operation until that key is presented
   over an encrypted channel at power-up. Device + words, two factors.
-- Caveat: the flash log keeps a superseded plain-seed record until natural
-  compaction overwrites it, so soft-lock's at-rest guarantee hardens over
-  time rather than at the instant of enabling (the lingering record is still
-  kbase-sealed — moot against anything but a fused-key compromise).
+- Caveat — superseded records linger: the flash log is append-only, so
+  re-sealing or deleting a secret leaves the old copy on flash until its page
+  is reclaimed. Two cases differ in how much that matters:
+  - The **OTP-burn migration** supersedes the *pre-OTP* seed, which was sealed
+    under the chip-serial-only root (no fuse secret). Left alone, a flash dump
+    plus the chip id would recover it — bypassing the burn. So it is **not**
+    left to lazy healing: the first boot after provisioning runs a one-shot
+    compaction (`Fs::compact`, gated by the `EF_HARDENED` marker, crash-safe)
+    that drives a full GC lap over the credential partition and physically
+    erases every superseded pre-OTP record before the device re-attaches to USB.
+  - The **soft-lock** transition leaves the same kind of lingering record, but
+    on a provisioned device it is already sealed under the fused root — moot
+    against anything short of a fused-key compromise — so soft-lock's at-rest
+    guarantee simply hardens over time as natural compaction overwrites it.
 - The FIDO seed is **never PIN-wrapped at rest** (a deliberate design
   decision): UP-only operations — `ssh ed25519-sk`, U2F, no-PIN assertions —
   must work from a cold boot with no PIN presented, so a PIN-keyed at-rest

--- a/firmware/src/flash_storage.rs
+++ b/firmware/src/flash_storage.rs
@@ -46,6 +46,15 @@ const COUNTER_LEN: usize = 128 * 1024;
 const MAIN_PAGES: usize = MAIN_LEN / SECTOR; // 352
 const COUNTER_PAGES: usize = COUNTER_LEN / SECTOR; // 32
 
+/// Transient FID the [`Storage::compact`] lap churns to advance the main ring.
+/// Routed to main (not a counter FID), it never reaches `Fs` and is removed at
+/// the end of the lap — pick a slot no protocol uses (the FIDO 0xCExx block
+/// ends at `EF_HARDENED` 0xCE14; creds start at 0xCF00).
+const SCRUB_FILLER_FID: u16 = 0xCEFE;
+/// One throwaway record's payload during the scrub lap. Larger ⇒ fewer
+/// `store_item` calls; must fit `KV_BUF` alongside the 2-byte key.
+const SCRUB_FILLER: [u8; 1024] = [0xA5; 1024];
+
 /// Cached key→location maps. A hit lets `store_item`'s `migrate_items` take the O(1)
 /// path per item instead of a full-partition scan — the difference between a ~0.2 s
 /// and a multi-second migration. Main covers ~250 resident credentials (two FIDs
@@ -185,6 +194,43 @@ impl Storage for FlashStorage {
     fn for_each_key(&mut self, f: &mut dyn FnMut(u16)) {
         for_each_in(&mut self.main, &mut self.buf, f);
         for_each_in(&mut self.counter, &mut self.buf, f);
+    }
+
+    /// Physically scrub superseded records from the **main** partition (where
+    /// every secret lives) by driving its `sequential-storage` ring a full lap.
+    ///
+    /// The library's `store_item` (overwrite) only appends, and `remove_item`
+    /// only flips a header CRC — both leave the prior payload in flash, readable
+    /// from a raw dump until the page is reclaimed. A page is reclaimed (its live
+    /// items migrated forward, then the whole 4 KiB sector erased) only when the
+    /// ring head needs it. So we write one partition's worth of throwaway records
+    /// to force the head all the way around: every page that held data at entry
+    /// is swept and erased, and the superseded copy of any migrated secret — in
+    /// particular the chip-serial-sealed pre-OTP seed left by
+    /// `migrate_keydev_boot` — is physically destroyed.
+    ///
+    /// One lap needs at most `MAIN_LEN` bytes of fresh writes (less by however
+    /// much live data is relocated en route), so `MAIN_LEN + SECTOR` guarantees a
+    /// full sweep no matter how full the partition is. The counter partition holds
+    /// only non-secret counters and churns on its own, so it is left untouched.
+    /// This is a one-shot, multi-second provisioning cost (see the `EF_HARDENED`
+    /// gate in `main`); it is crash-safe — an interrupted lap leaves the store in
+    /// a valid state and re-runs on the next boot.
+    fn compact(&mut self) -> Result<()> {
+        let writes = (MAIN_LEN + SECTOR).div_ceil(SCRUB_FILLER.len());
+        for i in 0..writes {
+            let mut v = SCRUB_FILLER;
+            v[0] = i as u8; // distinct payloads (defensive; store always appends)
+            block_on(self.main.store_item::<&[u8]>(
+                &mut self.buf,
+                &SCRUB_FILLER_FID,
+                &v.as_slice(),
+            ))
+            .map_err(|_| Error::MemoryFatal)?;
+        }
+        block_on(self.main.remove_item(&mut self.buf, &SCRUB_FILLER_FID))
+            .map_err(|_| Error::MemoryFatal)?;
+        Ok(())
     }
 }
 

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -263,6 +263,19 @@ async fn main(_spawner: Spawner) {
     rsk_fido::credential::migrate_rp_seal(&dev, &mut fs);
     let _ = rsk_fido::seed::ensure_seed(&dev, &mut fs, &mut rng);
     let _ = rsk_openpgp::scan_files(&dev, &mut fs, &mut rng);
+    // One-shot at-rest hardening. The seal migrations above re-key every secret
+    // from the chip-serial root to the OTP root, but the log-structured store
+    // keeps the superseded chip-serial-sealed copies (notably the pre-OTP seed)
+    // recoverable from a flash dump until the page is reclaimed. Scrub them with
+    // a full GC lap the first time we boot with the OTP key present. Gated on a
+    // flash marker so it runs once and crash-safely: an interrupted lap leaves
+    // `EF_HARDENED` unset and re-runs next boot (the lap is idempotent), and a
+    // device provisioned OTP-first pays it once with nothing to scrub. It is a
+    // multi-second stall — deliberately before USB attach, at an attended
+    // provisioning boot. See `flash_storage::FlashStorage::compact`.
+    if otp_mkek.is_some() && !fs.has_data(rsk_fido::consts::EF_HARDENED) && fs.compact().is_ok() {
+        let _ = fs.put(rsk_fido::consts::EF_HARDENED, &[1u8]);
+    }
     // PHY carries the boot-default LED brightness + steady (PicoForge's global LED
     // knobs) and the RS-Key wire-order tag. Apply them BEFORE `load_led_config` so
     // a per-status `EF_LED_CONF` (set via `rsk led`) overrides brightness/steady;
@@ -292,7 +305,7 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("rs-key-0001");
     config.max_power = 100;
     config.max_packet_size_0 = 64;
-    config.device_release = 0x077E; // bcdDevice: our build counter
+    config.device_release = 0x077F; // bcdDevice: our build counter
 
     let mut builder = Builder::new(
         driver,

--- a/fuzz/tests/churn_compaction.rs
+++ b/fuzz/tests/churn_compaction.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! At-rest hardening scrub proof.
+//!
+//! `sequential-storage` is append-only: an overwrite leaves the prior value in
+//! the log and `remove_item` only flips a header CRC, so a superseded payload
+//! survives in flash — recoverable from a raw dump — until its page is
+//! reclaimed. The device re-seals every secret from the chip-serial root to the
+//! OTP root at the first OTP boot (`migrate_keydev_boot` & friends), which
+//! overwrites them and thus strands the *weaker* chip-serial-sealed copies on
+//! flash. `FlashStorage::compact` scrubs those by driving the ring a full lap so
+//! every page is migrated forward and sector-erased.
+//!
+//! This test runs that exact churn on the same `sequential-storage` +
+//! `MockFlashBase` stack the power-cut target uses, then reads the **raw** flash
+//! bytes to prove the superseded secret is physically gone while the live value
+//! survives. Mutation guard: a no-op (or short) compaction leaves the remnant
+//! and fails the final assertion — the first assert documents that the remnant
+//! genuinely exists before the scrub.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use embassy_futures::block_on;
+use embedded_storage_async::nor_flash::{ErrorType, MultiwriteNorFlash, NorFlash, ReadNorFlash};
+use sequential_storage::cache::KeyPointerCache;
+use sequential_storage::map::{MapConfig, MapStorage};
+use sequential_storage::mock_flash::{MockFlashBase, MockFlashError, WriteCountCheck};
+
+// One 32 KiB ring (8 × 4 KiB pages, 4-byte words) — small enough that a full
+// lap completes in a test, same geometry as the power-cut target's main map.
+const WORD: usize = 4;
+const PAGE_WORDS: usize = 1024;
+const PAGES: usize = 8;
+type Mock = MockFlashBase<PAGES, WORD, PAGE_WORDS>;
+const SECTOR: usize = 4096;
+const PARTITION_LEN: usize = PAGES * SECTOR;
+const RANGE: core::ops::Range<u32> = 0..(PARTITION_LEN as u32);
+const KV_BUF: usize = 2048;
+type Cache = KeyPointerCache<PAGES, u16, 16>;
+type Store = MapStorage<u16, SharedMock, Cache>;
+
+// The churn parameters mirror `firmware/src/flash_storage.rs` exactly; only the
+// partition length differs (scaled to the test ring).
+const SCRUB_FILLER_FID: u16 = 0xCEFE;
+const SCRUB_FILLER: [u8; 1024] = [0xA5; 1024];
+
+#[derive(Clone)]
+struct SharedMock(Rc<RefCell<Mock>>);
+
+impl ErrorType for SharedMock {
+    type Error = MockFlashError;
+}
+impl ReadNorFlash for SharedMock {
+    const READ_SIZE: usize = <Mock as ReadNorFlash>::READ_SIZE;
+    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        block_on(self.0.borrow_mut().read(offset, bytes))
+    }
+    fn capacity(&self) -> usize {
+        self.0.borrow().capacity()
+    }
+}
+impl NorFlash for SharedMock {
+    const WRITE_SIZE: usize = <Mock as NorFlash>::WRITE_SIZE;
+    const ERASE_SIZE: usize = <Mock as NorFlash>::ERASE_SIZE;
+    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        block_on(self.0.borrow_mut().erase(from, to))
+    }
+    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        block_on(self.0.borrow_mut().write(offset, bytes))
+    }
+}
+impl MultiwriteNorFlash for SharedMock {}
+
+/// A full garbage-collection lap — the body of `FlashStorage::compact`, scaled
+/// to `PARTITION_LEN`. Writing one partition's worth (+ a sector) of throwaway
+/// records forces the ring head all the way around, reclaiming (migrating then
+/// sector-erasing) every page that held data at entry.
+fn churn_full_lap(map: &mut Store, buf: &mut [u8]) {
+    let writes = (PARTITION_LEN + SECTOR).div_ceil(SCRUB_FILLER.len());
+    for i in 0..writes {
+        let mut v = SCRUB_FILLER;
+        v[0] = i as u8;
+        let filler: &[u8] = &v;
+        block_on(map.store_item::<&[u8]>(buf, &SCRUB_FILLER_FID, &filler)).unwrap();
+    }
+    block_on(map.remove_item(buf, &SCRUB_FILLER_FID)).unwrap();
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+#[test]
+fn churn_lap_physically_scrubs_superseded_secret() {
+    let flash = Rc::new(RefCell::new(Mock::new(
+        WriteCountCheck::Disabled,
+        None,
+        true,
+    )));
+    let mut map = Store::new(
+        SharedMock(flash.clone()),
+        MapConfig::new(RANGE),
+        Cache::new(),
+    );
+    let mut buf = [0u8; KV_BUF];
+
+    // EF_KEY_DEV. Distinctive ASCII so the raw-byte scan can't collide with the
+    // 0xA5 filler or sequential-storage's binary headers.
+    const SEED_FID: u16 = 0xCC00;
+    let pre_otp: &[u8] = b"REMNANT-pre-OTP-seed-ciphertext-1";
+    let otp: &[u8] = b"LIVE-OTP-resealed-seed-ciphertxt2";
+
+    // Pre-OTP seal, then the boot migration re-seals under the OTP root — an
+    // overwrite of the same FID.
+    block_on(map.store_item::<&[u8]>(&mut buf, &SEED_FID, &pre_otp)).unwrap();
+    block_on(map.store_item::<&[u8]>(&mut buf, &SEED_FID, &otp)).unwrap();
+
+    // The append-only log still holds the weaker pre-OTP copy: this is the
+    // remnant a flash dump would recover (the bug being fixed).
+    assert!(
+        contains(&flash.borrow().as_bytes(), pre_otp),
+        "pre-condition: the superseded pre-OTP seed must exist in raw flash"
+    );
+    assert!(contains(&flash.borrow().as_bytes(), otp));
+
+    churn_full_lap(&mut map, &mut buf);
+
+    // Live value preserved…
+    let got = block_on(map.fetch_item::<&[u8]>(&mut buf, &SEED_FID))
+        .unwrap()
+        .expect("the OTP-sealed seed must survive the lap");
+    assert_eq!(got, otp, "live value corrupted by the scrub lap");
+
+    // …and the weaker remnant physically erased from flash.
+    assert!(
+        !contains(&flash.borrow().as_bytes(), pre_otp),
+        "the pre-OTP seed remnant must be physically scrubbed from raw flash"
+    );
+}

--- a/tools/rsk/otp.py
+++ b/tools/rsk/otp.py
@@ -127,6 +127,13 @@ def burn(args):
           " — BL/NS hard-lock NOT applied (OTP page 63 is bootloader-read-only;\n"
           "run `rsk otp lock-page58` from the firmware). Page-58 keys stay readable\n"
           "via `picotool otp get` from BOOTSEL until then."))
+    print(
+        "\nNext boot migrates your secrets under the fused root, then runs a\n"
+        "one-shot at-rest hardening pass that physically scrubs the old\n"
+        "chip-serial-sealed copies from flash. That first boot stays dark a few\n"
+        "seconds longer than usual (the scrub runs before USB attach) — do NOT\n"
+        "cut power during it. It runs once and re-runs if interrupted."
+    )
 
 
 def lock_page58(args):


### PR DESCRIPTION
## v0.2.7 — at-rest pre-OTP seed remnant scrub

### Security fix

The OTP-burn migration re-seals the FIDO seed from the chip-serial root to the
fused OTP root, but `sequential-storage`'s log is append-only: the superseded
**chip-serial-sealed** copy lingers in flash, recoverable from a raw dump plus
the chip id — **bypassing the OTP hardening** — until natural compaction
reclaims its page (rare on the cold credential partition). Same class as the
upstream pico-fido/pico-keys-sdk `flash_clear_file` finding.

**Fix:** the first boot with the OTP key present runs a one-shot `Fs::compact`
— a full GC lap over the credential partition that migrates live records
forward and sector-erases every page, physically destroying the superseded
pre-OTP copies. Gated by an `EF_HARDENED` flash marker (runs once, before USB
attach, crash-safe — an interrupted lap re-runs next boot). A device
provisioned OTP-first never creates the remnant.

### Verification

- **Host proof** on the real `sequential-storage` + mock-flash stack:
  `fuzz/tests/churn_compaction.rs` scans raw flash to confirm the remnant is
  present before the lap and gone after — mutation-checked (a no-op compaction
  fails the assert).
- **HW-verified** on a board that carried a real `0x01` remnant: scrubbed
  (378 stale keydev copies → 1, 92% of the partition rewritten), all applets
  intact. Full device test sweep green (`tests/` + `third_party/pico-fido` +
  `openpgp-card`), no regressions.
- Local gate green: fmt, clippy (embedded + host + fips firmware), all host
  tests, both firmware builds, gitleaks, flake.lock in sync.

### Also

- `production.md` recommends burning OTP before enrolling; documents the
  hardening pass.
- `threat-model.md` / `limitations.md` corrected — the "moot against anything
  but a fused-key compromise" caveat held only for the already-fused soft-lock
  remnant, not this one.
- `rsk otp burn` notes the post-burn hardening pass.

bcdDevice 0x077E → **0x077F**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
