### PR TITLE
Release v0.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@
 #             `nix develop -c ./scripts/check.sh` (docs/testing.md, "CI parity").
 #             Green locally means green here; no CI-only logic to drift.
 #   flavors — every feature combination of the firmware (no-touch ×
-#             advertise-pqc × fips-profile), each packaged as a downloadable
-#             firmware-<flavor>.uf2 artifact.
+#             advertise-pqc × fips-profile) plus the trusted-display build, each
+#             packaged as a downloadable firmware-<flavor>.uf2 artifact.
 #   knobs   — build smokes for the compile-time env knobs (docs/build.md):
 #             all VIDPID presets, FW_VERSION, XOSC_DELAY_MULT, FAKE_* test
 #             keys, and a check that the default build bakes this project's own
@@ -79,6 +79,13 @@ jobs:
             args: "--features no-touch,fips-profile"
           - name: no-touch-fips-pqc
             args: "--features no-touch,fips-profile,advertise-pqc"
+          # The trusted-display flavor: the panel takes the addressable-LED pin
+          # (LED_KIND=none, compile-time-guarded) and the UI assets want the
+          # larger flash (docs/guides/display.md). `env` is empty for every other
+          # row, so only this one carries the extra knobs.
+          - name: display
+            args: "--features display"
+            env: "LED_KIND=none FLASH_SIZE=16M"
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -101,7 +108,7 @@ jobs:
           restore-keys: cargo-${{ runner.os }}-
 
       - name: build (${{ matrix.name }})
-        run: nix develop -c cargo build --release -p firmware ${{ matrix.args }}
+        run: nix develop -c env ${{ matrix.env }} cargo build --release -p firmware ${{ matrix.args }}
 
       - name: package firmware-${{ matrix.name }}.uf2
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,9 +12,9 @@
 # an inline `attest-build-provenance` step can prove, i.e. Build L2).
 # See https://docs.github.com/actions/security-guides/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3
 #
-# This job: builds the 8 firmware flavors reproducibly via `nix build`, GATES on
-# a bit-identical rebuild of all eight (a non-reproducible image fails the job
-# before anything is published), generates a CycloneDX SBOM, hashes everything
+# This job: builds the 5 shipped firmware flavors reproducibly via `nix build`,
+# GATES on a bit-identical rebuild of all five (a non-reproducible image fails the
+# job before anything is published), generates a CycloneDX SBOM, hashes everything
 # into SHA256SUMS, attests GitHub build provenance for every .uf2, signs the
 # checksums with keyless cosign (sigstore/Fulcio via OIDC — no private key), and
 # publishes the GitHub Release.
@@ -84,15 +84,17 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
-      - name: build the 4 reproducible firmware flavors
+      - name: build the 5 reproducible firmware flavors
         run: |
           tag="${{ steps.tag.outputs.tag }}"
           mkdir -p dist
-          # Only the touch-required flavors ship. The `no-touch` flavors auto-confirm
-          # user presence (test-only; see firmware/Cargo.toml "Never ship a no-touch
-          # build") and MUST NOT be published — a signed no-touch asset would remove
-          # the physical-consent gate from an end-user build.
-          for pkg in firmware firmware-pqc firmware-fips firmware-fips-pqc; do
+          # The four touch-required flavors plus the trusted-display flavor (its
+          # on-screen Approve/Deny is the physical-consent gate). The `no-touch`
+          # flavors auto-confirm user presence (test-only; see firmware/Cargo.toml
+          # "Never ship a no-touch build") and MUST NOT be published — a signed
+          # no-touch asset would remove the physical-consent gate from an end-user
+          # build.
+          for pkg in firmware firmware-pqc firmware-fips firmware-fips-pqc firmware-display; do
             echo "::group::nix build .#$pkg"
             out="$(nix build ".#$pkg" --no-link --print-out-paths)"
             label="${pkg#firmware}"; label="${label#-}"
@@ -102,17 +104,17 @@ jobs:
           done
           ls -l dist
 
-      - name: reproducibility gate — rebuild all 4, require bit-identical
+      - name: reproducibility gate — rebuild all 5, require bit-identical
         run: |
           # `nix build --rebuild` recompiles the derivation already in the store
           # and fails with a hash mismatch if the output is not bit-identical.
           # A non-reproducible flavor fails here, before the release is created.
-          for pkg in firmware firmware-pqc firmware-fips firmware-fips-pqc; do
+          for pkg in firmware firmware-pqc firmware-fips firmware-fips-pqc firmware-display; do
             echo "::group::nix build .#$pkg --rebuild"
             nix build ".#$pkg" --rebuild --no-link
             echo "::endgroup::"
           done
-          echo "all 4 flavors rebuilt bit-identical"
+          echo "all 5 flavors rebuilt bit-identical"
 
       - name: generate the CycloneDX SBOM
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **A management-key mutual auth wrongly cleared the PIN verification, breaking
+  `age-plugin-yubikey`'s first-run.** The 9B management key stores pin-policy
+  ALWAYS, and a successful GENERAL AUTHENTICATE re-locked the session PIN even for
+  the management key — but that re-lock should only follow an actual key-slot sign
+  (it already gates the *check* on `is_key`). A client that verifies the PIN,
+  mutually authenticates the management key, then signs with a pin-policy=ONCE slot
+  key (age-plugin's generate order) hit `6982` on the sign. Now only an `is_key`
+  slot sign re-locks the PIN, matching a real YubiKey.
+
 - **PIV certificates over 256 bytes were invisible to `yubikey.rs`-based tools
   (e.g. `age-plugin-yubikey`).** A Case-3 `GET DATA` (command data, no `Le` — how
   `yubikey.rs` reads slot certificates) returned an oversized body whole instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **PIV certificates over 256 bytes were invisible to `yubikey.rs`-based tools
+  (e.g. `age-plugin-yubikey`).** A Case-3 `GET DATA` (command data, no `Le` — how
+  `yubikey.rs` reads slot certificates) returned an oversized body whole instead
+  of chaining it with `61xx` / `GET RESPONSE`. Clients with a short-APDU receive
+  buffer dropped the read, so a retired-slot age identity showed as "(Empty)"
+  right after it was generated. The CCID dispatcher now caps a no-`Le` response at
+  256 and chains the remainder, matching a real YubiKey (`docs/protocol.md` §1.1).
+  `ykman` / OpenSC were unaffected (they read with an extended `Le`).
+
 ## [0.3.1] — 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.3.2] — 2026-07-08
+
 ### Added
 
 - **Releases now build and publish the trusted-display flavor** as
@@ -1069,7 +1071,8 @@ family that keeps the "enterprise" features in the open tree.
   signature of it, and a CycloneDX SBOM. See
   [docs/releases.md](docs/releases.md) to verify a download.
 
-[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/TheMaxMur/RS-Key/compare/v0.2.8...v0.3.0
 [0.1.0]: https://github.com/TheMaxMur/RS-Key/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **The trusted-display power button now sleeps the device from *every* on-device
+  screen.** The PIN pad, the hold-to-confirm gestures, the "PIN blocked" notice,
+  the success pop, and the host Approve/Deny and "Save passkey?" prompts didn't
+  poll the sleep/wake button, so pressing it there did nothing (the reported case:
+  the PIN-entry screen). Every blocking on-device loop now honors the button —
+  sleeping blanks and, when a device PIN is set, auto-locks; a host ceremony
+  interrupted this way is aborted (declined/cancelled), never approved.
+
 - **A management-key mutual auth wrongly cleared the PIN verification, breaking
   `age-plugin-yubikey`'s first-run.** The 9B management key stores pin-policy
   ALWAYS, and a successful GENERAL AUTHENTICATE re-locked the session PIN even for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Added
+
+- **Releases now build and publish the trusted-display flavor** as
+  `rs-key-<tag>-display.uf2` — reproducibility-gated, signed and attested like the
+  other flavors (for the Waveshare RP2350-Touch-LCD-2.8; see
+  [docs/guides/display.md](docs/guides/display.md)). CI also packages it as a
+  build-smoke `firmware-display.uf2` artifact.
+
 ### Fixed
 
 - **A management-key mutual auth wrongly cleared the PIN verification, breaking

--- a/crates/rsk-fido/src/conformance/clientpin.rs
+++ b/crates/rsk-fido/src/conformance/clientpin.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.5 `authenticatorClientPIN` conformance assertions for the
+//! unauthenticated subcommands, driven through the wire envelope
+//! (`process_cbor`): getKeyAgreement's COSE_Key shape, getPINRetries, and the
+//! rejection of a subcommand the build does not support.
+
+use super::{Authr, assert_ok, field_at, int_map_keys};
+use crate::consts::{ALG_ECDH_ES_HKDF_256, CTAP_CLIENT_PIN, MAX_PIN_RETRIES};
+use crate::error::CtapError;
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+
+/// A clientPIN request `{1: pinUvAuthProtocol, 2: subCommand}`.
+fn cp_request(proto: u64, sub: u64) -> Vec<u8> {
+    let mut buf = [0u8; 32];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(2).unwrap();
+        e.u8(1).unwrap().u64(proto).unwrap();
+        e.u8(2).unwrap().u64(sub).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+#[test]
+fn clientpin_key_agreement_cose_key() {
+    // getKeyAgreement (subCommand 0x02) returns the authenticator's ephemeral
+    // ECDH public key as a COSE_Key: {1: {1:2, 3:-25, -1:1, -2:x, -3:y}} (§6.5.4).
+    let r = Authr::fresh().send(CTAP_CLIENT_PIN, &cp_request(2, 2));
+    assert_ok(&r);
+    assert_eq!(int_map_keys(&r.body), vec![1u32]);
+    let mut d = field_at(&r.body, 1).expect("keyAgreement (0x01) present");
+    assert_eq!(
+        d.map().unwrap().unwrap(),
+        5,
+        "an EC2 COSE_Key has 5 members"
+    );
+    assert_eq!(d.u8().unwrap(), 1, "kty label");
+    assert_eq!(d.u8().unwrap(), 2, "kty must be EC2");
+    assert_eq!(d.u8().unwrap(), 3, "alg label");
+    assert_eq!(
+        d.i64().unwrap(),
+        ALG_ECDH_ES_HKDF_256,
+        "alg must be ECDH-ES+HKDF-256"
+    );
+    assert_eq!(d.i8().unwrap(), -1, "crv label");
+    assert_eq!(d.u8().unwrap(), 1, "crv must be P-256");
+    assert_eq!(d.i8().unwrap(), -2, "x label");
+    assert_eq!(d.bytes().unwrap().len(), 32, "x is a 32-byte coordinate");
+    assert_eq!(d.i8().unwrap(), -3, "y label");
+    assert_eq!(d.bytes().unwrap().len(), 32, "y is a 32-byte coordinate");
+}
+
+#[test]
+fn clientpin_get_retries() {
+    // getPINRetries (subCommand 0x01) on a fresh device returns the max counter.
+    let r = Authr::fresh().send(CTAP_CLIENT_PIN, &cp_request(2, 1));
+    assert_ok(&r);
+    assert_eq!(int_map_keys(&r.body), vec![3u32]);
+    let mut d = field_at(&r.body, 3).expect("retries (0x03) present");
+    assert_eq!(d.u8().unwrap(), MAX_PIN_RETRIES);
+}
+
+#[test]
+fn clientpin_unsupported_subcommand() {
+    // getUVRetries (0x07) needs built-in UV; a screenless build rejects it with
+    // CTAP2_ERR_UNSUPPORTED_OPTION (§6.5).
+    let r = Authr::fresh().send(CTAP_CLIENT_PIN, &cp_request(2, 7));
+    assert_eq!(r.status, CtapError::UnsupportedOption.as_u8());
+    assert!(r.body.is_empty(), "an error response carries no CBOR body");
+}

--- a/crates/rsk-fido/src/conformance/config.rs
+++ b/crates/rsk-fido/src/conformance/config.rs
@@ -7,7 +7,9 @@
 //! `0xff*32 ‖ 0x0d ‖ subCommand ‖ params` is permission-checked (PERM_ACFG).
 
 use super::{Authr, assert_ok_empty, field_at, pin_auth};
-use crate::consts::{CONFIG_ENABLE_EA, CONFIG_TOGGLE_ALWAYS_UV, CTAP_CONFIG};
+use crate::consts::{
+    CONFIG_ENABLE_EA, CONFIG_SET_MIN_PIN, CONFIG_TOGGLE_ALWAYS_UV, CTAP_CONFIG, MIN_PIN_LENGTH,
+};
 use crate::error::CtapError;
 use crate::state::{PERM_ACFG, PERM_GA, puat_subcommand_msg};
 use minicbor::Encoder;
@@ -89,4 +91,61 @@ fn config_wrong_permission_rejected() {
     let param = acfg_param(&token, CONFIG_ENABLE_EA);
     let r = a.send(CTAP_CONFIG, &config_request(CONFIG_ENABLE_EA, &param));
     assert_eq!(r.status, CtapError::PinAuthInvalid.as_u8());
+}
+
+/// Read `minPINLength` (getInfo 0x0D).
+fn getinfo_min_pin(a: &mut Authr) -> u8 {
+    let r = a.get_info();
+    let mut d = field_at(&r.body, 0x0D).expect("minPINLength (0x0D) present");
+    d.u8().unwrap()
+}
+
+/// setMinPINLength request with subCommandParams `{1: newMin}`; the pinUvAuthParam
+/// covers `0xff*32 ‖ 0x0d ‖ 0x03 ‖ <raw subCommandParams>`.
+fn set_min_pin_req(token: &[u8; 32], new_min: u64) -> Vec<u8> {
+    let mut sub = [0u8; 8];
+    let sn = {
+        let mut e = Encoder::new(Cursor::new(&mut sub[..]));
+        e.map(1).unwrap();
+        e.u8(1).unwrap().u64(new_min).unwrap();
+        e.writer().position()
+    };
+    let mut msg = [0u8; 64];
+    let mn = puat_subcommand_msg(&mut msg, CTAP_CONFIG, CONFIG_SET_MIN_PIN as u8, &sub[..sn]);
+    let puap = pin_auth(token, &msg[..mn]);
+    let mut buf = [0u8; 64];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(4).unwrap();
+        e.u8(1).unwrap().u64(CONFIG_SET_MIN_PIN).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .u8(1)
+            .unwrap()
+            .u64(new_min)
+            .unwrap();
+        e.u8(3).unwrap().u64(2).unwrap();
+        e.u8(4).unwrap().bytes(&puap).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+#[test]
+fn config_set_min_pin_length_round_trips() {
+    let mut a = Authr::fresh();
+    assert_eq!(
+        getinfo_min_pin(&mut a),
+        MIN_PIN_LENGTH,
+        "minPINLength starts at the build default"
+    );
+    let token = a.arm_token(PERM_ACFG);
+    assert_ok_empty(&a.send(CTAP_CONFIG, &set_min_pin_req(&token, 6)));
+    assert_eq!(
+        getinfo_min_pin(&mut a),
+        6,
+        "getInfo minPINLength reflects setMinPINLength"
+    );
 }

--- a/crates/rsk-fido/src/conformance/config.rs
+++ b/crates/rsk-fido/src/conformance/config.rs
@@ -7,7 +7,7 @@
 //! `0xff*32 ‖ 0x0d ‖ subCommand ‖ params` is permission-checked (PERM_ACFG).
 
 use super::{Authr, assert_ok_empty, field_at, pin_auth};
-use crate::consts::{CONFIG_ENABLE_EA, CTAP_CONFIG};
+use crate::consts::{CONFIG_ENABLE_EA, CONFIG_TOGGLE_ALWAYS_UV, CTAP_CONFIG};
 use crate::error::CtapError;
 use crate::state::{PERM_ACFG, PERM_GA, puat_subcommand_msg};
 use minicbor::Encoder;
@@ -34,15 +34,15 @@ fn acfg_param(token: &[u8; 32], subcommand: u64) -> Vec<u8> {
     pin_auth(token, &msg[..n])
 }
 
-/// Read `options.ep` from a fresh getInfo (false if absent).
-fn getinfo_ep(a: &mut Authr) -> bool {
+/// Read a boolean `options.<name>` from a fresh getInfo (false if absent).
+fn getinfo_option(a: &mut Authr, name: &str) -> bool {
     let r = a.get_info();
     let mut d = field_at(&r.body, 4).expect("options (0x04) present");
     let n = d.map().unwrap().unwrap();
     for _ in 0..n {
-        let key = d.str().unwrap() == "ep";
+        let hit = d.str().unwrap() == name;
         let val = d.bool().unwrap();
-        if key {
+        if hit {
             return val;
         }
     }
@@ -52,13 +52,32 @@ fn getinfo_ep(a: &mut Authr) -> bool {
 #[test]
 fn config_enable_enterprise_attestation_round_trips() {
     let mut a = Authr::fresh();
-    assert!(!getinfo_ep(&mut a), "options.ep starts disabled");
+    assert!(!getinfo_option(&mut a, "ep"), "options.ep starts disabled");
     let token = a.arm_token(PERM_ACFG);
     let param = acfg_param(&token, CONFIG_ENABLE_EA);
     assert_ok_empty(&a.send(CTAP_CONFIG, &config_request(CONFIG_ENABLE_EA, &param)));
     assert!(
-        getinfo_ep(&mut a),
+        getinfo_option(&mut a, "ep"),
         "options.ep must flip to true after enableEnterpriseAttestation"
+    );
+}
+
+#[test]
+fn config_toggle_always_uv_round_trips() {
+    let mut a = Authr::fresh();
+    assert!(
+        !getinfo_option(&mut a, "alwaysUv"),
+        "options.alwaysUv starts disabled"
+    );
+    let token = a.arm_token(PERM_ACFG);
+    let param = acfg_param(&token, CONFIG_TOGGLE_ALWAYS_UV);
+    assert_ok_empty(&a.send(
+        CTAP_CONFIG,
+        &config_request(CONFIG_TOGGLE_ALWAYS_UV, &param),
+    ));
+    assert!(
+        getinfo_option(&mut a, "alwaysUv"),
+        "options.alwaysUv must flip to true after toggleAlwaysUv"
     );
 }
 

--- a/crates/rsk-fido/src/conformance/config.rs
+++ b/crates/rsk-fido/src/conformance/config.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.11 `authenticatorConfig` conformance, driven through the wire
+//! envelope (`process_cbor`): enableEnterpriseAttestation round-trips into
+//! getInfo `options.ep`, and the credMgmt-style pinUvAuthParam over
+//! `0xff*32 ‖ 0x0d ‖ subCommand ‖ params` is permission-checked (PERM_ACFG).
+
+use super::{Authr, assert_ok_empty, field_at, pin_auth};
+use crate::consts::{CONFIG_ENABLE_EA, CTAP_CONFIG};
+use crate::error::CtapError;
+use crate::state::{PERM_ACFG, PERM_GA, puat_subcommand_msg};
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+
+/// authenticatorConfig request `{1: subCommand, 3: proto, 4: pinUvAuthParam}`.
+fn config_request(subcommand: u64, param: &[u8]) -> Vec<u8> {
+    let mut buf = [0u8; 64];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(3).unwrap();
+        e.u8(1).unwrap().u64(subcommand).unwrap();
+        e.u8(3).unwrap().u64(2).unwrap();
+        e.u8(4).unwrap().bytes(param).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// The pinUvAuthParam for a parameter-less authenticatorConfig subcommand.
+fn acfg_param(token: &[u8; 32], subcommand: u64) -> Vec<u8> {
+    let mut msg = [0u8; 64];
+    let n = puat_subcommand_msg(&mut msg, CTAP_CONFIG, subcommand as u8, &[]);
+    pin_auth(token, &msg[..n])
+}
+
+/// Read `options.ep` from a fresh getInfo (false if absent).
+fn getinfo_ep(a: &mut Authr) -> bool {
+    let r = a.get_info();
+    let mut d = field_at(&r.body, 4).expect("options (0x04) present");
+    let n = d.map().unwrap().unwrap();
+    for _ in 0..n {
+        let key = d.str().unwrap() == "ep";
+        let val = d.bool().unwrap();
+        if key {
+            return val;
+        }
+    }
+    false
+}
+
+#[test]
+fn config_enable_enterprise_attestation_round_trips() {
+    let mut a = Authr::fresh();
+    assert!(!getinfo_ep(&mut a), "options.ep starts disabled");
+    let token = a.arm_token(PERM_ACFG);
+    let param = acfg_param(&token, CONFIG_ENABLE_EA);
+    assert_ok_empty(&a.send(CTAP_CONFIG, &config_request(CONFIG_ENABLE_EA, &param)));
+    assert!(
+        getinfo_ep(&mut a),
+        "options.ep must flip to true after enableEnterpriseAttestation"
+    );
+}
+
+#[test]
+fn config_wrong_permission_rejected() {
+    // A token without the authenticatorConfiguration permission → PIN_AUTH_INVALID.
+    let mut a = Authr::fresh();
+    let token = a.arm_token(PERM_GA);
+    let param = acfg_param(&token, CONFIG_ENABLE_EA);
+    let r = a.send(CTAP_CONFIG, &config_request(CONFIG_ENABLE_EA, &param));
+    assert_eq!(r.status, CtapError::PinAuthInvalid.as_u8());
+}

--- a/crates/rsk-fido/src/conformance/credmgmt.rs
+++ b/crates/rsk-fido/src/conformance/credmgmt.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.8 `authenticatorCredentialManagement` conformance, driven through
+//! the wire envelope (`process_cbor`): getCredsMetadata's count response, the
+//! pinUvAuthParam requirement, and the credMgmt-permission check. The MAC over a
+//! parameter-less subcommand covers just its command byte (§6.8).
+
+use super::{Authr, assert_ok, field_at, int_map_keys, pin_auth};
+use crate::consts::{ALG_ES256, CM_GET_CREDS_METADATA, CTAP_CREDENTIAL_MGMT, CTAP_MAKE_CREDENTIAL};
+use crate::error::CtapError;
+use crate::state::{PERM_CM, PERM_GA};
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+
+/// A discoverable ES256 makeCredential request over `rp` with user id `uid`.
+fn mc_rk(rp: &str, uid: &[u8]) -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(5).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(rp)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(uid).unwrap();
+        e.str("name").unwrap().str("dave").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// getCredsMetadata request: `{1: subCommand, [3: proto, 4: pinUvAuthParam]}`.
+fn cm_metadata(param: Option<&[u8]>) -> Vec<u8> {
+    let mut buf = [0u8; 64];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(if param.is_some() { 3 } else { 1 }).unwrap();
+        e.u8(1).unwrap().u64(CM_GET_CREDS_METADATA).unwrap();
+        if let Some(p) = param {
+            e.u8(3).unwrap().u64(2).unwrap();
+            e.u8(4).unwrap().bytes(p).unwrap();
+        }
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+#[test]
+fn credmgmt_creds_metadata_counts() {
+    let mut a = Authr::fresh();
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_rk("a.example", &[1])));
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_rk("b.example", &[2])));
+
+    let token = a.arm_token(PERM_CM);
+    let param = pin_auth(&token, &[CM_GET_CREDS_METADATA as u8]);
+    let r = a.send(CTAP_CREDENTIAL_MGMT, &cm_metadata(Some(&param)));
+    assert_ok(&r);
+    // { 1: existingResidentCredentials, 2: maxPossibleRemainingResidentCredentials }
+    assert_eq!(int_map_keys(&r.body), vec![1u32, 2]);
+    let mut d = field_at(&r.body, 1).expect("existing count (0x01)");
+    assert_eq!(
+        d.u16().unwrap(),
+        2,
+        "two resident credentials were registered"
+    );
+    let mut d = field_at(&r.body, 2).expect("remaining count (0x02)");
+    assert!(d.u16().unwrap() >= 1, "remaining capacity must be reported");
+}
+
+#[test]
+fn credmgmt_requires_pinuvauth() {
+    // credMgmt with no pinUvAuthParam → CTAP2_ERR_PUAT_REQUIRED (§6.8).
+    let r = Authr::fresh().send(CTAP_CREDENTIAL_MGMT, &cm_metadata(None));
+    assert_eq!(r.status, CtapError::PuatRequired.as_u8());
+}
+
+#[test]
+fn credmgmt_wrong_permission_rejected() {
+    // A token missing the credMgmt permission → CTAP2_ERR_PIN_AUTH_INVALID (§6.8).
+    let mut a = Authr::fresh();
+    let token = a.arm_token(PERM_GA);
+    let param = pin_auth(&token, &[CM_GET_CREDS_METADATA as u8]);
+    let r = a.send(CTAP_CREDENTIAL_MGMT, &cm_metadata(Some(&param)));
+    assert_eq!(r.status, CtapError::PinAuthInvalid.as_u8());
+}

--- a/crates/rsk-fido/src/conformance/credprotect.rs
+++ b/crates/rsk-fido/src/conformance/credprotect.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 credProtect (§12.1 + §6.2.2 privacy) conformance, driven through the
+//! wire envelope (`process_cbor`): a level-3 (userVerificationRequired) extension
+//! is echoed in the makeCredential authData, and a level-3 discoverable
+//! credential is invisible to getAssertion without user verification — but
+//! returned once a pinUvAuthToken supplies UV.
+
+use super::{Authr, assert_ok, field_at, pin_auth};
+use crate::consts::{
+    ALG_ES256, CRED_PROT_UV_REQUIRED, CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL, FLAG_ED,
+};
+use crate::error::CtapError;
+use crate::state::PERM_GA;
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+
+const RP_ID: &str = "protect.example";
+const USER_ID: &[u8] = &[7, 7, 7, 7];
+const CDH: [u8; 32] = [0xCD; 32];
+
+/// makeCredential with a `credProtect` extension (request key 6), optionally rk.
+fn mc_credprotect(level: u64, rk: bool) -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(if rk { 6 } else { 5 }).unwrap();
+        e.u8(1).unwrap().bytes(&CDH).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(USER_ID).unwrap();
+        e.str("name").unwrap().str("carol").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(6)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("credProtect")
+            .unwrap()
+            .u64(level)
+            .unwrap();
+        if rk {
+            e.u8(7)
+                .unwrap()
+                .map(1)
+                .unwrap()
+                .str("rk")
+                .unwrap()
+                .bool(true)
+                .unwrap();
+        }
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A getAssertion request over `RP_ID`, optionally carrying a pinUvAuthParam
+/// (keys 6/7) to supply UV.
+fn ga(uv: Option<&[u8]>) -> Vec<u8> {
+    let mut buf = [0u8; 128];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(if uv.is_some() { 4 } else { 2 }).unwrap();
+        e.u8(1).unwrap().str(RP_ID).unwrap();
+        e.u8(2).unwrap().bytes(&CDH).unwrap();
+        if let Some(param) = uv {
+            e.u8(6).unwrap().bytes(param).unwrap();
+            e.u8(7).unwrap().u64(2).unwrap();
+        }
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+#[test]
+fn credprotect_echoed_in_authdata() {
+    let r = Authr::fresh().send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_credprotect(CRED_PROT_UV_REQUIRED, false),
+    );
+    assert_ok(&r);
+    let mut d = field_at(&r.body, 2).expect("authData (0x02) present");
+    let ad = d.bytes().unwrap();
+    assert_eq!(
+        ad[32] & FLAG_ED,
+        FLAG_ED,
+        "ED flag must be set when extensions are present"
+    );
+    // Walk past the attested credential data (aaguid, credId, COSE key) to the
+    // authData extension map and read back the credProtect level.
+    let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    let mut ext = minicbor::Decoder::new(&ad[55 + cred_len..]);
+    ext.skip().unwrap(); // the COSE public key map
+    let n = ext.map().unwrap().expect("authData extension map");
+    let mut level = None;
+    for _ in 0..n {
+        if ext.str().unwrap() == "credProtect" {
+            level = Some(ext.u64().unwrap());
+        } else {
+            ext.skip().unwrap();
+        }
+    }
+    assert_eq!(
+        level,
+        Some(CRED_PROT_UV_REQUIRED),
+        "credProtect level must echo the request"
+    );
+}
+
+#[test]
+fn credprotect3_hidden_without_uv() {
+    let mut a = Authr::fresh();
+    assert_ok(&a.send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_credprotect(CRED_PROT_UV_REQUIRED, true),
+    ));
+    // A userVerificationRequired credential is invisible to a no-UV assertion
+    // (CTAP 2.1 §6.2.2 / §12.1) → CTAP2_ERR_NO_CREDENTIALS.
+    let r = a.send(CTAP_GET_ASSERTION, &ga(None));
+    assert_eq!(r.status, CtapError::NoCredentials.as_u8());
+}
+
+#[test]
+fn credprotect3_visible_with_uv() {
+    let mut a = Authr::fresh();
+    assert_ok(&a.send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_credprotect(CRED_PROT_UV_REQUIRED, true),
+    ));
+    // Supply UV via a pinUvAuthToken → the same credential is now returned.
+    let token = a.arm_token(PERM_GA);
+    let param = pin_auth(&token, &CDH);
+    let r = a.send(CTAP_GET_ASSERTION, &ga(Some(&param)));
+    assert_ok(&r);
+}

--- a/crates/rsk-fido/src/conformance/credprotect.rs
+++ b/crates/rsk-fido/src/conformance/credprotect.rs
@@ -9,7 +9,8 @@
 
 use super::{Authr, assert_ok, field_at, pin_auth};
 use crate::consts::{
-    ALG_ES256, CRED_PROT_UV_REQUIRED, CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL, FLAG_ED,
+    ALG_ES256, CRED_PROT_UV_OPTIONAL, CRED_PROT_UV_OPTIONAL_WITH_LIST, CRED_PROT_UV_REQUIRED,
+    CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL, FLAG_ED,
 };
 use crate::error::CtapError;
 use crate::state::PERM_GA;
@@ -142,4 +143,57 @@ fn credprotect3_visible_with_uv() {
     let param = pin_auth(&token, &CDH);
     let r = a.send(CTAP_GET_ASSERTION, &ga(Some(&param)));
     assert_ok(&r);
+}
+
+/// A getAssertion over `RP_ID` naming `id` in the allowList (no UV).
+fn ga_allow(id: &[u8]) -> Vec<u8> {
+    let mut buf = [0u8; 128];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(3).unwrap();
+        e.u8(1).unwrap().str(RP_ID).unwrap();
+        e.u8(2).unwrap().bytes(&CDH).unwrap();
+        e.u8(3).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.str("id").unwrap().bytes(id).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// The credential id from a makeCredential authData.
+fn cred_id(body: &[u8]) -> Vec<u8> {
+    let mut d = field_at(body, 2).expect("authData (0x02) present");
+    let ad = d.bytes().unwrap();
+    let cl = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    ad[55..55 + cl].to_vec()
+}
+
+#[test]
+fn credprotect1_always_visible() {
+    let mut a = Authr::fresh();
+    assert_ok(&a.send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_credprotect(CRED_PROT_UV_OPTIONAL, true),
+    ));
+    // Level 1 (userVerificationOptional) is returned to a no-UV discoverable assertion.
+    assert_ok(&a.send(CTAP_GET_ASSERTION, &ga(None)));
+}
+
+#[test]
+fn credprotect2_needs_list_or_uv() {
+    let mut a = Authr::fresh();
+    let r = a.send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_credprotect(CRED_PROT_UV_OPTIONAL_WITH_LIST, true),
+    );
+    assert_ok(&r);
+    let id = cred_id(&r.body);
+    // Level 2 is invisible to a no-UV discoverable assertion (§12.1)...
+    assert_eq!(
+        a.send(CTAP_GET_ASSERTION, &ga(None)).status,
+        CtapError::NoCredentials.as_u8()
+    );
+    // ...but visible when named in the allowList.
+    assert_ok(&a.send(CTAP_GET_ASSERTION, &ga_allow(&id)));
 }

--- a/crates/rsk-fido/src/conformance/errors.rs
+++ b/crates/rsk-fido/src/conformance/errors.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 error-code conformance: a malformed or spec-violating request must
+//! map to the *exact* status word, not merely fail to crash. The fuzz targets
+//! cover no-panic robustness on arbitrary input; this pins the CODE the way a
+//! conformance tool does. Driven through the wire envelope (`process_cbor`).
+
+use super::Authr;
+use crate::consts::{
+    ALG_ES256, CTAP_CLIENT_PIN, CTAP_CREDENTIAL_MGMT, CTAP_GET_ASSERTION, CTAP_LARGE_BLOBS,
+    CTAP_MAKE_CREDENTIAL,
+};
+use crate::error::CtapError;
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+
+/// CBOR-encode a request body with `f`.
+fn enc(f: impl Fn(&mut Encoder<Cursor<&mut [u8]>>)) -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        f(&mut e);
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// Assert `cmd ‖ params` answers exactly `err`.
+fn expect(cmd: u8, params: &[u8], err: CtapError) {
+    let r = Authr::fresh().send(cmd, params);
+    assert_eq!(
+        r.status,
+        err.as_u8(),
+        "unexpected status 0x{:02x} for a malformed request",
+        r.status
+    );
+}
+
+#[test]
+fn makecred_empty_params_is_invalid_cbor() {
+    expect(CTAP_MAKE_CREDENTIAL, &[], CtapError::InvalidCbor);
+}
+
+#[test]
+fn makecred_missing_client_data_hash() {
+    // A request that omits clientDataHash (starts at key 2) → MISSING_PARAMETER.
+    let req = enc(|e| {
+        e.map(3).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str("x.example")
+            .unwrap();
+        e.u8(3)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .bytes(&[1])
+            .unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+    });
+    expect(CTAP_MAKE_CREDENTIAL, &req, CtapError::MissingParameter);
+}
+
+#[test]
+fn makecred_up_false_is_invalid_option() {
+    // options.up=false is illegal for makeCredential (§6.1) → INVALID_OPTION.
+    let req = enc(|e| {
+        e.map(5).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str("x.example")
+            .unwrap();
+        e.u8(3)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .bytes(&[1])
+            .unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("up")
+            .unwrap()
+            .bool(false)
+            .unwrap();
+    });
+    expect(CTAP_MAKE_CREDENTIAL, &req, CtapError::InvalidOption);
+}
+
+#[test]
+fn getassertion_empty_params_is_invalid_cbor() {
+    expect(CTAP_GET_ASSERTION, &[], CtapError::InvalidCbor);
+}
+
+#[test]
+fn clientpin_missing_subcommand() {
+    // {1: proto} with no subCommand → MISSING_PARAMETER.
+    let req = enc(|e| {
+        e.map(1).unwrap();
+        e.u8(1).unwrap().u64(2).unwrap();
+    });
+    expect(CTAP_CLIENT_PIN, &req, CtapError::MissingParameter);
+}
+
+#[test]
+fn clientpin_invalid_protocol() {
+    // getKeyAgreement with an unknown pinUvAuthProtocol → INVALID_PARAMETER.
+    let req = enc(|e| {
+        e.map(2).unwrap();
+        e.u8(1).unwrap().u64(3).unwrap();
+        e.u8(2).unwrap().u64(2).unwrap();
+    });
+    expect(CTAP_CLIENT_PIN, &req, CtapError::InvalidParameter);
+}
+
+#[test]
+fn credmgmt_unknown_subcommand() {
+    // An unknown subCommand (with a param present) → INVALID_PARAMETER.
+    let req = enc(|e| {
+        e.map(3).unwrap();
+        e.u8(1).unwrap().u64(0x99).unwrap();
+        e.u8(3).unwrap().u64(2).unwrap();
+        e.u8(4).unwrap().bytes(&[0u8; 32]).unwrap();
+    });
+    expect(CTAP_CREDENTIAL_MGMT, &req, CtapError::InvalidParameter);
+}
+
+#[test]
+fn largeblobs_get_and_set_conflict() {
+    // Supplying both get (0x01) and set (0x02) → INVALID_PARAMETER.
+    let req = enc(|e| {
+        e.map(3).unwrap();
+        e.u8(1).unwrap().u64(0).unwrap();
+        e.u8(2).unwrap().bytes(&[0]).unwrap();
+        e.u8(3).unwrap().u64(0).unwrap();
+    });
+    expect(CTAP_LARGE_BLOBS, &req, CtapError::InvalidParameter);
+}
+
+#[test]
+fn largeblobs_missing_offset() {
+    // A get without the mandatory offset (0x03) → INVALID_PARAMETER.
+    let req = enc(|e| {
+        e.map(1).unwrap();
+        e.u8(1).unwrap().u64(0).unwrap();
+    });
+    expect(CTAP_LARGE_BLOBS, &req, CtapError::InvalidParameter);
+}

--- a/crates/rsk-fido/src/conformance/extensions.rs
+++ b/crates/rsk-fido/src/conformance/extensions.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 extension conformance (credBlob §12.5, hmac-secret §12.5), driven
+//! through the wire envelope (`process_cbor`): makeCredential echoes the
+//! extension outputs in authData, and getAssertion returns the stored credBlob.
+
+use super::{Authr, assert_ok, field_at};
+use crate::consts::{ALG_ES256, CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL, FLAG_ED};
+use minicbor::encode::write::Cursor;
+use minicbor::{Decoder, Encoder};
+
+const RP_ID: &str = "ext.example";
+const CDH: [u8; 32] = [0xCD; 32];
+const USER_ID: &[u8] = &[3, 1, 4, 1];
+const BLOB: [u8; 4] = [0xAB, 0xCD, 0xEF, 0x01];
+
+/// A discoverable makeCredential over `RP_ID` whose extensions map (key 6) holds
+/// `ext_count` entries written by `ext`.
+fn mc_with_ext(ext_count: u64, ext: impl Fn(&mut Encoder<Cursor<&mut [u8]>>)) -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(6).unwrap(); // keys 1,2,3,4,6,7
+        e.u8(1).unwrap().bytes(&CDH).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(USER_ID).unwrap();
+        e.str("name").unwrap().str("frank").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(6).unwrap().map(ext_count).unwrap();
+        ext(&mut e);
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A getAssertion over `RP_ID` requesting the stored credBlob (extensions key 4).
+fn ga_credblob() -> Vec<u8> {
+    let mut buf = [0u8; 128];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(3).unwrap();
+        e.u8(1).unwrap().str(RP_ID).unwrap();
+        e.u8(2).unwrap().bytes(&CDH).unwrap();
+        e.u8(4)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("credBlob")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// Read a boolean extension output from a makeCredential authData (walking past
+/// the attested credential data and the COSE public key to the extension map).
+fn mc_ext_bool(body: &[u8], name: &str) -> Option<bool> {
+    let mut d = field_at(body, 2).expect("authData (0x02) present");
+    let ad = d.bytes().unwrap();
+    let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    let mut ext = Decoder::new(&ad[55 + cred_len..]);
+    ext.skip().unwrap(); // the COSE public key
+    let n = ext.map().ok()??;
+    for _ in 0..n {
+        if ext.str().unwrap() == name {
+            return ext.bool().ok();
+        }
+        ext.skip().unwrap();
+    }
+    None
+}
+
+#[test]
+fn credblob_makecredential_echoes_stored_flag() {
+    // A short credBlob is stored → authData echoes credBlob: true.
+    let r = Authr::fresh().send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_with_ext(1, |e| {
+            e.str("credBlob").unwrap().bytes(&BLOB).unwrap();
+        }),
+    );
+    assert_ok(&r);
+    assert_eq!(mc_ext_bool(&r.body, "credBlob"), Some(true));
+}
+
+#[test]
+fn hmac_secret_makecredential_echoes_true() {
+    // hmac-secret is acknowledged in the makeCredential authData as a bool true.
+    let r = Authr::fresh().send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_with_ext(1, |e| {
+            e.str("hmac-secret").unwrap().bool(true).unwrap();
+        }),
+    );
+    assert_ok(&r);
+    assert_eq!(mc_ext_bool(&r.body, "hmac-secret"), Some(true));
+}
+
+#[test]
+fn credblob_returned_by_getassertion() {
+    let mut a = Authr::fresh();
+    assert_ok(&a.send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_with_ext(1, |e| {
+            e.str("credBlob").unwrap().bytes(&BLOB).unwrap();
+        }),
+    ));
+    let g = a.send(CTAP_GET_ASSERTION, &ga_credblob());
+    assert_ok(&g);
+    let mut d = field_at(&g.body, 2).expect("authData (0x02) present");
+    let ad = d.bytes().unwrap();
+    assert_eq!(
+        ad[32] & FLAG_ED,
+        FLAG_ED,
+        "ED flag set (extension output present)"
+    );
+    // Assertion authData is rpIdHash(32) | flags(1) | counter(4) | extension map.
+    let mut ext = Decoder::new(&ad[37..]);
+    let n = ext.map().unwrap().unwrap();
+    let mut got = None;
+    for _ in 0..n {
+        if ext.str().unwrap() == "credBlob" {
+            got = Some(ext.bytes().unwrap().to_vec());
+        } else {
+            ext.skip().unwrap();
+        }
+    }
+    assert_eq!(
+        got.as_deref(),
+        Some(&BLOB[..]),
+        "getAssertion returns the stored credBlob"
+    );
+}

--- a/crates/rsk-fido/src/conformance/getassertion.rs
+++ b/crates/rsk-fido/src/conformance/getassertion.rs
@@ -7,7 +7,9 @@
 //! user-presence-only (no PIN), so `AlwaysConfirm` satisfies them.
 
 use super::{Authr, assert_ok, field_at, int_map_keys};
-use crate::consts::{ALG_ES256, CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL, FLAG_AT, FLAG_UP};
+use crate::consts::{
+    ALG_ES256, CTAP_GET_ASSERTION, CTAP_GET_NEXT_ASSERTION, CTAP_MAKE_CREDENTIAL, FLAG_AT, FLAG_UP,
+};
 use crate::error::CtapError;
 use minicbor::Encoder;
 use minicbor::encode::write::Cursor;
@@ -140,4 +142,79 @@ fn getassertion_no_credentials() {
     let r = Authr::fresh().send(CTAP_GET_ASSERTION, &ga_request("absent.example"));
     assert_eq!(r.status, CtapError::NoCredentials.as_u8());
     assert!(r.body.is_empty(), "an error response carries no CBOR body");
+}
+
+/// A discoverable makeCredential over `RP_ID` with an explicit user id.
+fn mc_rk_user(uid: &[u8]) -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(5).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(uid).unwrap();
+        e.str("name").unwrap().str("user").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// The user id ("id") from an assertion's user field (key 4).
+fn assertion_user_id(body: &[u8]) -> Vec<u8> {
+    let mut d = field_at(body, 4).expect("user (0x04) present");
+    assert!(d.map().unwrap().unwrap() >= 1);
+    assert_eq!(d.str().unwrap(), "id");
+    d.bytes().unwrap().to_vec()
+}
+
+#[test]
+fn getnextassertion_walks_multiple_credentials() {
+    let mut a = Authr::fresh();
+    // Two discoverable credentials on the same RP (distinct user ids).
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_rk_user(&[0xA1])));
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_rk_user(&[0xB2])));
+
+    // The first getAssertion reports the count and returns one credential.
+    let g1 = a.send(CTAP_GET_ASSERTION, &ga_request(RP_ID));
+    assert_ok(&g1);
+    let mut d = field_at(&g1.body, 5).expect("numberOfCredentials (0x05) present");
+    assert_eq!(d.u32().unwrap(), 2, "two credentials must be reported");
+    let u1 = assertion_user_id(&g1.body);
+
+    // getNextAssertion returns the other; a further call is exhausted.
+    let g2 = a.send(CTAP_GET_NEXT_ASSERTION, &[]);
+    assert_ok(&g2);
+    let u2 = assertion_user_id(&g2.body);
+    assert_ne!(u1, u2, "the two assertions cover distinct credentials");
+    // getNextAssertion carries no numberOfCredentials.
+    assert!(
+        field_at(&g2.body, 5).is_none(),
+        "only the first assertion counts"
+    );
+
+    let g3 = a.send(CTAP_GET_NEXT_ASSERTION, &[]);
+    assert_eq!(
+        g3.status,
+        CtapError::NotAllowed.as_u8(),
+        "walk is exhausted"
+    );
 }

--- a/crates/rsk-fido/src/conformance/getassertion.rs
+++ b/crates/rsk-fido/src/conformance/getassertion.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.2 `authenticatorGetAssertion` conformance assertions, driven
+//! through the wire envelope (`process_cbor`). A discoverable credential is
+//! created first (makeCredential rk=true), then asserted; both are
+//! user-presence-only (no PIN), so `AlwaysConfirm` satisfies them.
+
+use super::{Authr, assert_ok, field_at, int_map_keys};
+use crate::consts::{ALG_ES256, CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL, FLAG_AT, FLAG_UP};
+use crate::error::CtapError;
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+use rsk_crypto::sha256;
+
+const RP_ID: &str = "example.com";
+const USER_ID: &[u8] = &[1, 2, 3, 4];
+
+/// A discoverable (rk=true) ES256 makeCredential request over `RP_ID`.
+fn mc_rk_request() -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(5).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(USER_ID).unwrap();
+        e.str("name").unwrap().str("alice").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A getAssertion request over `rp` with no allowList (discoverable lookup).
+fn ga_request(rp: &str) -> Vec<u8> {
+    let mut buf = [0u8; 128];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(2).unwrap();
+        e.u8(1).unwrap().str(rp).unwrap();
+        e.u8(2).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A fresh authenticator carrying one discoverable ES256 credential for `RP_ID`.
+fn authr_with_credential() -> Authr {
+    let mut a = Authr::fresh();
+    let r = a.send(CTAP_MAKE_CREDENTIAL, &mc_rk_request());
+    assert_ok(&r); // precondition, not the assertion under test
+    a
+}
+
+#[test]
+fn getassertion_response_envelope() {
+    let mut a = authr_with_credential();
+    let r = a.send(CTAP_GET_ASSERTION, &ga_request(RP_ID));
+    assert_ok(&r);
+    // Single discoverable credential → {1: credential, 2: authData, 3: sig, 4: user}.
+    assert_eq!(int_map_keys(&r.body), vec![1u32, 2, 3, 4]);
+    let mut d = field_at(&r.body, 1).expect("credential (0x01) present");
+    assert_eq!(
+        d.map().unwrap().unwrap(),
+        2,
+        "credential descriptor is {{id, type}}"
+    );
+    assert_eq!(d.str().unwrap(), "id");
+    assert!(!d.bytes().unwrap().is_empty(), "credential id present");
+    assert_eq!(d.str().unwrap(), "type");
+    assert_eq!(d.str().unwrap(), "public-key");
+}
+
+#[test]
+fn getassertion_authdata_and_user() {
+    let mut a = authr_with_credential();
+    let r = a.send(CTAP_GET_ASSERTION, &ga_request(RP_ID));
+
+    let mut d = field_at(&r.body, 2).expect("authData (0x02) present");
+    let ad = d.bytes().unwrap();
+    // Assertion authData is rpIdHash(32) | flags(1) | counter(4): no attested data.
+    assert!(
+        ad.len() >= 37,
+        "assertion authData must carry rpIdHash + flags + counter"
+    );
+    assert_eq!(
+        &ad[..32],
+        &sha256(RP_ID.as_bytes())[..],
+        "rpIdHash must be SHA-256(rpId)"
+    );
+    assert_eq!(ad[32] & FLAG_UP, FLAG_UP, "UP flag must be set");
+    assert_eq!(
+        ad[32] & FLAG_AT,
+        0,
+        "an assertion carries no attested credential data"
+    );
+
+    let mut s = field_at(&r.body, 3).expect("signature (0x03) present");
+    assert!(
+        !s.bytes().unwrap().is_empty(),
+        "assertion signature must be present"
+    );
+
+    let mut u = field_at(&r.body, 4).expect("user (0x04) present");
+    assert_eq!(
+        u.map().unwrap().unwrap(),
+        1,
+        "user is id-only without UV (§6.2.2 privacy)"
+    );
+    assert_eq!(u.str().unwrap(), "id");
+    assert_eq!(
+        u.bytes().unwrap(),
+        USER_ID,
+        "user handle must round-trip the registered id"
+    );
+}
+
+#[test]
+fn getassertion_no_credentials() {
+    // An assertion for an RP with no credentials → CTAP2_ERR_NO_CREDENTIALS (§6.2).
+    let r = Authr::fresh().send(CTAP_GET_ASSERTION, &ga_request("absent.example"));
+    assert_eq!(r.status, CtapError::NoCredentials.as_u8());
+    assert!(r.body.is_empty(), "an error response carries no CBOR body");
+}

--- a/crates/rsk-fido/src/conformance/getassertion.rs
+++ b/crates/rsk-fido/src/conformance/getassertion.rs
@@ -218,3 +218,29 @@ fn getnextassertion_walks_multiple_credentials() {
         "walk is exhausted"
     );
 }
+
+#[test]
+fn getassertion_signature_verifies() {
+    let mut a = Authr::fresh();
+    let mc = a.send(CTAP_MAKE_CREDENTIAL, &mc_rk_request());
+    assert_ok(&mc);
+    let (x, y) = {
+        let mut d = field_at(&mc.body, 2).expect("authData (0x02) present");
+        super::credential_pubkey(d.bytes().unwrap())
+    };
+
+    let g = a.send(CTAP_GET_ASSERTION, &ga_request(RP_ID));
+    assert_ok(&g);
+    let ad = {
+        let mut d = field_at(&g.body, 2).expect("authData (0x02) present");
+        d.bytes().unwrap().to_vec()
+    };
+    let sig = {
+        let mut d = field_at(&g.body, 3).expect("signature (0x03) present");
+        d.bytes().unwrap().to_vec()
+    };
+    // The assertion signs authData ‖ clientDataHash with the credential key.
+    let mut signed = ad;
+    signed.extend_from_slice(&[0xCD; 32]);
+    super::verify_p256(&x, &y, &signed, &sig);
+}

--- a/crates/rsk-fido/src/conformance/getinfo.rs
+++ b/crates/rsk-fido/src/conformance/getinfo.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.4 `authenticatorGetInfo` conformance assertions, driven through
+//! the wire envelope (`process_cbor`). The pilot for the host-side conformance
+//! layer; other commands fan out from the same harness.
+
+use super::{Authr, assert_ok, bool_map_canonical, field_at, int_map_keys};
+use crate::consts::{
+    AAGUID, ALG_EDDSA, ALG_ES256, ALG_ES256K, ALG_ES384, ALG_ES512, ALG_MLDSA44, FIRMWARE_VERSION,
+    MAX_CRED_ID_LENGTH, MAX_MSG_SIZE,
+};
+
+/// The exact set of getInfo members this build advertises, in canonical order.
+/// A new member must land here *and* in `metadata/rs-key.metadata.json` +
+/// `docs/protocol.md` — this test is the tripwire.
+const GETINFO_KEYS: [u32; 20] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+    0x14, 0x16, 0x1D, 0x1F,
+];
+
+#[test]
+fn getinfo_envelope_and_canonical() {
+    let r = Authr::fresh().get_info();
+    assert_ok(&r);
+    // Keys strictly ascending + no trailing bytes (checked inside int_map_keys),
+    // and exactly the advertised member set.
+    let keys = int_map_keys(&r.body);
+    assert_eq!(keys, GETINFO_KEYS, "getInfo top-level members changed");
+}
+
+#[test]
+fn getinfo_versions_and_aaguid() {
+    let r = Authr::fresh().get_info();
+
+    let mut d = field_at(&r.body, 0x01).expect("versions (0x01) present");
+    let n = d.array().unwrap().expect("versions is a definite array");
+    assert!(n >= 1, "versions must be non-empty");
+    let known = ["U2F_V2", "FIDO_2_0", "FIDO_2_1", "FIDO_2_2", "FIDO_2_3"];
+    let mut vers = Vec::new();
+    for _ in 0..n {
+        vers.push(d.str().unwrap().to_string());
+    }
+    for v in &vers {
+        assert!(known.contains(&v.as_str()), "unknown version string {v:?}");
+    }
+    // The CTAP2 baseline and the FIDO_2_1 surface must both be advertised.
+    assert!(vers.iter().any(|v| v == "FIDO_2_0"));
+    assert!(vers.iter().any(|v| v == "FIDO_2_1"));
+
+    let mut d = field_at(&r.body, 0x03).expect("aaguid (0x03) present");
+    let aaguid = d.bytes().unwrap();
+    assert_eq!(aaguid.len(), 16, "aaguid must be exactly 16 bytes");
+    assert_eq!(aaguid, &AAGUID[..], "aaguid must equal the model constant");
+}
+
+#[test]
+fn getinfo_options_dependencies() {
+    let r = Authr::fresh().get_info();
+    let mut d = field_at(&r.body, 0x04).expect("options (0x04) present");
+    // Canonical text-key order + every value a boolean.
+    let keys = bool_map_canonical(&mut d);
+    let has = |name: &str| keys.iter().any(|k| k == name);
+
+    for req in ["rk", "up", "clientPin", "pinUvAuthToken"] {
+        assert!(has(req), "required option {req:?} missing");
+    }
+    // CTAP 2.1 §6.4 dependency rules.
+    if has("pinUvAuthToken") {
+        assert!(
+            has("clientPin"),
+            "pinUvAuthToken implies the clientPin option"
+        );
+    }
+    assert!(
+        field_at(&r.body, 0x06).is_some(),
+        "clientPin support requires pinUvAuthProtocols (0x06)"
+    );
+    // No built-in UV on a screenless build → the uv option is omitted entirely.
+    assert!(!has("uv"), "uv option must be absent without built-in UV");
+}
+
+#[test]
+fn getinfo_algorithms_policy() {
+    let r = Authr::fresh().get_info();
+    let mut d = field_at(&r.body, 0x0A).expect("algorithms (0x0A) present");
+    let n = d.array().unwrap().expect("algorithms is a definite array");
+    assert!(n >= 1, "algorithms must be non-empty");
+    let mut algs = Vec::new();
+    for _ in 0..n {
+        assert_eq!(
+            d.map().unwrap().unwrap(),
+            2,
+            "each algorithm entry is a 2-key map"
+        );
+        assert_eq!(d.str().unwrap(), "alg");
+        algs.push(d.i64().unwrap());
+        assert_eq!(d.str().unwrap(), "type");
+        assert_eq!(d.str().unwrap(), "public-key");
+    }
+    for a in [ALG_ES256, ALG_ES384, ALG_ES512] {
+        assert!(algs.contains(&a), "NIST ECDSA curve {a} must be advertised");
+    }
+    // ES256K (-47) is never advertised (FIDO conformance MakeCred-Resp P-06).
+    assert!(
+        !algs.contains(&ALG_ES256K),
+        "ES256K (-47) must never be advertised"
+    );
+    // EdDSA is advertised by default, suppressed only under the conformance profile.
+    assert_eq!(
+        algs.contains(&ALG_EDDSA),
+        cfg!(not(feature = "fido-conformance")),
+        "EdDSA (-8) advertisement must track the fido-conformance feature"
+    );
+    // ML-DSA-44 only when explicitly opted in.
+    assert_eq!(
+        algs.contains(&ALG_MLDSA44),
+        cfg!(feature = "advertise-pqc"),
+        "ML-DSA-44 (-48) advertisement must track the advertise-pqc feature"
+    );
+}
+
+#[test]
+fn getinfo_limits_and_formats() {
+    let r = Authr::fresh().get_info();
+
+    let mut d = field_at(&r.body, 0x05).expect("maxMsgSize (0x05) present");
+    assert_eq!(d.u64().unwrap(), MAX_MSG_SIZE);
+
+    let mut d = field_at(&r.body, 0x08).expect("maxCredentialIdLength (0x08) present");
+    assert_eq!(
+        d.u64().unwrap(),
+        MAX_CRED_ID_LENGTH,
+        "maxCredentialIdLength must equal the credential-box ceiling (metadata must match)"
+    );
+
+    let mut d = field_at(&r.body, 0x06).expect("pinUvAuthProtocols (0x06) present");
+    let n = d.array().unwrap().unwrap();
+    assert!(n >= 1, "pinUvAuthProtocols must be non-empty");
+    for _ in 0..n {
+        let p = d.u32().unwrap();
+        assert!(p == 1 || p == 2, "unknown pinUvAuthProtocol {p}");
+    }
+
+    assert!(
+        str_array(&r.body, 0x09).iter().any(|s| s == "usb"),
+        "transports must include usb"
+    );
+    assert!(
+        str_array(&r.body, 0x16).iter().any(|s| s == "packed"),
+        "attestationFormats must include packed"
+    );
+
+    let mut d = field_at(&r.body, 0x1F).expect("authenticatorConfigCommands (0x1F) present");
+    let n = d.array().unwrap().unwrap();
+    let mut cmds = Vec::new();
+    for _ in 0..n {
+        cmds.push(d.u32().unwrap());
+    }
+    assert_eq!(cmds, vec![0x01u32, 0x02, 0x03]);
+
+    let mut d = field_at(&r.body, 0x0E).expect("firmwareVersion (0x0E) present");
+    assert_eq!(d.u32().unwrap(), FIRMWARE_VERSION);
+}
+
+/// Collect a getInfo text-string array member into owned strings.
+fn str_array(body: &[u8], key: u32) -> Vec<String> {
+    let mut d = field_at(body, key).expect("array field present");
+    let n = d.array().unwrap().expect("definite array");
+    let mut out = Vec::new();
+    for _ in 0..n {
+        out.push(d.str().unwrap().to_string());
+    }
+    out
+}

--- a/crates/rsk-fido/src/conformance/hmac.rs
+++ b/crates/rsk-fido/src/conformance/hmac.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §12.5 hmac-secret *evaluate* conformance, driven through the wire
+//! envelope (`process_cbor`): a credential is created with hmac-secret, then a
+//! getAssertion carries `{keyAgreement, saltEnc, saltAuth}` and the encrypted
+//! output decrypts (under the ECDH shared secret) to a 32-byte value that is
+//! deterministic per (credential, salt). The platform runs the real
+//! pinUvAuthProtocol-2 primitives.
+
+use super::{Authr, assert_ok, field_at};
+use crate::consts::{ALG_ES256, CTAP_CLIENT_PIN, CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL};
+use crate::cose::cose_key_ecdh;
+use minicbor::encode::write::Cursor;
+use minicbor::{Decoder, Encoder};
+use rsk_crypto::pinproto::{self, PinProto, public_xy};
+
+const RP_ID: &str = "hmac.example";
+const CDH: [u8; 32] = [0xCD; 32];
+const SALT: [u8; 32] = [0xA1; 32];
+
+/// The platform half of the ECDH exchange (a fixed key + the shared secret).
+struct Ecdh {
+    x: [u8; 32],
+    y: [u8; 32],
+    shared: Vec<u8>,
+}
+
+impl Ecdh {
+    fn establish(a: &mut Authr) -> Self {
+        // getKeyAgreement: {1: proto=2, 2: subCommand=2}.
+        let mut kbuf = [0u8; 16];
+        let kn = {
+            let mut e = Encoder::new(Cursor::new(&mut kbuf[..]));
+            e.map(2).unwrap();
+            e.u8(1).unwrap().u64(2).unwrap();
+            e.u8(2).unwrap().u64(2).unwrap();
+            e.writer().position()
+        };
+        let r = a.send(CTAP_CLIENT_PIN, &kbuf[..kn]);
+        let (ax, ay) = authenticator_public(&r.body);
+        let mut s = [0u8; 32];
+        s[0] = 0x13;
+        s[31] = 0x42;
+        let (x, y) = public_xy(&s).unwrap();
+        let mut shared = [0u8; 64];
+        let slen = pinproto::ecdh(PinProto::Two, &s, &ax, &ay, &mut shared).unwrap();
+        Ecdh {
+            x,
+            y,
+            shared: shared[..slen].to_vec(),
+        }
+    }
+
+    fn enc(&self, pt: &[u8]) -> Vec<u8> {
+        let mut out = [0u8; 96];
+        let n = pinproto::encrypt(PinProto::Two, &self.shared, &[0x55; 16], pt, &mut out).unwrap();
+        out[..n].to_vec()
+    }
+
+    fn mac(&self, data: &[u8]) -> Vec<u8> {
+        let mut out = [0u8; 32];
+        let n = pinproto::authenticate(PinProto::Two, &self.shared, data, &mut out).unwrap();
+        out[..n].to_vec()
+    }
+
+    fn decrypt(&self, ct: &[u8]) -> Vec<u8> {
+        let mut out = [0u8; 96];
+        let n = pinproto::decrypt(PinProto::Two, &self.shared, ct, &mut out).unwrap();
+        out[..n].to_vec()
+    }
+}
+
+/// The authenticator's key-agreement public key from getKeyAgreement.
+fn authenticator_public(body: &[u8]) -> ([u8; 32], [u8; 32]) {
+    let mut d = field_at(body, 1).expect("keyAgreement (0x01) present");
+    assert_eq!(d.map().unwrap().unwrap(), 5);
+    d.u8().unwrap();
+    d.u8().unwrap(); // 1: kty
+    d.u8().unwrap();
+    d.i64().unwrap(); // 3: alg
+    d.i8().unwrap();
+    d.u8().unwrap(); // -1: crv
+    d.i8().unwrap(); // -2: x label
+    let mut x = [0u8; 32];
+    x.copy_from_slice(d.bytes().unwrap());
+    d.i8().unwrap(); // -3: y label
+    let mut y = [0u8; 32];
+    y.copy_from_slice(d.bytes().unwrap());
+    (x, y)
+}
+
+/// A discoverable makeCredential over `RP_ID` requesting hmac-secret.
+fn mc_hmac() -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(6).unwrap();
+        e.u8(1).unwrap().bytes(&CDH).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[9, 9]).unwrap();
+        e.str("name").unwrap().str("grace").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(6)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("hmac-secret")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A getAssertion over `RP_ID` evaluating hmac-secret for `salt`.
+fn ga_hmac(ecdh: &Ecdh, salt: &[u8]) -> Vec<u8> {
+    let salt_enc = ecdh.enc(salt);
+    let salt_auth = ecdh.mac(&salt_enc);
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(3).unwrap();
+        e.u8(1).unwrap().str(RP_ID).unwrap();
+        e.u8(2).unwrap().bytes(&CDH).unwrap();
+        // extensions: { hmac-secret: { 1: keyAgreement, 2: saltEnc, 3: saltAuth, 4: proto } }
+        e.u8(4).unwrap().map(1).unwrap();
+        e.str("hmac-secret").unwrap().map(4).unwrap();
+        e.u8(1).unwrap();
+        cose_key_ecdh(&mut e, &ecdh.x, &ecdh.y).unwrap();
+        e.u8(2).unwrap().bytes(&salt_enc).unwrap();
+        e.u8(3).unwrap().bytes(&salt_auth).unwrap();
+        e.u8(4).unwrap().u64(2).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// The (still-encrypted) hmac-secret output from a getAssertion authData.
+fn hmac_output(body: &[u8]) -> Vec<u8> {
+    let mut d = field_at(body, 2).expect("authData (0x02) present");
+    let ad = d.bytes().unwrap();
+    // Assertion authData is rpIdHash(32) | flags(1) | counter(4) | extension map.
+    let mut ext = Decoder::new(&ad[37..]);
+    let n = ext.map().unwrap().unwrap();
+    for _ in 0..n {
+        if ext.str().unwrap() == "hmac-secret" {
+            return ext.bytes().unwrap().to_vec();
+        }
+        ext.skip().unwrap();
+    }
+    panic!("hmac-secret output missing from the assertion");
+}
+
+#[test]
+fn hmac_secret_evaluate_returns_output() {
+    let mut a = Authr::fresh();
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_hmac()));
+    let ecdh = Ecdh::establish(&mut a);
+    let g = a.send(CTAP_GET_ASSERTION, &ga_hmac(&ecdh, &SALT));
+    assert_ok(&g);
+    let out = ecdh.decrypt(&hmac_output(&g.body));
+    assert_eq!(
+        out.len(),
+        32,
+        "one salt yields a 32-byte hmac-secret output"
+    );
+}
+
+#[test]
+fn hmac_secret_is_deterministic_per_salt() {
+    let mut a = Authr::fresh();
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_hmac()));
+    let ecdh = Ecdh::establish(&mut a);
+
+    let out1 = ecdh.decrypt(&hmac_output(
+        &a.send(CTAP_GET_ASSERTION, &ga_hmac(&ecdh, &SALT)).body,
+    ));
+    let out2 = ecdh.decrypt(&hmac_output(
+        &a.send(CTAP_GET_ASSERTION, &ga_hmac(&ecdh, &SALT)).body,
+    ));
+    assert_eq!(out1, out2, "same salt → same hmac-secret output");
+
+    let salt2 = [0xB2u8; 32];
+    let other = ecdh.decrypt(&hmac_output(
+        &a.send(CTAP_GET_ASSERTION, &ga_hmac(&ecdh, &salt2)).body,
+    ));
+    assert_ne!(out1, other, "a different salt yields a different output");
+}

--- a/crates/rsk-fido/src/conformance/largeblobs.rs
+++ b/crates/rsk-fido/src/conformance/largeblobs.rs
@@ -6,11 +6,13 @@
 //! serialized array as `{1: bytes}`, `get=0` is a valid zero-byte read, and an
 //! out-of-range offset is rejected.
 
-use super::{Authr, assert_ok, field_at, int_map_keys};
+use super::{Authr, assert_ok, assert_ok_empty, field_at, int_map_keys, pin_auth};
 use crate::consts::{CTAP_LARGE_BLOBS, LARGEBLOB_MIN, MAX_LARGE_BLOB_SIZE};
 use crate::error::CtapError;
+use crate::state::PERM_LBW;
 use minicbor::Encoder;
 use minicbor::encode::write::Cursor;
+use rsk_crypto::sha256;
 
 /// A largeBlobs get request `{1: get, 3: offset}`.
 fn lb_get(offset: u64, get: u64) -> Vec<u8> {
@@ -58,4 +60,49 @@ fn largeblobs_offset_past_end_rejected() {
     // offset > size → CTAP2_ERR_INVALID_PARAMETER.
     let r = Authr::fresh().send(CTAP_LARGE_BLOBS, &lb_get(u64::from(u32::MAX), 1));
     assert_eq!(r.status, CtapError::InvalidParameter.as_u8());
+}
+
+/// A largeBlobs set request `{2: fragment, 3: offset, 4: length, 5: param, 6: proto}`.
+fn lb_set(set: &[u8], offset: u64, length: u64, param: &[u8]) -> Vec<u8> {
+    let mut buf = [0u8; 128];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(5).unwrap();
+        e.u8(2).unwrap().bytes(set).unwrap();
+        e.u8(3).unwrap().u64(offset).unwrap();
+        e.u8(4).unwrap().u64(length).unwrap();
+        e.u8(5).unwrap().bytes(param).unwrap();
+        e.u8(6).unwrap().u64(2).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+#[test]
+fn largeblobs_write_then_read() {
+    let mut a = Authr::fresh();
+    let token = a.arm_token(PERM_LBW);
+    // A valid serialized large-blob array: body followed by left16(SHA-256(body)).
+    let body = [0xAAu8; 20];
+    let mut blob = body.to_vec();
+    blob.extend_from_slice(&sha256(&body)[..16]);
+    // pinUvAuthParam over 0xff*32 ‖ 0x0c ‖ 0x00 ‖ offset_le(4) ‖ SHA-256(fragment).
+    let mut vd = [0u8; 70];
+    vd[..32].fill(0xff);
+    vd[32] = CTAP_LARGE_BLOBS;
+    vd[38..70].copy_from_slice(&sha256(&blob));
+    let param = pin_auth(&token, &vd);
+
+    assert_ok_empty(&a.send(
+        CTAP_LARGE_BLOBS,
+        &lb_set(&blob, 0, blob.len() as u64, &param),
+    ));
+    // The written array reads back verbatim.
+    let g = a.send(CTAP_LARGE_BLOBS, &lb_get(0, MAX_LARGE_BLOB_SIZE as u64));
+    let mut d = field_at(&g.body, 1).expect("config fragment (0x01) present");
+    assert_eq!(
+        d.bytes().unwrap(),
+        &blob[..],
+        "the stored array round-trips"
+    );
 }

--- a/crates/rsk-fido/src/conformance/largeblobs.rs
+++ b/crates/rsk-fido/src/conformance/largeblobs.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.10 `authenticatorLargeBlobs` conformance for the ungated read,
+//! driven through the wire envelope (`process_cbor`): a full get returns the
+//! serialized array as `{1: bytes}`, `get=0` is a valid zero-byte read, and an
+//! out-of-range offset is rejected.
+
+use super::{Authr, assert_ok, field_at, int_map_keys};
+use crate::consts::{CTAP_LARGE_BLOBS, LARGEBLOB_MIN, MAX_LARGE_BLOB_SIZE};
+use crate::error::CtapError;
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+
+/// A largeBlobs get request `{1: get, 3: offset}`.
+fn lb_get(offset: u64, get: u64) -> Vec<u8> {
+    let mut buf = [0u8; 32];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(2).unwrap();
+        e.u8(1).unwrap().u64(get).unwrap();
+        e.u8(3).unwrap().u64(offset).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+#[test]
+fn largeblobs_get_full_array() {
+    // A full read returns the serialized large-blob array as {1: bytes}; a fresh
+    // device carries at least the 17-byte initial trailer (empty array + hash).
+    let r = Authr::fresh().send(CTAP_LARGE_BLOBS, &lb_get(0, MAX_LARGE_BLOB_SIZE as u64));
+    assert_ok(&r);
+    assert_eq!(int_map_keys(&r.body), vec![1u32]);
+    let mut d = field_at(&r.body, 1).expect("config fragment (0x01) present");
+    let frag = d.bytes().unwrap();
+    assert!(
+        frag.len() >= LARGEBLOB_MIN,
+        "initial array carries the minimum trailer"
+    );
+    assert!(
+        frag.len() <= MAX_LARGE_BLOB_SIZE,
+        "fragment within the advertised max"
+    );
+}
+
+#[test]
+fn largeblobs_get_zero_length_is_valid() {
+    // get=0 is a valid zero-byte read (conformance LargeBlobs-1 P-2).
+    let r = Authr::fresh().send(CTAP_LARGE_BLOBS, &lb_get(0, 0));
+    assert_ok(&r);
+    let mut d = field_at(&r.body, 1).expect("config fragment (0x01) present");
+    assert_eq!(d.bytes().unwrap().len(), 0);
+}
+
+#[test]
+fn largeblobs_offset_past_end_rejected() {
+    // offset > size → CTAP2_ERR_INVALID_PARAMETER.
+    let r = Authr::fresh().send(CTAP_LARGE_BLOBS, &lb_get(u64::from(u32::MAX), 1));
+    assert_eq!(r.status, CtapError::InvalidParameter.as_u8());
+}

--- a/crates/rsk-fido/src/conformance/makecredential.rs
+++ b/crates/rsk-fido/src/conformance/makecredential.rs
@@ -45,6 +45,35 @@ fn mc_request(alg: i64) -> Vec<u8> {
     buf[..n].to_vec()
 }
 
+/// A makeCredential over `RP_ID` whose excludeList (key 5) names `cred_id`.
+fn mc_request_exclude(cred_id: &[u8]) -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(5).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[1, 2, 3, 4]).unwrap();
+        e.str("name").unwrap().str("alice").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(5).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.str("id").unwrap().bytes(cred_id).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
 fn make_es256() -> Resp {
     Authr::fresh().send(CTAP_MAKE_CREDENTIAL, &mc_request(ALG_ES256))
 }
@@ -130,4 +159,20 @@ fn makecred_unsupported_algorithm_rejected() {
     let r = Authr::fresh().send(CTAP_MAKE_CREDENTIAL, &mc_request(-257));
     assert_eq!(r.status, CtapError::UnsupportedAlgorithm.as_u8());
     assert!(r.body.is_empty(), "an error response carries no CBOR body");
+}
+
+#[test]
+fn makecred_exclude_list_rejects_existing() {
+    let mut a = Authr::fresh();
+    let r1 = a.send(CTAP_MAKE_CREDENTIAL, &mc_request(ALG_ES256));
+    assert_ok(&r1);
+    let cred_id = {
+        let mut d = field_at(&r1.body, 2).expect("authData (0x02) present");
+        let ad = d.bytes().unwrap();
+        let cl = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+        ad[55..55 + cl].to_vec()
+    };
+    // Re-registering with that credential in excludeList → CREDENTIAL_EXCLUDED (§6.1).
+    let r2 = a.send(CTAP_MAKE_CREDENTIAL, &mc_request_exclude(&cred_id));
+    assert_eq!(r2.status, CtapError::CredentialExcluded.as_u8());
 }

--- a/crates/rsk-fido/src/conformance/makecredential.rs
+++ b/crates/rsk-fido/src/conformance/makecredential.rs
@@ -176,3 +176,25 @@ fn makecred_exclude_list_rejects_existing() {
     let r2 = a.send(CTAP_MAKE_CREDENTIAL, &mc_request_exclude(&cred_id));
     assert_eq!(r2.status, CtapError::CredentialExcluded.as_u8());
 }
+
+#[test]
+fn makecred_attestation_signature_verifies() {
+    let r = make_es256();
+    let ad = {
+        let mut d = field_at(&r.body, 2).expect("authData (0x02) present");
+        d.bytes().unwrap().to_vec()
+    };
+    let (x, y) = super::credential_pubkey(&ad);
+    let sig = {
+        let mut d = field_at(&r.body, 3).expect("attStmt (0x03) present");
+        assert_eq!(d.map().unwrap().unwrap(), 2);
+        assert_eq!(d.str().unwrap(), "alg");
+        d.i64().unwrap();
+        assert_eq!(d.str().unwrap(), "sig");
+        d.bytes().unwrap().to_vec()
+    };
+    // Packed self-attestation signs authData ‖ clientDataHash with the credential key.
+    let mut signed = ad;
+    signed.extend_from_slice(&[0xCD; 32]);
+    super::verify_p256(&x, &y, &signed, &sig);
+}

--- a/crates/rsk-fido/src/conformance/makecredential.rs
+++ b/crates/rsk-fido/src/conformance/makecredential.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.1 `authenticatorMakeCredential` conformance assertions, driven
+//! through the wire envelope (`process_cbor`): the attestation-object shape, the
+//! authenticator-data layout, the packed self-attestation statement, and the
+//! unsupported-algorithm rejection. A no-PIN request is user-presence-only, so
+//! `AlwaysConfirm` satisfies it without arming a token.
+
+use super::{Authr, Resp, assert_ok, field_at, int_map_keys};
+use crate::consts::{
+    AAGUID, ALG_ES256, CTAP_MAKE_CREDENTIAL, FLAG_AT, FLAG_UP, MAX_CRED_ID_LENGTH,
+};
+use crate::error::CtapError;
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+use rsk_crypto::sha256;
+
+const RP_ID: &str = "example.com";
+
+/// A minimal single-algorithm makeCredential request over `RP_ID` (keys 1–4:
+/// clientDataHash, rp, user, pubKeyCredParams).
+fn mc_request(alg: i64) -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(4).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[1, 2, 3, 4]).unwrap();
+        e.str("name").unwrap().str("alice").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(alg).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+fn make_es256() -> Resp {
+    Authr::fresh().send(CTAP_MAKE_CREDENTIAL, &mc_request(ALG_ES256))
+}
+
+#[test]
+fn makecred_response_envelope() {
+    let r = make_es256();
+    assert_ok(&r);
+    // Attestation object: exactly {1: fmt, 2: authData, 3: attStmt}, canonical.
+    assert_eq!(int_map_keys(&r.body), vec![1u32, 2, 3]);
+    let mut d = field_at(&r.body, 1).expect("fmt (0x01) present");
+    assert_eq!(
+        d.str().unwrap(),
+        "packed",
+        "attestation format must be packed"
+    );
+}
+
+#[test]
+fn makecred_authdata_structure() {
+    let r = make_es256();
+    let mut d = field_at(&r.body, 2).expect("authData (0x02) present");
+    let ad = d.bytes().unwrap();
+    // rpIdHash(32) | flags(1) | counter(4) | aaguid(16) | credLen(2) | credId | COSE key
+    assert!(
+        ad.len() >= 55,
+        "authData too short for attested credential data"
+    );
+    assert_eq!(
+        &ad[..32],
+        &sha256(RP_ID.as_bytes())[..],
+        "rpIdHash must be SHA-256(rpId)"
+    );
+    assert_eq!(
+        ad[32] & (FLAG_AT | FLAG_UP),
+        FLAG_AT | FLAG_UP,
+        "AT (attested data) and UP (user present) flags must be set"
+    );
+    assert_eq!(
+        &ad[37..53],
+        &AAGUID[..],
+        "attested aaguid must equal the model constant"
+    );
+    let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    assert!(cred_len > 0, "credential id must be non-empty");
+    assert!(
+        cred_len <= MAX_CRED_ID_LENGTH as usize,
+        "credential id exceeds the advertised ceiling"
+    );
+    assert!(
+        ad.len() >= 55 + cred_len,
+        "authData truncated before the COSE public key"
+    );
+}
+
+#[test]
+fn makecred_attestation_statement() {
+    let r = make_es256();
+    let mut d = field_at(&r.body, 3).expect("attStmt (0x03) present");
+    // Packed self-attestation is exactly {alg, sig} — no x5c chain.
+    assert_eq!(
+        d.map().unwrap().unwrap(),
+        2,
+        "self-attestation attStmt is {{alg, sig}}"
+    );
+    assert_eq!(d.str().unwrap(), "alg");
+    assert_eq!(
+        d.i64().unwrap(),
+        ALG_ES256,
+        "attStmt alg must match the credential key"
+    );
+    assert_eq!(d.str().unwrap(), "sig");
+    assert!(
+        !d.bytes().unwrap().is_empty(),
+        "attStmt signature must be present"
+    );
+}
+
+#[test]
+fn makecred_unsupported_algorithm_rejected() {
+    // A request whose only pubKeyCredParams entry is an unsupported COSE id (RS256,
+    // -257) must fail with CTAP2_ERR_UNSUPPORTED_ALGORITHM (CTAP 2.1 §6.1).
+    let r = Authr::fresh().send(CTAP_MAKE_CREDENTIAL, &mc_request(-257));
+    assert_eq!(r.status, CtapError::UnsupportedAlgorithm.as_u8());
+    assert!(r.body.is_empty(), "an error response carries no CBOR body");
+}

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -13,7 +13,10 @@ use super::*;
 use minicbor::Decoder;
 use rsk_fs::storage::ram::RamStorage;
 
+mod clientpin;
+mod getassertion;
 mod getinfo;
+mod makecredential;
 
 /// Deterministic RNG (copied per test file, matching the repo convention).
 struct SeqRng(u64);

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -24,6 +24,7 @@ mod credprotect;
 mod extensions;
 mod getassertion;
 mod getinfo;
+mod hmac;
 mod largeblobs;
 mod makecredential;
 mod pin;

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -10,9 +10,12 @@
 //! so a protocol regression fails at commit time, not on a flashed board.
 
 use super::*;
+use crate::u2f::process_u2f;
 use minicbor::Decoder;
 use rsk_crypto::pinproto::PinProto;
 use rsk_fs::storage::ram::RamStorage;
+use rsk_sdk::apdu::Apdu;
+use rsk_sdk::sw::Sw;
 
 mod clientpin;
 mod config;
@@ -24,6 +27,7 @@ mod largeblobs;
 mod makecredential;
 mod reset;
 mod selection;
+mod u2f;
 
 /// Deterministic RNG (copied per test file, matching the repo convention).
 struct SeqRng(u64);
@@ -135,6 +139,28 @@ impl Authr {
         self.state.paut.permissions = permissions;
         self.state.begin_using_token(false);
         token
+    }
+
+    /// Send a raw U2F (CTAP1) APDU and return its status word and response body.
+    /// U2F answers with `(Sw, body)` rather than the CTAP2 status-byte envelope.
+    fn send_u2f(&mut self, raw: &[u8]) -> (Sw, Vec<u8>) {
+        let apdu = Apdu::parse(raw).unwrap();
+        let mut out = [0u8; 1024];
+        let mut yes = AlwaysConfirm;
+        let mut no = Decline;
+        let presence: &mut dyn UserPresence = if self.confirm { &mut yes } else { &mut no };
+        let (sw, n) = {
+            let mut ctx = Ctx {
+                dev: dev(),
+                fs: &mut self.fs,
+                rng: &mut self.rng,
+                state: &mut self.state,
+                now_ms: 0,
+                presence,
+            };
+            process_u2f(&mut ctx, &apdu, &mut out)
+        };
+        (sw, out[..n].to_vec())
     }
 }
 

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -11,9 +11,12 @@
 
 use super::*;
 use minicbor::Decoder;
+use rsk_crypto::pinproto::PinProto;
 use rsk_fs::storage::ram::RamStorage;
 
 mod clientpin;
+mod credmgmt;
+mod credprotect;
 mod getassertion;
 mod getinfo;
 mod makecredential;
@@ -93,6 +96,30 @@ impl Authr {
     fn get_info(&mut self) -> Resp {
         self.send(consts::CTAP_GET_INFO, &[])
     }
+
+    /// Arm a live pinUvAuthToken with `permissions` and mark a PIN configured;
+    /// returns the token so a caller can MAC a message with [`pin_auth`]. Call
+    /// AFTER any up-only registration — a configured PIN gates a bare
+    /// makeCredential. Mirrors `getassertion_tests::arm_pin`.
+    fn arm_token(&mut self, permissions: u8) -> [u8; 32] {
+        let mut pin_file = [0u8; 35];
+        pin_file[0] = 8; // retries
+        pin_file[1] = 4; // min length
+        pin_file[2] = 1;
+        self.fs.put(consts::EF_PIN, &pin_file).unwrap();
+        let token = [0x99u8; 32];
+        self.state.paut.token = token;
+        self.state.paut.permissions = permissions;
+        self.state.begin_using_token(false);
+        token
+    }
+}
+
+/// A protocol-2 `pinUvAuthParam`: the HMAC of `msg` under the armed `token`.
+fn pin_auth(token: &[u8; 32], msg: &[u8]) -> Vec<u8> {
+    let mut out = [0u8; 48];
+    let n = rsk_crypto::pinproto::authenticate(PinProto::Two, token, msg, &mut out).unwrap();
+    out[..n].to_vec()
 }
 
 /// A successful response carries `CTAP2_OK` and a non-empty CBOR body.

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -12,6 +12,8 @@
 use super::*;
 use crate::u2f::process_u2f;
 use minicbor::Decoder;
+use p256::EncodedPoint;
+use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
 use rsk_crypto::pinproto::PinProto;
 use rsk_fs::storage::ram::RamStorage;
 use rsk_sdk::apdu::Apdu;
@@ -273,4 +275,34 @@ fn bool_map_canonical(d: &mut Decoder) -> Vec<String> {
 /// bytewise.
 fn canonical_lt(a: &str, b: &str) -> bool {
     (a.len(), a.as_bytes()) < (b.len(), b.as_bytes())
+}
+
+/// Assert an ECDSA P-256 signature (`der_sig`) over `msg` verifies under the
+/// public key `(x, y)` — the cryptographic check a conformance tool performs.
+fn verify_p256(x: &[u8], y: &[u8], msg: &[u8], der_sig: &[u8]) {
+    let pt = EncodedPoint::from_affine_coordinates(x.into(), y.into(), false);
+    let vk = VerifyingKey::from_encoded_point(&pt).unwrap();
+    vk.verify(msg, &Signature::from_der(der_sig).unwrap())
+        .expect("P-256 signature verifies under the given public key");
+}
+
+/// The credential COSE public key `(x, y)` embedded in a makeCredential authData
+/// (`{1:2, 3:alg, -1:crv, -2:x, -3:y}` after the attested-credential-data header).
+fn credential_pubkey(ad: &[u8]) -> ([u8; 32], [u8; 32]) {
+    let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    let mut d = Decoder::new(&ad[55 + cred_len..]);
+    assert_eq!(d.map().unwrap().unwrap(), 5);
+    d.u8().unwrap();
+    d.u8().unwrap(); // 1: kty
+    d.u8().unwrap();
+    d.i64().unwrap(); // 3: alg
+    d.i8().unwrap();
+    d.u8().unwrap(); // -1: crv
+    d.i8().unwrap(); // -2: x label
+    let mut x = [0u8; 32];
+    x.copy_from_slice(d.bytes().unwrap());
+    d.i8().unwrap(); // -3: y label
+    let mut y = [0u8; 32];
+    y.copy_from_slice(d.bytes().unwrap());
+    (x, y)
 }

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -15,11 +15,15 @@ use rsk_crypto::pinproto::PinProto;
 use rsk_fs::storage::ram::RamStorage;
 
 mod clientpin;
+mod config;
 mod credmgmt;
 mod credprotect;
 mod getassertion;
 mod getinfo;
+mod largeblobs;
 mod makecredential;
+mod reset;
+mod selection;
 
 /// Deterministic RNG (copied per test file, matching the repo convention).
 struct SeqRng(u64);
@@ -40,6 +44,14 @@ fn dev() -> Device<'static> {
     }
 }
 
+/// A user-presence backend that never confirms — a button left untouched.
+struct Decline;
+impl UserPresence for Decline {
+    fn request(&mut self, _confirm: Confirm<'_>) -> Presence {
+        Presence::Timeout
+    }
+}
+
 /// One CTAP2 reply as seen on the wire: the leading status byte and, on success,
 /// the CBOR payload that follows it.
 struct Resp {
@@ -53,7 +65,8 @@ struct Authr {
     fs: Fs<RamStorage>,
     state: FidoState,
     rng: SeqRng,
-    presence: AlwaysConfirm,
+    /// Whether presence requests confirm (`AlwaysConfirm`) or time out (`Decline`).
+    confirm: bool,
 }
 
 impl Authr {
@@ -66,8 +79,15 @@ impl Authr {
             fs,
             state: FidoState::new(),
             rng,
-            presence: AlwaysConfirm,
+            confirm: true,
         }
+    }
+
+    /// Like [`fresh`](Self::fresh) but every presence request times out.
+    fn declining() -> Self {
+        let mut a = Self::fresh();
+        a.confirm = false;
+        a
     }
 
     /// Send `command_byte ‖ params` through the dispatcher and capture the reply.
@@ -75,6 +95,9 @@ impl Authr {
         let mut data = vec![cmd];
         data.extend_from_slice(params);
         let mut out = [0u8; 2048];
+        let mut yes = AlwaysConfirm;
+        let mut no = Decline;
+        let presence: &mut dyn UserPresence = if self.confirm { &mut yes } else { &mut no };
         let n = {
             let mut ctx = Ctx {
                 dev: dev(),
@@ -82,7 +105,7 @@ impl Authr {
                 rng: &mut self.rng,
                 state: &mut self.state,
                 now_ms: 0,
-                presence: &mut self.presence,
+                presence,
             };
             process_cbor(&mut ctx, &data, &mut out)
         };
@@ -133,6 +156,16 @@ fn assert_ok(r: &Resp) {
         !r.body.is_empty(),
         "a CTAP2_OK response must carry a payload"
     );
+}
+
+/// A successful response with no CBOR payload (selection, reset, authenticatorConfig).
+fn assert_ok_empty(r: &Resp) {
+    assert_eq!(
+        r.status, CTAP2_OK,
+        "expected CTAP2_OK, got status 0x{:02x}",
+        r.status
+    );
+    assert!(r.body.is_empty(), "this command returns no CBOR payload");
 }
 
 /// Decode a definite-length map with unsigned-integer keys; assert the keys are

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -30,6 +30,7 @@ mod getinfo;
 mod hmac;
 mod largeblobs;
 mod makecredential;
+mod multialg;
 mod pin;
 mod reset;
 mod selection;

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! Host-side CTAP2 conformance layer. Unlike the per-command `*_tests.rs` (which
+//! call the command functions directly), these tests drive the full
+//! `process_cbor` dispatcher and assert the *wire envelope* a host observes —
+//! the normative CTAP 2.1 §6.4+ structural rules a conformance tool checks
+//! (canonical CBOR key order, field types, cross-field dependencies, no unknown
+//! or trailing bytes). Re-derived from the public spec: host-only, no hardware,
+//! so a protocol regression fails at commit time, not on a flashed board.
+
+use super::*;
+use minicbor::Decoder;
+use rsk_fs::storage::ram::RamStorage;
+
+mod getinfo;
+
+/// Deterministic RNG (copied per test file, matching the repo convention).
+struct SeqRng(u64);
+impl Rng for SeqRng {
+    fn fill(&mut self, buf: &mut [u8]) {
+        for b in buf.iter_mut() {
+            self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+            *b = (self.0 >> 33) as u8;
+        }
+    }
+}
+
+fn dev() -> Device<'static> {
+    Device {
+        serial_hash: &[0xAB; 32],
+        serial_id: &[1, 2, 3, 4, 5, 6, 7, 8],
+        otp_key: None,
+    }
+}
+
+/// One CTAP2 reply as seen on the wire: the leading status byte and, on success,
+/// the CBOR payload that follows it.
+struct Resp {
+    status: u8,
+    body: Vec<u8>,
+}
+
+/// A host-side authenticator under test — a fresh flash + FIDO state that CTAP2
+/// commands run against, driven through the real `process_cbor` dispatcher.
+struct Authr {
+    fs: Fs<RamStorage>,
+    state: FidoState,
+    rng: SeqRng,
+    presence: AlwaysConfirm,
+}
+
+impl Authr {
+    /// A freshly-provisioned authenticator: seed ensured, no PIN, no credentials.
+    fn fresh() -> Self {
+        let mut fs = Fs::new(RamStorage::new(), &[]);
+        let mut rng = SeqRng(1);
+        crate::seed::ensure_seed(&dev(), &mut fs, &mut rng).unwrap();
+        Authr {
+            fs,
+            state: FidoState::new(),
+            rng,
+            presence: AlwaysConfirm,
+        }
+    }
+
+    /// Send `command_byte ‖ params` through the dispatcher and capture the reply.
+    fn send(&mut self, cmd: u8, params: &[u8]) -> Resp {
+        let mut data = vec![cmd];
+        data.extend_from_slice(params);
+        let mut out = [0u8; 2048];
+        let n = {
+            let mut ctx = Ctx {
+                dev: dev(),
+                fs: &mut self.fs,
+                rng: &mut self.rng,
+                state: &mut self.state,
+                now_ms: 0,
+                presence: &mut self.presence,
+            };
+            process_cbor(&mut ctx, &data, &mut out)
+        };
+        assert!(n >= 1, "process_cbor must write at least a status byte");
+        Resp {
+            status: out[0],
+            body: out[1..n].to_vec(),
+        }
+    }
+
+    fn get_info(&mut self) -> Resp {
+        self.send(consts::CTAP_GET_INFO, &[])
+    }
+}
+
+/// A successful response carries `CTAP2_OK` and a non-empty CBOR body.
+fn assert_ok(r: &Resp) {
+    assert_eq!(
+        r.status, CTAP2_OK,
+        "expected CTAP2_OK, got status 0x{:02x}",
+        r.status
+    );
+    assert!(
+        !r.body.is_empty(),
+        "a CTAP2_OK response must carry a payload"
+    );
+}
+
+/// Decode a definite-length map with unsigned-integer keys; assert the keys are
+/// strictly ascending (CTAP canonical order) with no trailing bytes, and return
+/// them in order.
+fn int_map_keys(body: &[u8]) -> Vec<u32> {
+    let mut d = Decoder::new(body);
+    let n = d.map().unwrap().expect("definite-length map");
+    let mut keys = Vec::new();
+    let mut prev: Option<u32> = None;
+    for _ in 0..n {
+        let k = d.u32().unwrap();
+        if let Some(p) = prev {
+            assert!(
+                k > p,
+                "map keys not strictly ascending: 0x{p:02x} then 0x{k:02x}"
+            );
+        }
+        prev = Some(k);
+        keys.push(k);
+        d.skip().unwrap();
+    }
+    assert_eq!(
+        d.position(),
+        body.len(),
+        "unexpected trailing bytes after map"
+    );
+    keys
+}
+
+/// Return a decoder positioned at the value of integer `key` in a top-level map,
+/// or `None` if the key is absent.
+fn field_at(body: &[u8], key: u32) -> Option<Decoder<'_>> {
+    let mut d = Decoder::new(body);
+    let n = d.map().ok()??;
+    for _ in 0..n {
+        let k = d.u32().ok()?;
+        let vpos = d.position();
+        if k == key {
+            return Some(Decoder::new(&body[vpos..]));
+        }
+        d.skip().ok()?;
+    }
+    None
+}
+
+/// Walk a map whose keys are text and whose values are all booleans; assert
+/// canonical key order (length, then bytewise) and return the keys in order.
+fn bool_map_canonical(d: &mut Decoder) -> Vec<String> {
+    let n = d.map().unwrap().expect("definite-length map");
+    let mut keys = Vec::new();
+    let mut prev: Option<String> = None;
+    for _ in 0..n {
+        let k = d.str().unwrap().to_string();
+        d.bool().unwrap(); // every option value must decode as a boolean
+        if let Some(p) = &prev {
+            assert!(
+                canonical_lt(p, &k),
+                "text keys not in canonical order: {p:?} then {k:?}"
+            );
+        }
+        prev = Some(k.clone());
+        keys.push(k);
+    }
+    keys
+}
+
+/// CTAP canonical CBOR key order for text keys: shorter encodings first, then
+/// bytewise.
+fn canonical_lt(a: &str, b: &str) -> bool {
+    (a.len(), a.as_bytes()) < (b.len(), b.as_bytes())
+}

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -23,6 +23,7 @@ mod clientpin;
 mod config;
 mod credmgmt;
 mod credprotect;
+mod errors;
 mod extensions;
 mod getassertion;
 mod getinfo;

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -26,6 +26,7 @@ mod getassertion;
 mod getinfo;
 mod largeblobs;
 mod makecredential;
+mod pin;
 mod reset;
 mod selection;
 mod u2f;

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -21,6 +21,7 @@ mod clientpin;
 mod config;
 mod credmgmt;
 mod credprotect;
+mod extensions;
 mod getassertion;
 mod getinfo;
 mod largeblobs;

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -72,6 +72,8 @@ struct Authr {
     rng: SeqRng,
     /// Whether presence requests confirm (`AlwaysConfirm`) or time out (`Decline`).
     confirm: bool,
+    /// Monotonic clock (ms), advanced per command so credential timestamps differ.
+    clock: u64,
 }
 
 impl Authr {
@@ -85,6 +87,7 @@ impl Authr {
             state: FidoState::new(),
             rng,
             confirm: true,
+            clock: 0,
         }
     }
 
@@ -99,6 +102,8 @@ impl Authr {
     fn send(&mut self, cmd: u8, params: &[u8]) -> Resp {
         let mut data = vec![cmd];
         data.extend_from_slice(params);
+        self.clock += 1000;
+        let now_ms = self.clock;
         let mut out = [0u8; 2048];
         let mut yes = AlwaysConfirm;
         let mut no = Decline;
@@ -109,7 +114,7 @@ impl Authr {
                 fs: &mut self.fs,
                 rng: &mut self.rng,
                 state: &mut self.state,
-                now_ms: 0,
+                now_ms,
                 presence,
             };
             process_cbor(&mut ctx, &data, &mut out)
@@ -146,6 +151,8 @@ impl Authr {
     /// U2F answers with `(Sw, body)` rather than the CTAP2 status-byte envelope.
     fn send_u2f(&mut self, raw: &[u8]) -> (Sw, Vec<u8>) {
         let apdu = Apdu::parse(raw).unwrap();
+        self.clock += 1000;
+        let now_ms = self.clock;
         let mut out = [0u8; 1024];
         let mut yes = AlwaysConfirm;
         let mut no = Decline;
@@ -156,7 +163,7 @@ impl Authr {
                 fs: &mut self.fs,
                 rng: &mut self.rng,
                 state: &mut self.state,
-                now_ms: 0,
+                now_ms,
                 presence,
             };
             process_u2f(&mut ctx, &apdu, &mut out)

--- a/crates/rsk-fido/src/conformance/multialg.rs
+++ b/crates/rsk-fido/src/conformance/multialg.rs
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! Multi-algorithm create+assert conformance, driven end-to-end through the wire
+//! envelope (`process_cbor`). For each COSE algorithm the authenticator supports
+//! by default (ES256/384/512, EdDSA) this registers a credential, then logs in
+//! with it, and cryptographically verifies both signatures a conformance tool
+//! checks: the packed self-attestation (CTAP 2.1 §6.1, over authData ‖ CDH) and
+//! the assertion (§6.2). It also asserts the per-curve COSE public-key shape
+//! (kty/crv/coordinate width). The sibling `ec_tests.rs`/`getassertion_tests.rs`
+//! prove the curves at the module and command-fn level; this proves them across
+//! the full dispatcher, the surface a host actually observes.
+
+use super::{Authr, assert_ok, field_at, int_map_keys};
+use crate::consts::{
+    ALG_EDDSA, ALG_ES256, ALG_ES384, ALG_ES512, CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL,
+    CURVE_ED25519, CURVE_P256, CURVE_P384, CURVE_P521, FLAG_AT, FLAG_UP,
+};
+use minicbor::Decoder;
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+use rsk_crypto::sha256;
+
+const RP_ID: &str = "example.com";
+/// The fixed clientDataHash every request in this module carries.
+const CDH: [u8; 32] = [0xCD; 32];
+
+/// COSE key types (RFC 9053 §7): OKP for Ed25519, EC2 for the NIST curves.
+const KTY_OKP: u8 = 1;
+const KTY_EC2: u8 = 2;
+
+/// One algorithm's wire fingerprint: the COSE id offered in pubKeyCredParams and
+/// the credential public-key shape it must yield in attestedCredentialData.
+struct AlgSpec {
+    name: &'static str,
+    alg: i64,
+    kty: u8,
+    crv: u8,
+    /// EC2 field-element width; for OKP the compressed-point length.
+    coord: usize,
+}
+
+const ES256: AlgSpec = AlgSpec {
+    name: "ES256",
+    alg: ALG_ES256,
+    kty: KTY_EC2,
+    crv: CURVE_P256,
+    coord: 32,
+};
+const ES384: AlgSpec = AlgSpec {
+    name: "ES384",
+    alg: ALG_ES384,
+    kty: KTY_EC2,
+    crv: CURVE_P384,
+    coord: 48,
+};
+const ES512: AlgSpec = AlgSpec {
+    name: "ES512",
+    alg: ALG_ES512,
+    kty: KTY_EC2,
+    crv: CURVE_P521,
+    coord: 66,
+};
+const EDDSA: AlgSpec = AlgSpec {
+    name: "EdDSA",
+    alg: ALG_EDDSA,
+    kty: KTY_OKP,
+    crv: CURVE_ED25519,
+    coord: 32,
+};
+
+/// A parsed credential public key, enough to verify a signature under it.
+enum CoseKey {
+    Ec2 { x: Vec<u8>, y: Vec<u8> },
+    Okp { x: [u8; 32] },
+}
+
+/// A single-algorithm, non-discoverable makeCredential request over `RP_ID`
+/// (keys 1–4: clientDataHash, rp, user, pubKeyCredParams).
+fn mc_request(alg: i64) -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(4).unwrap();
+        e.u8(1).unwrap().bytes(&CDH).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[1, 2, 3, 4]).unwrap();
+        e.str("name").unwrap().str("alice").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(alg).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A getAssertion request over `RP_ID` whose allowList names `cred_id`
+/// (keys 1–3: rpId, clientDataHash, allowList).
+fn ga_request(cred_id: &[u8]) -> Vec<u8> {
+    let mut buf = [0u8; 512];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(3).unwrap();
+        e.u8(1).unwrap().str(RP_ID).unwrap();
+        e.u8(2).unwrap().bytes(&CDH).unwrap();
+        e.u8(3).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.str("id").unwrap().bytes(cred_id).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// The authData byte string at key 2 of a makeCredential or getAssertion reply.
+fn authdata(body: &[u8]) -> Vec<u8> {
+    let mut d = field_at(body, 2).expect("authData (0x02) present");
+    d.bytes().unwrap().to_vec()
+}
+
+/// The credential id carried inline in a makeCredential authData.
+fn cred_id_of(ad: &[u8]) -> Vec<u8> {
+    let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    ad[55..55 + cred_len].to_vec()
+}
+
+/// The `(alg, sig)` of a packed self-attestation statement (key 3), asserting the
+/// canonical `{alg, sig}` shape (no x5c chain for self-attestation).
+fn att_stmt(body: &[u8]) -> (i64, Vec<u8>) {
+    let mut d = field_at(body, 3).expect("attStmt (0x03) present");
+    assert_eq!(
+        d.map().unwrap().unwrap(),
+        2,
+        "self-attestation attStmt is {{alg, sig}}"
+    );
+    assert_eq!(d.str().unwrap(), "alg");
+    let alg = d.i64().unwrap();
+    assert_eq!(d.str().unwrap(), "sig");
+    (alg, d.bytes().unwrap().to_vec())
+}
+
+/// The assertion signature byte string at key 3 of a getAssertion reply.
+fn assertion_sig(body: &[u8]) -> Vec<u8> {
+    let mut d = field_at(body, 3).expect("signature (0x03) present");
+    d.bytes().unwrap().to_vec()
+}
+
+/// Parse the credential COSE public key from the tail of a makeCredential
+/// authData, asserting the algorithm's expected kty/crv/coordinate width.
+fn cose_key(spec: &AlgSpec, ad: &[u8]) -> CoseKey {
+    let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    let mut d = Decoder::new(&ad[55 + cred_len..]);
+    let entries = d.map().unwrap().expect("definite-length COSE key");
+    assert_eq!(
+        d.u8().unwrap(),
+        1,
+        "{}: first COSE key label is kty",
+        spec.name
+    );
+    assert_eq!(d.u8().unwrap(), spec.kty, "{}: unexpected kty", spec.name);
+    assert_eq!(
+        d.u8().unwrap(),
+        3,
+        "{}: second COSE key label is alg",
+        spec.name
+    );
+    assert_eq!(d.i64().unwrap(), spec.alg, "{}: COSE key alg", spec.name);
+    assert_eq!(d.i8().unwrap(), -1, "{}: crv label", spec.name);
+    assert_eq!(d.u8().unwrap(), spec.crv, "{}: unexpected curve", spec.name);
+    assert_eq!(d.i8().unwrap(), -2, "{}: x label", spec.name);
+    let x = d.bytes().unwrap().to_vec();
+    assert_eq!(x.len(), spec.coord, "{}: x coordinate width", spec.name);
+    if spec.kty == KTY_EC2 {
+        assert_eq!(entries, 5, "{}: EC2 key is 5 entries", spec.name);
+        assert_eq!(d.i8().unwrap(), -3, "{}: y label", spec.name);
+        let y = d.bytes().unwrap().to_vec();
+        assert_eq!(y.len(), spec.coord, "{}: y coordinate width", spec.name);
+        CoseKey::Ec2 { x, y }
+    } else {
+        assert_eq!(entries, 4, "{}: OKP key is 4 entries", spec.name);
+        CoseKey::Okp {
+            x: x.try_into().expect("Ed25519 point is 32 bytes"),
+        }
+    }
+}
+
+/// Whether `sig` verifies over `msg` under `key` for `alg` — the cryptographic
+/// check a conformance tool performs. EC signatures are DER; the RustCrypto
+/// `Verifier` hashes with the curve's paired digest (SHA-256/384/512). EdDSA is a
+/// raw 64-byte signature over the message.
+fn verifies(alg: i64, key: &CoseKey, msg: &[u8], sig: &[u8]) -> bool {
+    match (alg, key) {
+        (ALG_ES256, CoseKey::Ec2 { x, y }) => {
+            use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+            let pt = p256::EncodedPoint::from_affine_coordinates(
+                p256::FieldBytes::from_slice(x),
+                p256::FieldBytes::from_slice(y),
+                false,
+            );
+            let vk = VerifyingKey::from_encoded_point(&pt).unwrap();
+            let Ok(s) = Signature::from_der(sig) else {
+                return false;
+            };
+            vk.verify(msg, &s).is_ok()
+        }
+        (ALG_ES384, CoseKey::Ec2 { x, y }) => {
+            use p384::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+            let pt = p384::EncodedPoint::from_affine_coordinates(
+                p384::FieldBytes::from_slice(x),
+                p384::FieldBytes::from_slice(y),
+                false,
+            );
+            let vk = VerifyingKey::from_encoded_point(&pt).unwrap();
+            let Ok(s) = Signature::from_der(sig) else {
+                return false;
+            };
+            vk.verify(msg, &s).is_ok()
+        }
+        (ALG_ES512, CoseKey::Ec2 { x, y }) => {
+            use p521::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+            let pt = p521::EncodedPoint::from_affine_coordinates(
+                p521::FieldBytes::from_slice(x),
+                p521::FieldBytes::from_slice(y),
+                false,
+            );
+            let vk = VerifyingKey::from_encoded_point(&pt).unwrap();
+            let Ok(s) = Signature::from_der(sig) else {
+                return false;
+            };
+            vk.verify(msg, &s).is_ok()
+        }
+        (ALG_EDDSA, CoseKey::Okp { x }) => {
+            use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+            let vk = VerifyingKey::from_bytes(x).unwrap();
+            let Ok(s) = Signature::from_slice(sig) else {
+                return false;
+            };
+            vk.verify(msg, &s).is_ok()
+        }
+        _ => panic!("algorithm / key-type mismatch"),
+    }
+}
+
+/// Register a credential for `spec`, log in with it, and verify both signatures
+/// under its credential key — the full multi-algorithm round-trip.
+fn create_and_assert(spec: &AlgSpec) {
+    let mut a = Authr::fresh();
+
+    let mc = a.send(CTAP_MAKE_CREDENTIAL, &mc_request(spec.alg));
+    assert_ok(&mc);
+    assert_eq!(
+        int_map_keys(&mc.body),
+        vec![1u32, 2, 3],
+        "{}: attObj is {{fmt, authData, attStmt}}",
+        spec.name
+    );
+    let ad = authdata(&mc.body);
+    let key = cose_key(spec, &ad);
+    let (att_alg, att_sig) = att_stmt(&mc.body);
+    assert_eq!(
+        att_alg, spec.alg,
+        "{}: attStmt alg must match the credential key",
+        spec.name
+    );
+    // Packed self-attestation signs authData ‖ clientDataHash with the new key.
+    let mut att_signed = ad.clone();
+    att_signed.extend_from_slice(&CDH);
+    assert!(
+        verifies(spec.alg, &key, &att_signed, &att_sig),
+        "{}: packed self-attestation signature must verify",
+        spec.name
+    );
+
+    let cred_id = cred_id_of(&ad);
+    let ga = a.send(CTAP_GET_ASSERTION, &ga_request(&cred_id));
+    assert_ok(&ga);
+    let ga_ad = authdata(&ga.body);
+    assert_eq!(
+        &ga_ad[..32],
+        &sha256(RP_ID.as_bytes())[..],
+        "{}: assertion rpIdHash",
+        spec.name
+    );
+    assert_eq!(ga_ad[32] & FLAG_UP, FLAG_UP, "{}: UP flag set", spec.name);
+    assert_eq!(
+        ga_ad[32] & FLAG_AT,
+        0,
+        "{}: assertion carries no attested credential data",
+        spec.name
+    );
+    // The assertion signs authData ‖ clientDataHash with the same credential key.
+    let mut ga_signed = ga_ad.clone();
+    ga_signed.extend_from_slice(&CDH);
+    assert!(
+        verifies(spec.alg, &key, &ga_signed, &assertion_sig(&ga.body)),
+        "{}: assertion signature must verify",
+        spec.name
+    );
+}
+
+#[test]
+fn es256_create_and_assert() {
+    create_and_assert(&ES256);
+}
+
+#[test]
+fn es384_create_and_assert() {
+    create_and_assert(&ES384);
+}
+
+#[test]
+fn es512_create_and_assert() {
+    create_and_assert(&ES512);
+}
+
+#[test]
+fn eddsa_create_and_assert() {
+    create_and_assert(&EDDSA);
+}
+
+#[test]
+fn tampered_authdata_fails_for_every_algorithm() {
+    // A verification harness that never rejects would let every positive test
+    // pass vacuously. Flipping the UP bit in the signed authData must break the
+    // self-attestation for each algorithm, proving the signature binds authData.
+    for spec in [&ES256, &ES384, &ES512, &EDDSA] {
+        let mut a = Authr::fresh();
+        let mc = a.send(CTAP_MAKE_CREDENTIAL, &mc_request(spec.alg));
+        assert_ok(&mc);
+        let ad = authdata(&mc.body);
+        let key = cose_key(spec, &ad);
+        let (_, att_sig) = att_stmt(&mc.body);
+        let mut tampered = ad.clone();
+        tampered[32] ^= FLAG_UP;
+        tampered.extend_from_slice(&CDH);
+        assert!(
+            !verifies(spec.alg, &key, &tampered, &att_sig),
+            "{}: signature must not verify over mutated authData",
+            spec.name
+        );
+    }
+}

--- a/crates/rsk-fido/src/conformance/pin.rs
+++ b/crates/rsk-fido/src/conformance/pin.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.5 clientPIN crypto-flow conformance, driven through the wire
+//! envelope (`process_cbor`): key agreement (ECDH), setPIN, getPinToken (correct
+//! PIN → a decryptable token; wrong PIN → PIN_INVALID + a retry decrement) and
+//! changePIN. The platform side runs the real pinUvAuthProtocol-2 primitives, so
+//! the exchange is verified end to end.
+
+use super::{Authr, assert_ok_empty, field_at};
+use crate::consts::{CTAP_CLIENT_PIN, MAX_PIN_RETRIES};
+use crate::cose::cose_key_ecdh;
+use crate::error::{CTAP2_OK, CtapError};
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+use rsk_crypto::pinproto::{self, PinProto, public_xy};
+use rsk_crypto::sha256;
+
+const PIN: &[u8] = b"1234";
+
+/// A short two-key clientPIN request `{1: proto=2, 2: subCommand}`.
+fn cp_short(sub: u64) -> Vec<u8> {
+    let mut buf = [0u8; 16];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(2).unwrap();
+        e.u8(1).unwrap().u64(2).unwrap();
+        e.u8(2).unwrap().u64(sub).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// Read `options.clientPin` from a fresh getInfo.
+fn client_pin_set(a: &mut Authr) -> bool {
+    let r = a.get_info();
+    let mut d = field_at(&r.body, 4).expect("options (0x04) present");
+    let n = d.map().unwrap().unwrap();
+    for _ in 0..n {
+        let hit = d.str().unwrap() == "clientPin";
+        let v = d.bool().unwrap();
+        if hit {
+            return v;
+        }
+    }
+    false
+}
+
+/// getPINRetries (subCommand 1) → the current counter.
+fn pin_retries(a: &mut Authr) -> u8 {
+    let r = a.send(CTAP_CLIENT_PIN, &cp_short(1));
+    let mut d = field_at(&r.body, 3).expect("retries (0x03) present");
+    d.u8().unwrap()
+}
+
+/// The platform half of the PIN protocol: a fixed ECDH key + the shared secret.
+struct PinClient {
+    x: [u8; 32],
+    y: [u8; 32],
+    shared: Vec<u8>,
+}
+
+impl PinClient {
+    /// Perform key agreement (getKeyAgreement) and derive the shared secret.
+    fn establish(a: &mut Authr) -> Self {
+        let r = a.send(CTAP_CLIENT_PIN, &cp_short(2));
+        let (ax, ay) = authenticator_public(&r.body);
+        let mut s = [0u8; 32];
+        s[0] = 0x13;
+        s[31] = 0x42;
+        let (x, y) = public_xy(&s).unwrap();
+        let mut shared = [0u8; 64];
+        let slen = pinproto::ecdh(PinProto::Two, &s, &ax, &ay, &mut shared).unwrap();
+        PinClient {
+            x,
+            y,
+            shared: shared[..slen].to_vec(),
+        }
+    }
+
+    fn enc(&self, pt: &[u8]) -> Vec<u8> {
+        let mut out = [0u8; 96];
+        let n = pinproto::encrypt(PinProto::Two, &self.shared, &[0x55; 16], pt, &mut out).unwrap();
+        out[..n].to_vec()
+    }
+
+    fn mac(&self, data: &[u8]) -> Vec<u8> {
+        let mut out = [0u8; 32];
+        let n = pinproto::authenticate(PinProto::Two, &self.shared, data, &mut out).unwrap();
+        out[..n].to_vec()
+    }
+
+    /// setPIN request: `{1:2, 2:3, 3:keyAgreement, 4:pinUvAuthParam, 5:newPinEnc}`.
+    fn set_pin(&self, pin: &[u8]) -> Vec<u8> {
+        let mut padded = [0u8; 64];
+        padded[..pin.len()].copy_from_slice(pin);
+        let npe = self.enc(&padded);
+        let puap = self.mac(&npe);
+        let mut buf = [0u8; 256];
+        let n = {
+            let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+            e.map(5).unwrap();
+            e.u8(1).unwrap().u64(2).unwrap();
+            e.u8(2).unwrap().u64(3).unwrap();
+            e.u8(3).unwrap();
+            cose_key_ecdh(&mut e, &self.x, &self.y).unwrap();
+            e.u8(4).unwrap().bytes(&puap).unwrap();
+            e.u8(5).unwrap().bytes(&npe).unwrap();
+            e.writer().position()
+        };
+        buf[..n].to_vec()
+    }
+
+    /// Legacy getPinToken request: `{1:2, 2:5, 3:keyAgreement, 6:pinHashEnc}`.
+    fn get_token(&self, pin: &[u8]) -> Vec<u8> {
+        let h = sha256(pin);
+        let phe = self.enc(&h[..16]);
+        let mut buf = [0u8; 256];
+        let n = {
+            let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+            e.map(4).unwrap();
+            e.u8(1).unwrap().u64(2).unwrap();
+            e.u8(2).unwrap().u64(5).unwrap();
+            e.u8(3).unwrap();
+            cose_key_ecdh(&mut e, &self.x, &self.y).unwrap();
+            e.u8(6).unwrap().bytes(&phe).unwrap();
+            e.writer().position()
+        };
+        buf[..n].to_vec()
+    }
+
+    /// changePIN request: `{1:2, 2:4, 3:keyAgreement, 4:puap, 5:newPinEnc, 6:pinHashEnc}`.
+    fn change_pin(&self, old: &[u8], new: &[u8]) -> Vec<u8> {
+        let mut padded = [0u8; 64];
+        padded[..new.len()].copy_from_slice(new);
+        let npe = self.enc(&padded);
+        let oh = sha256(old);
+        let phe = self.enc(&oh[..16]);
+        let mut macd = npe.clone();
+        macd.extend_from_slice(&phe);
+        let puap = self.mac(&macd);
+        let mut buf = [0u8; 256];
+        let n = {
+            let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+            e.map(6).unwrap();
+            e.u8(1).unwrap().u64(2).unwrap();
+            e.u8(2).unwrap().u64(4).unwrap();
+            e.u8(3).unwrap();
+            cose_key_ecdh(&mut e, &self.x, &self.y).unwrap();
+            e.u8(4).unwrap().bytes(&puap).unwrap();
+            e.u8(5).unwrap().bytes(&npe).unwrap();
+            e.u8(6).unwrap().bytes(&phe).unwrap();
+            e.writer().position()
+        };
+        buf[..n].to_vec()
+    }
+
+    /// Decrypt the pinUvAuthToken from a getPinToken response `{2: enc}`.
+    fn decrypt_token(&self, body: &[u8]) -> [u8; 32] {
+        let mut d = field_at(body, 2).expect("pinUvAuthToken (0x02) present");
+        let enc = d.bytes().unwrap();
+        let mut tok = [0u8; 32];
+        let n = pinproto::decrypt(PinProto::Two, &self.shared, enc, &mut tok).unwrap();
+        assert_eq!(n, 32, "a pinUvAuthToken is 32 bytes");
+        tok
+    }
+}
+
+/// The authenticator's key-agreement public key (x, y) from getKeyAgreement:
+/// `{1: {1:2, 3:-25, -1:1, -2:x, -3:y}}`.
+fn authenticator_public(body: &[u8]) -> ([u8; 32], [u8; 32]) {
+    let mut d = field_at(body, 1).expect("keyAgreement (0x01) present");
+    assert_eq!(d.map().unwrap().unwrap(), 5);
+    d.u8().unwrap();
+    d.u8().unwrap(); // 1: kty = 2
+    d.u8().unwrap();
+    d.i64().unwrap(); // 3: alg = -25
+    d.i8().unwrap();
+    d.u8().unwrap(); // -1: crv = 1
+    d.i8().unwrap(); // -2: x label
+    let mut x = [0u8; 32];
+    x.copy_from_slice(d.bytes().unwrap());
+    d.i8().unwrap(); // -3: y label
+    let mut y = [0u8; 32];
+    y.copy_from_slice(d.bytes().unwrap());
+    (x, y)
+}
+
+#[test]
+fn clientpin_set_pin_enables_client_pin() {
+    let mut a = Authr::fresh();
+    assert!(!client_pin_set(&mut a), "clientPin starts unset");
+    let pc = PinClient::establish(&mut a);
+    assert_ok_empty(&a.send(CTAP_CLIENT_PIN, &pc.set_pin(PIN)));
+    assert!(
+        client_pin_set(&mut a),
+        "clientPin flips to true after setPIN"
+    );
+    assert_eq!(
+        pin_retries(&mut a),
+        MAX_PIN_RETRIES,
+        "setPIN does not consume a retry"
+    );
+}
+
+#[test]
+fn clientpin_get_token_with_correct_pin() {
+    let mut a = Authr::fresh();
+    let pc = PinClient::establish(&mut a);
+    assert_ok_empty(&a.send(CTAP_CLIENT_PIN, &pc.set_pin(PIN)));
+    let r = a.send(CTAP_CLIENT_PIN, &pc.get_token(PIN));
+    assert_eq!(r.status, CTAP2_OK);
+    let tok = pc.decrypt_token(&r.body);
+    assert_ne!(tok, [0u8; 32], "a non-trivial pinUvAuthToken is returned");
+}
+
+#[test]
+fn clientpin_wrong_pin_decrements_retries() {
+    let mut a = Authr::fresh();
+    let pc = PinClient::establish(&mut a);
+    assert_ok_empty(&a.send(CTAP_CLIENT_PIN, &pc.set_pin(PIN)));
+    let before = pin_retries(&mut a);
+    let r = a.send(CTAP_CLIENT_PIN, &pc.get_token(b"9999"));
+    assert_eq!(r.status, CtapError::PinInvalid.as_u8());
+    assert_eq!(
+        pin_retries(&mut a),
+        before - 1,
+        "a wrong PIN consumes exactly one retry"
+    );
+}
+
+#[test]
+fn clientpin_change_pin() {
+    let mut a = Authr::fresh();
+    let pc = PinClient::establish(&mut a);
+    assert_ok_empty(&a.send(CTAP_CLIENT_PIN, &pc.set_pin(PIN)));
+    assert_ok_empty(&a.send(CTAP_CLIENT_PIN, &pc.change_pin(PIN, b"5678")));
+    // The new PIN yields a token; the old PIN is rejected.
+    assert_eq!(
+        a.send(CTAP_CLIENT_PIN, &pc.get_token(b"5678")).status,
+        CTAP2_OK
+    );
+    assert_eq!(
+        a.send(CTAP_CLIENT_PIN, &pc.get_token(PIN)).status,
+        CtapError::PinInvalid.as_u8()
+    );
+}

--- a/crates/rsk-fido/src/conformance/reset.rs
+++ b/crates/rsk-fido/src/conformance/reset.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §5.6 `authenticatorReset` conformance, driven through the wire
+//! envelope (`process_cbor`): a present-gated wipe that clears credentials, and
+//! a no-presence rejection.
+
+use super::{Authr, assert_ok, assert_ok_empty};
+use crate::consts::{ALG_ES256, CTAP_GET_ASSERTION, CTAP_MAKE_CREDENTIAL, CTAP_RESET};
+use crate::error::CtapError;
+use minicbor::Encoder;
+use minicbor::encode::write::Cursor;
+
+const RP_ID: &str = "reset.example";
+
+fn mc_rk() -> Vec<u8> {
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(5).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(RP_ID)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[5, 5, 5, 5]).unwrap();
+        e.str("name").unwrap().str("erin").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+fn ga() -> Vec<u8> {
+    let mut buf = [0u8; 64];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(2).unwrap();
+        e.u8(1).unwrap().str(RP_ID).unwrap();
+        e.u8(2).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+#[test]
+fn reset_wipes_credentials() {
+    let mut a = Authr::fresh();
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_rk()));
+    // authenticatorReset erases all FIDO state on user presence.
+    assert_ok_empty(&a.send(CTAP_RESET, &[]));
+    // The discoverable credential is gone.
+    let r = a.send(CTAP_GET_ASSERTION, &ga());
+    assert_eq!(r.status, CtapError::NoCredentials.as_u8());
+}
+
+#[test]
+fn reset_denied_without_presence() {
+    // Reset is destructive → it must not proceed without a touch (§5.6).
+    let r = Authr::declining().send(CTAP_RESET, &[]);
+    assert_eq!(r.status, CtapError::UserActionTimeout.as_u8());
+}

--- a/crates/rsk-fido/src/conformance/selection.rs
+++ b/crates/rsk-fido/src/conformance/selection.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! CTAP 2.1 §6.9 `authenticatorSelection` conformance, driven through the wire
+//! envelope (`process_cbor`): an empty success on presence, a timeout without it.
+
+use super::{Authr, assert_ok_empty};
+use crate::consts::CTAP_SELECTION;
+use crate::error::CtapError;
+
+#[test]
+fn selection_confirms_on_presence() {
+    // A present user yields an empty CTAP2_OK (the "this is me" tap).
+    let r = Authr::fresh().send(CTAP_SELECTION, &[]);
+    assert_ok_empty(&r);
+}
+
+#[test]
+fn selection_times_out_without_presence() {
+    // No touch → CTAP2_ERR_USER_ACTION_TIMEOUT (§6.9 / conformance HID-1).
+    let r = Authr::declining().send(CTAP_SELECTION, &[]);
+    assert_eq!(r.status, CtapError::UserActionTimeout.as_u8());
+}

--- a/crates/rsk-fido/src/conformance/u2f.rs
+++ b/crates/rsk-fido/src/conformance/u2f.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! U2F / CTAP1 conformance, driven through the U2F APDU dispatcher
+//! (`process_u2f`): the version string, the registration response layout, a
+//! register→authenticate round-trip (user-presence flag + counter + signature),
+//! and the class/instruction error words.
+
+use super::Authr;
+use crate::consts::{
+    CTAP_AUTHENTICATE, CTAP_REGISTER, CTAP_VERSION, U2F_AUTH_ENFORCE, U2F_AUTH_FLAG_TUP,
+    U2F_REGISTER_ID,
+};
+use crate::keyderiv::KEY_HANDLE_LEN;
+use rsk_sdk::sw::Sw;
+
+const APP: [u8; 32] = [0x5A; 32];
+const CHAL: [u8; 32] = [0xC4; 32];
+
+/// A case-1 U2F APDU with no data field (CLA INS P1 P2=0x00).
+fn short(cla: u8, ins: u8, p1: u8) -> Vec<u8> {
+    std::vec![cla, ins, p1, 0x00]
+}
+
+/// An extended-length U2F APDU carrying `data` (extended Lc, extended Le = 0).
+fn ext(cla: u8, ins: u8, p1: u8, data: &[u8]) -> Vec<u8> {
+    let mut v = std::vec![
+        cla,
+        ins,
+        p1,
+        0x00,
+        0x00,
+        (data.len() >> 8) as u8,
+        data.len() as u8
+    ];
+    v.extend_from_slice(data);
+    v.extend_from_slice(&[0x00, 0x00]);
+    v
+}
+
+/// The U2F register request body: challenge(32) ‖ application(32).
+fn register_data() -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(&CHAL);
+    d.extend_from_slice(&APP);
+    d
+}
+
+#[test]
+fn u2f_version() {
+    let (sw, body) = Authr::fresh().send_u2f(&short(0x00, CTAP_VERSION, 0));
+    assert_eq!(sw, Sw::OK);
+    assert_eq!(&body, b"U2F_V2");
+}
+
+#[test]
+fn u2f_register_response_shape() {
+    let (sw, r) = Authr::fresh().send_u2f(&ext(0x00, CTAP_REGISTER, 0, &register_data()));
+    assert_eq!(sw, Sw::OK);
+    // 0x05 ‖ 0x04||pubkey(64) ‖ khLen ‖ kh ‖ attestationCert(DER) ‖ signature(DER)
+    assert_eq!(r[0], U2F_REGISTER_ID, "legacy reserved byte 0x05");
+    assert_eq!(r[1], 0x04, "public key is an uncompressed EC point");
+    assert_eq!(r[66] as usize, KEY_HANDLE_LEN, "key-handle length byte");
+    let cert = &r[67 + KEY_HANDLE_LEN..];
+    assert_eq!(cert[0], 0x30, "attestation certificate is a DER SEQUENCE");
+}
+
+#[test]
+fn u2f_register_then_authenticate() {
+    let mut a = Authr::fresh();
+    let (sw, reg) = a.send_u2f(&ext(0x00, CTAP_REGISTER, 0, &register_data()));
+    assert_eq!(sw, Sw::OK);
+    let key_handle = reg[67..67 + KEY_HANDLE_LEN].to_vec();
+
+    let mut ad = Vec::new();
+    ad.extend_from_slice(&CHAL);
+    ad.extend_from_slice(&APP);
+    ad.push(KEY_HANDLE_LEN as u8);
+    ad.extend_from_slice(&key_handle);
+    let (sw, r) = a.send_u2f(&ext(0x00, CTAP_AUTHENTICATE, U2F_AUTH_ENFORCE, &ad));
+    assert_eq!(sw, Sw::OK);
+    // userPresence(1) ‖ counter(4) ‖ signature(DER).
+    assert_eq!(
+        r[0] & U2F_AUTH_FLAG_TUP,
+        U2F_AUTH_FLAG_TUP,
+        "user-presence flag set"
+    );
+    assert!(r.len() >= 5 + 8, "counter and signature present");
+    assert_eq!(r[5], 0x30, "authentication signature is a DER SEQUENCE");
+}
+
+#[test]
+fn u2f_class_and_instruction_errors() {
+    let mut a = Authr::fresh();
+    // U2F requires CLA 0x00.
+    let (sw, _) = a.send_u2f(&short(0x01, CTAP_VERSION, 0));
+    assert_eq!(sw, Sw::CLA_NOT_SUPPORTED);
+    // An unknown instruction is rejected.
+    let (sw, _) = a.send_u2f(&short(0x00, 0xEE, 0));
+    assert_eq!(sw, Sw::INS_NOT_SUPPORTED);
+}

--- a/crates/rsk-fido/src/conformance/u2f.rs
+++ b/crates/rsk-fido/src/conformance/u2f.rs
@@ -99,3 +99,28 @@ fn u2f_class_and_instruction_errors() {
     let (sw, _) = a.send_u2f(&short(0x00, 0xEE, 0));
     assert_eq!(sw, Sw::INS_NOT_SUPPORTED);
 }
+
+#[test]
+fn u2f_authenticate_signature_verifies() {
+    let mut a = Authr::fresh();
+    let (sw, reg) = a.send_u2f(&ext(0x00, CTAP_REGISTER, 0, &register_data()));
+    assert_eq!(sw, Sw::OK);
+    // The registration response carries the credential public key: 0x04 ‖ x ‖ y.
+    let x = &reg[2..34];
+    let y = &reg[34..66];
+    let key_handle = reg[67..67 + KEY_HANDLE_LEN].to_vec();
+
+    let mut ad = Vec::new();
+    ad.extend_from_slice(&CHAL);
+    ad.extend_from_slice(&APP);
+    ad.push(KEY_HANDLE_LEN as u8);
+    ad.extend_from_slice(&key_handle);
+    let (sw, r) = a.send_u2f(&ext(0x00, CTAP_AUTHENTICATE, U2F_AUTH_ENFORCE, &ad));
+    assert_eq!(sw, Sw::OK);
+    // U2F authenticate signs application ‖ userPresence(1) ‖ counter(4) ‖ challenge.
+    let mut signed = Vec::new();
+    signed.extend_from_slice(&APP);
+    signed.extend_from_slice(&r[..5]);
+    signed.extend_from_slice(&CHAL);
+    super::verify_p256(x, y, &signed, &r[5..]);
+}

--- a/crates/rsk-fido/src/lib.rs
+++ b/crates/rsk-fido/src/lib.rs
@@ -228,3 +228,6 @@ pub fn process_cbor<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, data: &[u8], out: &
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod conformance;

--- a/crates/rsk-piv/src/auth.rs
+++ b/crates/rsk-piv/src/auth.rs
@@ -379,7 +379,13 @@ pub(crate) fn general_authenticate<S: Storage>(
 
     match sw {
         Ok(()) => {
-            if pinpol == PINPOLICY_ALWAYS {
+            // pin-policy ALWAYS re-locks the PIN after each use — but only for an
+            // actual key-slot sign, mirroring the `is_key` check that gated it
+            // above. The 9B management key also stores pin-policy ALWAYS, and its
+            // mutual auth is not a PIN-gated op, so it must not clear has_pin (else
+            // a VERIFY-then-mgmt-auth-then-sign client, e.g. age-plugin-yubikey,
+            // hits 6982 on the slot sign).
+            if pinpol == PINPOLICY_ALWAYS && is_key(key_ref) {
                 sess.has_pin = false;
             }
             Sw::OK

--- a/crates/rsk-piv/src/tests.rs
+++ b/crates/rsk-piv/src/tests.rs
@@ -218,6 +218,57 @@ fn touch_policy_never_skips_presence() {
 }
 
 #[test]
+fn management_auth_preserves_pin_verification() {
+    // age-plugin-yubikey first-run order: VERIFY PIN, THEN mutual-auth the 9B
+    // management key, THEN use a pin-policy=ONCE slot key. The 9B key's stored
+    // pin-policy is ALWAYS, but a mutual auth is not a key-slot operation, so it
+    // must NOT clear the session PIN state — only an is_key sign does. Before the
+    // fix the mgmt auth cleared has_pin and the slot sign failed with 6982.
+    let rng = RefCell::new(TestRng(7));
+    let pres = RefCell::new(AlwaysConfirm);
+    let mut app = PivApplet::new(SERIAL, HASH, None, &rng, &pres);
+    let mut fs = new_fs();
+    select(&mut app, &mut fs);
+
+    verify_pin(&mut app, &mut fs); // has_pin set first…
+    auth_mgm(&mut app, &mut fs); // …then the 9B (pin-policy ALWAYS) mutual auth.
+
+    // Retired-slot key, pin-policy ONCE, touch NEVER (isolates the PIN check).
+    let tmpl = vec![
+        0xAC,
+        0x09,
+        0x80,
+        0x01,
+        ALGO_ECCP256,
+        0xAA,
+        0x01,
+        PINPOLICY_ONCE,
+        0xAB,
+        0x01,
+        TOUCHPOLICY_NEVER,
+    ];
+    let (sw, _) = run(&mut app, &mut fs, INS_ASYM_KEYGEN, 0, 0x82, &tmpl);
+    assert_eq!(sw, Sw::OK);
+
+    // pin-policy ONCE is satisfied by the earlier VERIFY — the sign must pass.
+    let mut msg = vec![0x7C, 0x24, 0x82, 0x00, 0x81, 0x20];
+    msg.extend_from_slice(&[0x42u8; 32]);
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_AUTHENTICATE,
+        ALGO_ECCP256,
+        0x82,
+        &msg,
+    );
+    assert_eq!(
+        sw,
+        Sw::OK,
+        "mgmt mutual auth must not clear the session PIN state"
+    );
+}
+
+#[test]
 fn select_returns_apt() {
     let rng = RefCell::new(TestRng(7));
     let pres = RefCell::new(AlwaysConfirm);

--- a/crates/rsk-piv/src/tests.rs
+++ b/crates/rsk-piv/src/tests.rs
@@ -1081,6 +1081,86 @@ fn cert_object_is_wrapped_and_parses() {
 }
 
 #[test]
+fn retired_slot_generate_then_cert_roundtrip() {
+    // Reproduces the age-plugin-yubikey generate flow into a retired slot (its
+    // "Slot 1" = PIV retired R1 = keyref 0x82, cert object 5FC10D). age-plugin
+    // detects slot occupancy via Key::list, which reads each retired slot's
+    // certificate — so the cert must persist and read back, else the slot shows
+    // "(Empty)" and decryption can't find the identity.
+    let rng = RefCell::new(TestRng(7));
+    let pres = RefCell::new(AlwaysConfirm);
+    let mut app = PivApplet::new(SERIAL, HASH, None, &rng, &pres);
+    let mut fs = new_fs();
+    select(&mut app, &mut fs);
+    auth_mgm(&mut app, &mut fs);
+    verify_pin(&mut app, &mut fs);
+
+    let get_r1 = [0x5C, 0x03, 0x5F, 0xC1, 0x0D];
+    // Fresh retired slot reads empty (the pre-generate occupancy check).
+    let (sw, _) = run(&mut app, &mut fs, INS_GET_DATA, 0x3F, 0xFF, &get_r1);
+    assert_eq!(sw, Sw::FILE_NOT_FOUND);
+
+    // GENERATE into R1 (keyref 0x82).
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_ASYM_KEYGEN,
+        0,
+        0x82,
+        &gen_template(ALGO_ECCP256),
+    );
+    assert_eq!(sw, Sw::OK, "GENERATE into retired R1 must succeed");
+
+    // Our GENERATE auto-writes a self-signed cert → the slot must read occupied.
+    let (sw, obj) = run(&mut app, &mut fs, INS_GET_DATA, 0x3F, 0xFF, &get_r1);
+    assert_eq!(
+        sw,
+        Sw::OK,
+        "retired slot cert must be readable after GENERATE"
+    );
+    assert!(find_tag(&obj, 0x53).is_some());
+
+    // age-plugin then PUT DATA its own self-signed cert (carrying the age OID).
+    // A real P-256 age cert is ~400 bytes, so the 0x70/0x53 lengths are long-form
+    // and the command is an extended-length APDU — the path a 10-byte fake misses.
+    let cert_payload = vec![0xABu8; 390];
+    let mut inner = vec![
+        0x70,
+        0x82,
+        (cert_payload.len() >> 8) as u8,
+        cert_payload.len() as u8,
+    ];
+    inner.extend_from_slice(&cert_payload);
+    inner.extend_from_slice(&[0x71, 0x01, 0x00, 0xFE, 0x00]);
+    let mut put = vec![
+        0x5C,
+        0x03,
+        0x5F,
+        0xC1,
+        0x0D,
+        0x53,
+        0x82,
+        (inner.len() >> 8) as u8,
+        inner.len() as u8,
+    ];
+    put.extend_from_slice(&inner);
+    let (sw, _) = run(&mut app, &mut fs, INS_PUT_DATA, 0x3F, 0xFF, &put);
+    assert_eq!(sw, Sw::OK, "PUT DATA of the age cert must succeed");
+
+    // The slot must still read occupied, now with the age cert.
+    let (sw, obj2) = run(&mut app, &mut fs, INS_GET_DATA, 0x3F, 0xFF, &get_r1);
+    assert_eq!(
+        sw,
+        Sw::OK,
+        "retired slot cert must read back after PUT DATA"
+    );
+    assert_eq!(
+        find_tag(&obj2, 0x53).and_then(|b| find_tag(b, 0x70)),
+        Some(&cert_payload[..])
+    );
+}
+
+#[test]
 fn attestation_chains_to_f9() {
     let rng = RefCell::new(TestRng(7));
     let pres = RefCell::new(AlwaysConfirm);

--- a/crates/rsk-sdk/src/applet.rs
+++ b/crates/rsk-sdk/src/applet.rs
@@ -309,8 +309,14 @@ impl Dispatcher {
     /// Otherwise the response (and status) pass through unchanged — so extended
     /// `Le` consumers (ykman, our APDU tests) and non-chaining applets are
     /// byte-for-byte unaffected.
+    ///
+    /// `ne == 0` is a case-3 command (data, no `Le`): ISO 7816-4 still caps its
+    /// response at the short maximum, so a larger body must chain via `61xx` too.
+    /// yubikey.rs / age-plugin read slot certs this way and drop any slot whose
+    /// cert overruns 256 bytes if we dump it whole instead of chaining.
     fn maybe_chain(&mut self, sw: Sw, ne: usize, chaining_ok: bool, res: &mut ResBuf) -> Sw {
-        if !chaining_ok || ne == 0 || !sw.is_ok() || res.len() <= ne {
+        let ne = if ne == 0 { NE_SHORT_MAX } else { ne };
+        if !chaining_ok || !sw.is_ok() || res.len() <= ne {
             return sw;
         }
         let tail_len = res.len() - ne;

--- a/crates/rsk-sdk/src/applet_tests.rs
+++ b/crates/rsk-sdk/src/applet_tests.rs
@@ -293,6 +293,76 @@ fn get_response_honours_a_smaller_le() {
 }
 
 #[test]
+fn case3_no_le_large_response_is_chained() {
+    // Regression (age-plugin-yubikey empty-slot bug): yubikey.rs sends GET DATA as
+    // a case-3 APDU (command data, NO Le) and relies on 61xx response chaining to
+    // read a slot certificate larger than 256 bytes. A no-Le command must chain,
+    // not dump the whole oversized body — the client's short-APDU receive buffer
+    // can't hold it, so it drops the slot and the identity shows as "(Empty)".
+    let mut c = Chunky {
+        body_len: 305,
+        chain: true,
+    };
+    let mut applets: [&mut dyn Applet<()>; 1] = [&mut c];
+    let mut disp = Dispatcher::new();
+    let mut out = [0u8; 512];
+    let mut res = ResBuf::new(&mut out);
+    select_chunky(&mut disp, &mut applets, &mut res);
+
+    // Case-3 GET DATA (Lc=3 data, no Le), body 305 > 256 → 256 bytes + 61 31 (49 left).
+    let sw = disp.process(
+        &[0x00, 0xCA, 0x00, 0x00, 0x03, 0x5F, 0xC1, 0x0D],
+        &mut applets,
+        &mut (),
+        &mut res,
+    );
+    assert_eq!(
+        sw,
+        Sw::new(0x61, 49),
+        "a no-Le command must chain a large body, not return it whole"
+    );
+    assert_eq!(res.len(), 256);
+    let mut got = res.as_slice().to_vec();
+
+    // GET RESPONSE drains the 49-byte tail.
+    let sw = disp.process(
+        &[0x00, 0xC0, 0x00, 0x00, 0x00],
+        &mut applets,
+        &mut (),
+        &mut res,
+    );
+    assert_eq!(sw, Sw::OK);
+    assert_eq!(res.len(), 49);
+    got.extend_from_slice(res.as_slice());
+    let want: Vec<u8> = (0..305).map(|i| (i & 0xFF) as u8).collect();
+    assert_eq!(got, want);
+}
+
+#[test]
+fn case3_no_le_small_response_is_not_chained() {
+    // The flip side: a no-Le response that fits in the short maximum is returned
+    // whole with 9000 — no needless chaining for the common small object.
+    let mut c = Chunky {
+        body_len: 40,
+        chain: true,
+    };
+    let mut applets: [&mut dyn Applet<()>; 1] = [&mut c];
+    let mut disp = Dispatcher::new();
+    let mut out = [0u8; 512];
+    let mut res = ResBuf::new(&mut out);
+    select_chunky(&mut disp, &mut applets, &mut res);
+
+    let sw = disp.process(
+        &[0x00, 0xCA, 0x00, 0x00, 0x03, 0x5F, 0xC1, 0x0D],
+        &mut applets,
+        &mut (),
+        &mut res,
+    );
+    assert_eq!(sw, Sw::OK);
+    assert_eq!(res.len(), 40);
+}
+
+#[test]
 fn extended_le_response_is_not_chained() {
     let mut c = Chunky {
         body_len: 269,

--- a/docs/guides/display.md
+++ b/docs/guides/display.md
@@ -38,9 +38,11 @@ nix build .#firmware-display        # → result/firmware.uf2
 ```
 
 `GPIO16` (the WS2812 pin on a standard board) drives the backlight here;
-`WAKE_PIN` (default `25`, the board's BAT_PWR button) wakes the panel from
-display sleep. See the full knob table in [build.md](../build.md) — the
-`display`-only knobs are `WAKE_PIN` / `WAKE_ACTIVE_HIGH`.
+`WAKE_PIN` (default `25`, the board's BAT_PWR button) both wakes the panel from
+display sleep and, while awake, sleeps it on demand from *any* screen — a press
+blanks the panel and (when a device PIN is set) locks the on-device UI, aborting
+any host prompt it interrupts. See the full knob table in [build.md](../build.md)
+— the `display`-only knobs are `WAKE_PIN` / `WAKE_ACTIVE_HIGH`.
 
 Flash it like any other image (BOOTSEL → `picotool load`, [hardware.md](../hardware.md)).
 Two notes:

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -53,6 +53,13 @@ def select(conn, aid):
 
 ![ISO-7816 short-APDU cases — every command opens with the four-byte header CLA INS P1 P2. Case 1 is header only; Case 2 appends a one-byte Le (expected response length, 00 meaning up to 256); Case 3 appends Lc then Lc bytes of command data; Case 4 appends Lc, data, and Le. SELECT is a Case 4 command, VERIFY a Case 3 command](images/apdu-cases.svg)
 
+A success body longer than the request's `Le` — including a Case-3 command that
+carries no `Le` at all, capped at 256 — is returned with ISO-7816 **response
+chaining**: the first chunk ships with status `61 XX` (`XX` = further bytes
+available, `00` = 256+), and the host issues `GET RESPONSE` (`00 C0 00 00 <Le>`)
+until `9000`. Any `GET DATA` reading a certificate object over 256 bytes chains
+this way, so a host that sends `GET DATA` without an `Le` must still follow `61xx`.
+
 ### 1.2 CTAPHID framing
 
 64-byte HID reports. Init frame: `CID(4) | CMD(1) | BCNT_HI | BCNT_LO | data[:57]`;

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -31,6 +31,14 @@ bulk stream, ISO-7816 APDUs, CTAP2 CBOR. Defenses:
   while the device is plugged in and unlocked (sign, decrypt, assert). A
   security key authenticates *presence and possession*, not the intent of
   every byte the host sends. Touch requirements bound the rate.
+- **The residual gap is *intent* — the trusted-display flavor closes it.** Because
+  a standard key attests presence and possession, a malicious page can silently
+  drive an authorized key over WebUSB to phish a real sign-in ([demonstrated
+  against YubiKeys in Chrome](https://www.wired.com/story/chrome-yubikey-phishing-webusb/)).
+  The [trusted-display flavor](guides/display.md) paints the true `rpId` on the
+  device's own screen and gates each signature on a tap there, so a compromised
+  host cannot fake what you approve. [Qubes OS's CTAP proxy](https://doc.qubes-os.org/en/latest/user/security-in-qubes/ctap-proxy.html#the-qubes-approach-to-ctap)
+  tackles the same gap in software, mediating CTAP through a trusted VM.
 
 ### 2. A thief with the powered-off device (at-rest)
 

--- a/firmware/src/display/applets.rs
+++ b/firmware/src/display/applets.rs
@@ -133,6 +133,9 @@ impl Ui {
                     if let Some(new_nick) = self.run_rename(&nick, hash) {
                         nick = new_nick;
                     }
+                    if self.asleep {
+                        return ServiceResult::Leave(None); // slept via the power button
+                    }
                     let _ = rsk_ui::render_service(
                         &mut self.panel,
                         &title(&nick),
@@ -173,6 +176,9 @@ impl Ui {
                 }
                 if let Some(i) = rsk_ui::hit_list(p, rsk_ui::PK_LIST_TOP, n as u16) {
                     self.run_delete(&title(&nick), &accts[i as usize].name, fids[i as usize]);
+                    if self.asleep {
+                        return ServiceResult::Leave(None); // slept via the power button
+                    }
                     let r = self.load_accts(hash, &mut accts, &mut fids, page);
                     n = r.0;
                     total = r.1;

--- a/firmware/src/display/pin.rs
+++ b/firmware/src/display/pin.rs
@@ -242,6 +242,12 @@ impl Ui {
         let scroll_title = rsk_ui::pin_title_overflows(title);
         let mut last_off = u32::MAX; // != any real offset, so the first frame always draws
         let outcome = loop {
+            // The power button sleeps (and auto-locks) from the PIN pad too — abandoning the
+            // entry with `Cancelled`, the same outcome a host CTAPHID_CANCEL yields, so a host
+            // waiting on this PIN is released. Checked first, before any repaint.
+            if self.sleep_button_pressed() {
+                break rsk_fido::PinEntry::Cancelled;
+            }
             if scroll_title {
                 let ms = start.elapsed().as_millis();
                 let off = (ms.saturating_sub(MARQUEE_PAUSE_MS) / MARQUEE_MS_PER_PX) as u32;
@@ -336,6 +342,10 @@ impl Ui {
         let show = Duration::from_millis(5000);
         let t0 = Instant::now();
         loop {
+            // The power button dismisses the notice by sleeping (and auto-locking) too.
+            if self.sleep_button_pressed() {
+                break;
+            }
             if self.touch.read().is_some() {
                 self.touch.wait_release(t0, show);
                 break;
@@ -366,12 +376,28 @@ impl Ui {
         self.shown = None;
         note_activity();
         match hold_ms {
-            Some(ms) => block_for(Duration::from_millis(ms)),
+            // Auto-dismiss after `ms`, but poll the power button through the dwell so even a
+            // brief self-dismissing pop is sleepable like every other screen (no touch: this
+            // variant has no Done button). The wipe pop reboots right after, so a sleep there
+            // is harmlessly moot.
+            Some(ms) => {
+                let start = Instant::now();
+                while start.elapsed() < Duration::from_millis(ms) {
+                    if self.sleep_button_pressed() {
+                        break;
+                    }
+                    block_for(Duration::from_millis(TOUCH_POLL_MS));
+                }
+            }
             None => {
                 let idle_limit = Duration::from_millis(MENU_INACTIVITY_MS);
                 self.touch.wait_release(Instant::now(), idle_limit);
                 let mut last = Instant::now();
                 loop {
+                    // The power button sleeps (and auto-locks) instead of tapping Done.
+                    if self.sleep_button_pressed() {
+                        break;
+                    }
                     if let Some(p) = self.touch.read() {
                         if rsk_ui::hit_success_done(p) {
                             break;
@@ -432,6 +458,11 @@ impl Ui {
         let mut last_num: u16 = 0;
         let mut last = Instant::now();
         loop {
+            // The power button sleeps (and auto-locks) mid-hold; nothing has committed yet,
+            // so this abandons the confirm exactly like a lifted finger.
+            if self.sleep_button_pressed() {
+                return false;
+            }
             let mut on_hold = false;
             if let Some(p) = self.touch.read() {
                 last = Instant::now();
@@ -573,18 +604,27 @@ impl Ui {
                 // The pad already enforced the length floor; a flash error is the only
                 // realistic failure and leaves no PIN set — abandon either way. Route to the
                 // device PIN's own record or the FIDO clientPIN's by target.
-                let _ = match target {
-                    PinScope::Device => rsk_fido::passkeys::store_device_pin(
-                        &dev,
-                        &mut self.fs.borrow_mut(),
-                        &new[..n1],
-                    ),
-                    PinScope::Fido => rsk_fido::passkeys::store_local_pin(
-                        &dev,
-                        &mut self.fs.borrow_mut(),
-                        &new[..n1],
-                    ),
-                };
+                match target {
+                    PinScope::Device => {
+                        let _ = rsk_fido::passkeys::store_device_pin(
+                            &dev,
+                            &mut self.fs.borrow_mut(),
+                            &new[..n1],
+                        );
+                        // Keep the cached lock-proxy fresh: a host ceremony sleeping right
+                        // after this set reads `home_pin_set` (fs is borrowed there), so a
+                        // stale `false` would skip the auto-lock. A store failure only makes
+                        // this over-lock, which unlock-with-no-PIN harmlessly drops.
+                        self.home_pin_set = true;
+                    }
+                    PinScope::Fido => {
+                        let _ = rsk_fido::passkeys::store_local_pin(
+                            &dev,
+                            &mut self.fs.borrow_mut(),
+                            &new[..n1],
+                        );
+                    }
+                }
                 break;
             }
             // Mismatch: re-prompt from "New PIN" with the reason; the loop clears both.
@@ -643,6 +683,11 @@ impl Ui {
                 1 => self.run_change_piv_ref(rsk_piv::PinRef::Puk),
                 2 => self.run_unblock_piv_pin(),
                 _ => self.run_protect_mgm_key(),
+            }
+            // A sub-flow may have slept + locked via the power button; unwind instead of
+            // re-showing this menu over the blanked panel (status_task owns it from here).
+            if self.asleep {
+                return;
             }
             // Each sub-flow ends in a success pop or a cancel; re-show this menu afterwards.
         }

--- a/firmware/src/display/power.rs
+++ b/firmware/src/display/power.rs
@@ -60,8 +60,18 @@ impl Ui {
     /// Enter display sleep, additionally locking the on-device UI when a device PIN is
     /// set — so a walked-away device requires the PIN to browse passkeys / settings on
     /// wake. Without a PIN there is nothing to unlock with, so it only blanks.
+    ///
+    /// Called from host-ceremony screens too (the built-in-UV pad, an Approve/Deny prompt),
+    /// where the worker still holds `fs` borrowed for the whole command — so read the
+    /// PIN-set bit with `try_borrow_mut` and fall back to the cached `home_pin_set` rather
+    /// than double-borrowing. That fallback is accurate: a device PIN can't change mid-
+    /// ceremony, and it stays fresh past an on-device set (see [`Ui::run_set_pin`]).
     pub(super) fn enter_sleep(&mut self) {
-        if rsk_fido::passkeys::device_pin_is_set(&mut self.fs.borrow_mut()) {
+        let pin_set = match self.fs.try_borrow_mut() {
+            Ok(mut fs) => rsk_fido::passkeys::device_pin_is_set(&mut fs),
+            Err(_) => self.home_pin_set,
+        };
+        if pin_set {
             self.locked = true;
         }
         self.sleep();
@@ -79,11 +89,13 @@ impl Ui {
         }
     }
 
-    /// Poll the sleep/wake button from inside a browse modal: if pressed, sleep now
-    /// (auto-locking like any sleep), wait for release, and return `true` so the modal
-    /// exits to the now-asleep [`status_task`]. `status_task` polls the button itself on
-    /// Home / Locked, so calling this in the tab modals makes the power button sleep the
-    /// device from *any* on-device screen, not just Home.
+    /// Poll the sleep/wake button from inside a modal: if pressed, sleep now (auto-locking
+    /// like any sleep), wait for release, and return `true` so the caller abandons its wait
+    /// and unwinds to the now-asleep [`status_task`]. Called from every blocking on-device
+    /// loop — browse modals, the PIN pad, hold-to-confirm, and the host Approve/Deny prompts
+    /// — so the power button sleeps the device from *any* screen, not just Home. Each caller
+    /// must, after a `true`, either return itself or check `self.asleep` so the sleep
+    /// propagates up (a parent loop that keeps polling a blanked panel reads touches blind).
     pub(super) fn sleep_button_pressed(&mut self) -> bool {
         if self.wake_pressed() {
             self.enter_sleep();

--- a/firmware/src/display/presence.rs
+++ b/firmware/src/display/presence.rs
@@ -87,6 +87,12 @@ impl TouchPresence {
             let mut hold_start: Option<Instant> = None;
             let mut last_num: u16 = 0;
             loop {
+                // The power button sleeps (and auto-locks) from a host confirm prompt too;
+                // aborting the ceremony (→ Cancelled) is the safe outcome, like a decline —
+                // no signature is ever produced without the deliberate on-screen hold.
+                if u.sleep_button_pressed() {
+                    break Outcome::Cancelled;
+                }
                 match u.touch.read().and_then(rsk_ui::hit_confirm) {
                     Some(Button::Deny) => break Outcome::Declined,
                     Some(Button::Allow) => {
@@ -149,6 +155,11 @@ impl TouchPresence {
             let _ = rsk_ui::render_add_passkey(&mut u.panel, &rp, &account);
             u.shown = None;
             loop {
+                // The power button sleeps (and auto-locks) from the registration card too,
+                // abandoning it (→ Cancelled) like a lifted finger that times out.
+                if u.sleep_button_pressed() {
+                    break Outcome::Cancelled;
+                }
                 match u.touch.read().and_then(rsk_ui::hit_confirm) {
                     Some(Button::Allow) => break Outcome::Confirmed,
                     Some(Button::Deny) => break Outcome::Declined,

--- a/firmware/src/display/status.rs
+++ b/firmware/src/display/status.rs
@@ -198,20 +198,24 @@ pub async fn status_task(ui: &'static RefCell<Ui>) {
                                 // through collect_pin's ambient-quiet window.
                                 u.run_unlock();
                                 note_activity();
-                                let screen = if u.locked {
-                                    Screen::Locked
-                                } else {
-                                    // Just unlocked: a host op during the lock may have
-                                    // changed the count, so refresh before painting Home.
-                                    u.refresh_home_stats();
-                                    Screen::Home(HomeView {
-                                        status: status_to_kind(led::status()),
-                                        pin_set: u.home_pin_set,
-                                        passkeys: u.home_passkeys,
-                                    })
-                                };
-                                let _ = rsk_ui::render(&mut u.panel, &screen);
-                                u.shown = Some(screen);
+                                // The power button can sleep from the unlock pad; the panel is
+                                // then blanked, so leave the repaint to the wake path.
+                                if !u.asleep {
+                                    let screen = if u.locked {
+                                        Screen::Locked
+                                    } else {
+                                        // Just unlocked: a host op during the lock may have
+                                        // changed the count, so refresh before painting Home.
+                                        u.refresh_home_stats();
+                                        Screen::Home(HomeView {
+                                            status: status_to_kind(led::status()),
+                                            pin_set: u.home_pin_set,
+                                            passkeys: u.home_passkeys,
+                                        })
+                                    };
+                                    let _ = rsk_ui::render(&mut u.panel, &screen);
+                                    u.shown = Some(screen);
+                                }
                             } else if u.onboarding {
                                 // Fresh PIN-less device: route the tap to the onboarding
                                 // buttons (Set a PIN / Continue without). Repaint at once —
@@ -221,17 +225,21 @@ pub async fn status_task(ui: &'static RefCell<Ui>) {
                                 // resolves the prompt, so the cached stats are current here.
                                 u.run_onboarding(p);
                                 note_activity();
-                                let screen = if u.onboarding {
-                                    Screen::Onboard
-                                } else {
-                                    Screen::Home(HomeView {
-                                        status: status_to_kind(led::status()),
-                                        pin_set: u.home_pin_set,
-                                        passkeys: u.home_passkeys,
-                                    })
-                                };
-                                let _ = rsk_ui::render(&mut u.panel, &screen);
-                                u.shown = Some(screen);
+                                // Setting a PIN here runs the pad, which the power button can
+                                // sleep from; skip the repaint when it did (panel blanked).
+                                if !u.asleep {
+                                    let screen = if u.onboarding {
+                                        Screen::Onboard
+                                    } else {
+                                        Screen::Home(HomeView {
+                                            status: status_to_kind(led::status()),
+                                            pin_set: u.home_pin_set,
+                                            passkeys: u.home_passkeys,
+                                        })
+                                    };
+                                    let _ = rsk_ui::render(&mut u.panel, &screen);
+                                    u.shown = Some(screen);
+                                }
                             } else {
                                 // A tap on the bottom nav opens a tab. Each tab modal returns
                                 // the next nav destination, so the user switches tab→tab
@@ -250,27 +258,32 @@ pub async fn status_task(ui: &'static RefCell<Ui>) {
                                     };
                                 }
                                 note_activity(); // a browse session just ended — restart clock
-                                // If the menu closed with the UI locked (the power button slept
-                                // + locked it from inside Settings), keep Locked as the shown
-                                // state so the menu can't linger.
-                                if u.locked {
-                                    let screen = Screen::Locked;
-                                    let _ = rsk_ui::render(&mut u.panel, &screen);
-                                    u.shown = Some(screen);
-                                } else if opened_tab && !crate::worker::host_request_pending() {
-                                    // Closing a tab back to idle repaints Home now (not next
-                                    // poll) so it feels instant. Skip if a host command is
-                                    // queued — the worker paints next (no stale flash). The
-                                    // tab modal may have added/deleted a passkey or set the
-                                    // PIN, so refresh the card facts first.
-                                    u.refresh_home_stats();
-                                    let screen = Screen::Home(HomeView {
-                                        status: status_to_kind(led::status()),
-                                        pin_set: u.home_pin_set,
-                                        passkeys: u.home_passkeys,
-                                    });
-                                    let _ = rsk_ui::render(&mut u.panel, &screen);
-                                    u.shown = Some(screen);
+                                // The power button can sleep from inside a tab modal; the panel
+                                // is then blanked (and locked if a PIN is set), so leave the
+                                // repaint to status_task's wake path and paint here only awake.
+                                if !u.asleep {
+                                    if u.locked {
+                                        // The menu closed with the UI locked (a sub-flow slept
+                                        // + locked without blanking is impossible, so this is
+                                        // unreachable today, but keeps Locked from lingering).
+                                        let screen = Screen::Locked;
+                                        let _ = rsk_ui::render(&mut u.panel, &screen);
+                                        u.shown = Some(screen);
+                                    } else if opened_tab && !crate::worker::host_request_pending() {
+                                        // Closing a tab back to idle repaints Home now (not next
+                                        // poll) so it feels instant. Skip if a host command is
+                                        // queued — the worker paints next (no stale flash). The
+                                        // tab modal may have added/deleted a passkey or set the
+                                        // PIN, so refresh the card facts first.
+                                        u.refresh_home_stats();
+                                        let screen = Screen::Home(HomeView {
+                                            status: status_to_kind(led::status()),
+                                            pin_set: u.home_pin_set,
+                                            passkeys: u.home_passkeys,
+                                        });
+                                        let _ = rsk_ui::render(&mut u.panel, &screen);
+                                        u.shown = Some(screen);
+                                    }
                                 }
                             }
                         } else {

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x07F3;
+    let device_release: u16 = 0x07F4;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x07F1;
+    let device_release: u16 = 0x07F2;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x07F2;
+    let device_release: u16 = 0x07F3;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/nix/firmware.nix
+++ b/nix/firmware.nix
@@ -223,8 +223,8 @@ in
     };
     # Trusted-display flavor for the Waveshare RP2350-Touch-LCD-2.8: 16 MB flash,
     # and the ST7789 panel is the status indicator instead of an addressable LED
-    # (LED_KIND=none), which also frees GPIO16 for the backlight. Experimental and
-    # off the release matrix until the panel is HW-verified (Phase 1).
+    # (LED_KIND=none), which also frees GPIO16 for the backlight. Experimental;
+    # the panel is HW-verified (Phase 1), so it now ships in the signed release.
     firmware-display = mkFirmware {
       name = "firmware-display";
       flashSize = "16M";


### PR DESCRIPTION
Release **v0.3.2** — trusted-display sleep fix, `age-plugin-yubikey` interop fixes, and the trusted-display release flavor.

## Firmware (bcdDevice 0x07F1 → 0x07F4)
- **fix(display):** the power/WAKE button now sleeps + auto-locks the device from *every* on-device screen — the PIN pad, hold-to-confirm gestures, the "PIN blocked" notice, the success pop, and the host Approve/Deny & "Save passkey?" prompts (reported case: the PIN-entry screen ignored it). A host ceremony interrupted this way is aborted, never approved.
- **fix(piv):** keep PIN verification across a management-key mutual auth — a successful GENERAL AUTHENTICATE no longer re-locks the session PIN unless an actual key-slot signs, fixing `age-plugin-yubikey --generate` hitting `6982`.
- **fix(ccid):** chain a no-`Le` (Case-3) `GET DATA` response over 256 bytes with `61xx` / `GET RESPONSE`, so `yubikey.rs`-based tools (age-plugin) can read retired-slot certificates that were showing as "(Empty)".

## Release / CI
- **Releases now build and publish the trusted-display flavor** `rs-key-<tag>-display.uf2` — reproducibility-gated, signed and attested like the other flavors; CI also packages a build-smoke `firmware-display.uf2`.
- Threat-model citations (WebUSB phishing, Qubes CTAP proxy).

## Tests
- Host-side CTAP2 + U2F conformance layer (67 tests) and a retired-slot certificate round-trip test — internal quality, no wire change.

Gate green on every commit; the sleep fix was flashed and HW-verified on the display board (bcdDevice 0x07F4). See [CHANGELOG](CHANGELOG.md) `[0.3.2]`.