### PR TITLE
fix(fuzz): make churn_compaction test miri-clean

### DIFF
--- a/fuzz/tests/churn_compaction.rs
+++ b/fuzz/tests/churn_compaction.rs
@@ -94,10 +94,16 @@ fn contains(haystack: &[u8], needle: &[u8]) -> bool {
 
 #[test]
 fn churn_lap_physically_scrubs_superseded_secret() {
+    // Last arg = MockFlash's source-pointer `alignment_check`. It is OFF here: the
+    // stack `[u8; N]` buffers are align-1 and happen to land 4-aligned on a real
+    // machine but not under miri (which runs this test in deep-checks), and the
+    // RP2350 QSPI write does not require source alignment anyway. This test proves
+    // the scrub, not flash alignment strictness — which the libfuzzer flash
+    // targets (kv_durability / power_cut) already exercise with the check ON.
     let flash = Rc::new(RefCell::new(Mock::new(
         WriteCountCheck::Disabled,
         None,
-        true,
+        false,
     )));
     let mut map = Store::new(
         SharedMock(flash.clone()),


### PR DESCRIPTION
The `churn_compaction` scrub-proof test (added in 0.2.7) is the only sequential-storage-over-MockFlash test that `cargo miri test` runs, and MockFlash's `alignment_check` requires a 4-aligned source pointer. The align-1 `[u8; N]` buffers land aligned on a real machine but not under miri, so the deep-checks `miri` job has been red since the test landed — it is not a release gate, so v0.2.7/v0.2.8 shipped fine.

Turn the alignment check off for this test (it proves the scrub, not flash-alignment strictness; the RP2350 QSPI write needs no source alignment, and the `kv_durability`/`power_cut` fuzz targets exercise the check ON under libfuzzer). Verified locally: `cargo miri test --test churn_compaction` passes (1 passed, ~174s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)