### PR TITLE
Release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **OpenPGP decrypt no longer breaks after a `VERIFY` of both PW1 modes (issue
+  #25).** `gpg`/`scdaemon` verifies one PIN entry into both PW1 modes
+  back-to-back — mode `82` (DECIPHER/INTERNAL AUTH) then mode `81` (signing) —
+  before a decrypt. `check_pin` cleared **both** PW1 latches on every successful
+  verify and re-raised only the current one, so the trailing mode-`81` verify
+  silently dropped the mode-`82` authorization the next `PSO:DECIPHER` needs,
+  which then returned `6982` and surfaced to the user as `Bad PIN` with the
+  correct PIN (typically after a replug, once `scdaemon` re-ran the full verify
+  sequence). PW1.81, PW1.82 and PW3 are now treated as the independent access
+  latches the card spec requires — a successful `VERIFY` raises only its own.
+  Session-only state; no wire or on-flash format change. Firmware `bcdDevice`
+  → `0x0809`.
 - **A `put` past the dynamic-file cap no longer strands its value on flash.** A
   new runtime file (e.g. a resident credential) written once the dynamic set is
   full committed its bytes to flash *before* the cap check rejected it, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,69 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `put` past the dynamic-file cap no longer strands its value on flash.** A
+  new runtime file (e.g. a resident credential) written once the dynamic set is
+  full committed its bytes to flash *before* the cap check rejected it, so the
+  caller saw `NoMemory` while the value stayed on flash — readable yet
+  unregistered, and re-dropped by every reboot rescan at the same cap. The cap
+  is now enforced before the write, so an over-cap `put` fails atomically and
+  leaves no trace. Latent (it needs 256 dynamic files to trigger); no wire or
+  on-flash format change. Firmware `bcdDevice` → `0x07FD`.
+- **OpenPGP `PUT DATA` for the PW-status DO (`C4`) can no longer overwrite the
+  PIN retry counters.** `put_pw_status` capped the copy at the full 7-byte
+  record, so a ≥5-byte field wrote host bytes over the live PW1/RC/PW3 retry
+  counters — its own doc comment says they are preserved; they were not. A host
+  (malicious or a buggy 7-byte read-modify-write) could zero them and block
+  every PIN across a power cycle, recoverable only by a key-destroying
+  `TERMINATE DF`. The copy is now capped at the writable prefix (flag + the
+  three max-length bytes); the retry counters are read-only. PW3-gated, so no
+  privilege change. Firmware `bcdDevice` → `0x07FE`.
+- **PIV `MOVE KEY` onto a key's own slot (`p1 == p2`) no longer destroys it.**
+  A self-move wrote the sealed key/cert/metadata back into the slot and then
+  unconditionally deleted the *source* — the same slot — leaving it empty while
+  returning `0x9000`, silently erasing the (possibly only) key. Same-slot moves
+  are now rejected with `INCORRECT_P1P2` before any write, matching real
+  hardware. Management-key-gated, so no privilege change. Firmware `bcdDevice`
+  → `0x07FF`.
+- **OpenPGP empty-data `VERIFY` in PW2 mode (`P2=0x82`) reports PW1's retries
+  again.** The `EF_RC → EF_PW1` remap was gated on a non-empty data field, so a
+  status query (`00 20 00 82 00`) probed the reset-code EF instead of the shared
+  PW1 verifier — answering `6A88`, or a spurious `PIN_BLOCKED` when a reset code
+  was configured and blocked. The remap now applies to the status query too.
+  Firmware `bcdDevice` → `0x0800`.
+- **FIDO `getAssertion` no longer over-reports `numberOfCredentials`.** With more
+  than `MAX_ASSERTION_CREDS` (16) discoverable credentials for one RP, the count
+  reported the full match total while the `getNextAssertion` queue caps at 16, so
+  a platform was told to fetch more than the device could serve and hit a
+  premature `NOT_ALLOWED`. The count is now clamped to the servable queue size.
+  Firmware `bcdDevice` → `0x0801`.
+- **FIDO `getAssertion` binds an unscoped `pinUvAuthToken` to the request rpId on
+  first use (CTAP 2.1 §6.2.2).** A token minted without an rpId (legacy
+  `getPinToken`, or `0x09` with `ga` permission and no rpId) was reusable across
+  arbitrary RPs for its whole lifetime — `makeCredential` bound it but
+  `getAssertion` did not. It now binds on first use, so a later cross-RP
+  assertion fails `PinAuthInvalid`. Firmware `bcdDevice` → `0x0802`.
+- **CCID `XfrBlock` responses can no longer be silently truncated.** The applet
+  response buffer (`RESP_CAP`) was sized to the full 2048-byte CCID message
+  rather than its 2038-byte payload budget (message − 10-byte header), so a large
+  response (e.g. a long OATH `LIST`) overran one frame and `run_xfr` dropped the
+  trailing bytes including the status word. The buffer now matches the frame
+  payload budget. Firmware `bcdDevice` → `0x0803`.
+- **RSA keygen ignores a stale core1 prime when it did not engage the second
+  core.** When the core1 entry gate timed out (`engaged=false`), the search still
+  drained core1's find slots, which could hold a prime from the *previous*
+  (possibly different-size) keygen — combining it would yield a malformed modulus
+  with a weak factor. The search now consumes core1's finds only when it actually
+  engaged core1 this keygen; stale finds are scrubbed at wind-down. Astronomically
+  rare, but a real undefended race. Firmware `bcdDevice` → `0x0804`.
+- **LED breathing effect no longer flickers dark at its peak.** `effect_vapor`
+  divided the falling ramp by `period/2` (floor) over `half+1` steps, so for an
+  odd `speed` the brightness could exceed `peak` at the apex and wrap to a dark
+  value through the `u8` cast. The value is clamped to `peak` before the cast.
+  Firmware `bcdDevice` → `0x0805`.
+
 ## [0.3.3] — 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,26 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   credentials from older firmware carry an implicit v1 marker and keep deriving
   from the box, so an already-provisioned device is unaffected. No box or
   on-flash format change. Firmware `bcdDevice` → `0x0806`.
+- **PIV `SET PIN RETRIES` (INS `0xFA`) now requires the PIN, not just the
+  management key.** The handler gated only on the management key, then reset the
+  PIN and PUK to their public defaults ("123456" / "12345678"). Because the
+  default management key is public and the `9B` slot is touch-`NEVER`, a host
+  that authenticated it could reset an *unknown* cardholder PIN without knowing
+  it — locking the legitimate user out, and (for a touch-`NEVER` key slot) using
+  their PIN-protected keys after verifying the now-default PIN. It now demands
+  the current PIN as well, matching YubiKey's `set-pin-retries`. Reachable only
+  by an already-management-authenticated caller, so no new privilege for a
+  legitimate admin. Firmware `bcdDevice` → `0x0807`.
+- **FIDO vendor `AUDIT_READ` (`0x41 / 0x07`) now requires a touch on a device
+  with no PIN.** With no clientPIN the PIN gate is a no-op, so any local process
+  could export the tamper-evident journal, whose per-entry `detail` is a 64-bit
+  `rpIdHash` prefix — short enough to dictionary-match back to the relying
+  parties a no-PIN device had been used with (the entries are only weakly
+  pseudonymous, not anonymous). A physical touch is now required in that case,
+  matching the sibling `AUDIT_CHECKPOINT`; a PIN-backed device is unchanged.
+  Privacy hardening — no key material is exposed. The `rsk` CLI (`0.3.9`) and TUI
+  (`0.2.9`) clients now prompt for that touch and map its denial. Firmware
+  `bcdDevice` → `0x0808`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,19 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   odd `speed` the brightness could exceed `peak` at the apex and wrap to a dark
   value through the `u8` cast. The value is clamped to `peak` before the cast.
   Firmware `bcdDevice` → `0x0805`.
+- **`updateUserInformation` no longer breaks a passkey by rotating its keys.**
+  Editing a resident credential's user name (CTAP2.1 `authenticatorCredential
+  Management` 0x07) reseals the credential box with a fresh IV. The signing key,
+  hmac-secret and largeBlobKey were all derived from that box, so they rotated on
+  every update — the relying party's stored public key stopped verifying and the
+  passkey was effectively bricked. New resident credentials now stamp a **v2
+  version byte** into their 42-byte resident id (a reserved header byte, outside
+  the id's HMAC chain) and derive those three keys from the **stable** id instead
+  of the box, so they survive the reseal. The credential id itself was already
+  preserved; this extends that stability to the keys. Forward-compatible: resident
+  credentials from older firmware carry an implicit v1 marker and keep deriving
+  from the box, so an already-provisioned device is unaffected. No box or
+  on-flash format change. Firmware `bcdDevice` → `0x0806`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.3.4] — 2026-07-12
+
 ### Fixed
 
 - **OpenPGP decrypt no longer breaks after a `VERIFY` of both PW1 modes (issue
@@ -1341,7 +1343,8 @@ family that keeps the "enterprise" features in the open tree.
   signature of it, and a CycloneDX SBOM. See
   [docs/releases.md](docs/releases.md) to verify a download.
 
-[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,19 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   value through the `u8` cast. The value is clamped to `peak` before the cast.
   Firmware `bcdDevice` → `0x0805`.
 
+### Changed
+
+- **`rsk` CLI and `rsk-tui` harden their handling of device-controlled data.** A
+  counterfeit or malfunctioning USB device that returned non-string/absent
+  getInfo fields (`versions`, `aaguid`, `clientPin`) or a malformed soft-lock
+  state could crash `rsk status` / `rsk inventory list` / `rsk lock` with an
+  uncaught `TypeError`, or inject ANSI/OSC/bidi escapes into the operator's
+  terminal via unsanitized `clientPin`/lock-state strings; `rsk-tui --json` left
+  DEL/C1/bidi bytes unescaped. All device-controlled display values now route
+  through the shared sanitizer or a type-guarded join, bool-coerced where
+  appropriate, and the TUI `--json` writer escapes every control and non-ASCII
+  char. Host-only (`rsk` `0.3.8`, `rsk-tui` `0.2.8`); no firmware change.
+
 ## [0.3.3] — 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,26 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   (`0.2.9`) clients now prompt for that touch and map its denial. Firmware
   `bcdDevice` → `0x0808`.
 
+### Security
+
+- **Dual-core RSA keygen rejects a wrong-size prime at the inter-core handoff.**
+  `RsaKeygen::offer_le` — the byte-transport entry the core0 drain feeds core1's
+  finds through — converted whatever length it was handed, so a stale prime from
+  a prior different-size keygen would have corrupted the assembled modulus. The
+  mailbox is scrubbed on engage and keygens are serialized on the worker, so this
+  never fires today; the length check is a belt-and-suspenders backstop that fails
+  a mismatched find closed even if a future refactor reopened the handoff window.
+  Defense-in-depth (found in the run-16 audit); no wire or on-flash format change.
+  Firmware `bcdDevice` → `0x080B`.
+- **PIV `GENERAL AUTHENTICATE` rejects a key slot with a truncated metadata
+  record.** The handler read the PIN- and touch-policy bytes without checking the
+  meta record was at least the 3-byte `[algo, pin, touch]` header, unlike
+  `info::read_slot`; a sub-header record would have read policy from the zero-fill
+  and skipped the touch gate. Every metadata writer emits ≥ 3 bytes, so no slot
+  can reach this state — the guard is a defense-in-depth backstop (found in the
+  run-16 audit) matching the sibling reader. No wire or on-flash format change.
+  Firmware `bcdDevice` → `0x080A`.
+
 ### Changed
 
 - **`rsk` CLI and `rsk-tui` harden their handling of device-controlled data.** A

--- a/crates/rsk-fido/src/credential.rs
+++ b/crates/rsk-fido/src/credential.rs
@@ -115,6 +115,20 @@ pub(crate) const NICK_BOX_MAX: usize = IV_LEN + RP_NICK_MAX_LEN + TAG_LEN;
 pub const CRED_RESIDENT_LEN: usize = 42;
 const CRED_RESIDENT_HEADER_LEN: usize = 10;
 
+/// Offset of the resident-id format marker — a reserved header byte that sits
+/// OUTSIDE the `[10..42]` HMAC chain [`derive_resident`] fills, so it carries a
+/// version tag the RP treats as opaque without perturbing the id's entropy.
+/// It selects the key-derivation input (box vs. stable resident id) for the
+/// credential's signing / hmac-secret / largeBlobKey keys — see
+/// [`resident_key_input`].
+const RESIDENT_VERSION_IDX: usize = 8;
+/// v2 marker: the signing / hmac-secret / largeBlobKey keys derive from the
+/// STABLE resident id, so they survive an updateUserInformation reseal (CTAP2.1
+/// §6.8). Every newly created resident credential is v2; older stored credentials
+/// carry the implicit v1 marker (0) and keep deriving from the box, so an
+/// already-provisioned device stays byte-for-byte compatible across the upgrade.
+const RESIDENT_VERSION_V2: u8 = 1;
+
 /// Credential extensions sealed into the box. `minPinLength` is not stored —
 /// it is a request-only flag that gates the authData `minPINLength` output.
 #[derive(Clone, Copy, Default)]
@@ -428,14 +442,19 @@ fn parse_body(cbor: &[u8]) -> Option<Credential<'_>> {
 }
 
 /// The 42-byte resident id returned to the RP for a resident credential.
-/// Header = `serial-derived(4) ‖ proto23(4) ‖ 00 00`, then a 32-byte HMAC
-/// chain over the box.
+/// Header = `serial-derived(4) ‖ proto23(4) ‖ version(1) ‖ 00`, then a 32-byte
+/// HMAC chain over the box. The version byte ([`RESIDENT_VERSION_IDX`]) is not
+/// part of the chain (which spans `[10..42]`), so setting it leaves the id's
+/// entropy — and every already-stored v1 id's `[10..42]` — unchanged. New
+/// resident credentials are stamped v2 so their keys derive from this stable id
+/// (see [`resident_key_input`]); it is written only at create time and never
+/// re-derived for a lookup, so the flip cannot strand older stored ids.
 pub fn derive_resident(cred_id: &[u8], dev: &Device) -> [u8; CRED_RESIDENT_LEN] {
     let mut outk = [0u8; CRED_RESIDENT_LEN];
     let h0 = hmac_sha256(&[0u8; 32], dev.serial_id);
     outk[..32].copy_from_slice(&h0);
     outk[4..8].copy_from_slice(CRED_PROTO_RESIDENT);
-    outk[8] = 0;
+    outk[RESIDENT_VERSION_IDX] = RESIDENT_VERSION_V2;
     outk[9] = 0;
 
     let mut cred_idr = [0u8; 32];
@@ -470,6 +489,35 @@ pub fn derive_large_blob_key(seed: &[u8; 32], cred_id: &[u8]) -> [u8; 32] {
     k = hmac_sha256(&k, b"largeBlobKey");
     k = hmac_sha256(&k, cred_id);
     k
+}
+
+/// The key-derivation input for a credential's signing key ([`fido_load_key`]),
+/// hmac-secret ([`derive_hmac_key`]) and largeBlobKey ([`derive_large_blob_key`]).
+///
+/// A **v2 resident** credential (its stored `resident_id` carries the
+/// [`RESIDENT_VERSION_V2`] marker) keys off that STABLE id, so the keys survive an
+/// updateUserInformation reseal — which draws a fresh IV and thus a new box
+/// ([`crate::credmgmt`], CTAP2.1 §6.8). Every other case keys off the box exactly
+/// as before: a **v1** resident credential (older, marker 0) so the RP's stored
+/// pubkey still verifies, and a **non-resident** credential (`resident_id` is
+/// `None`) which has no stable id and cannot be resealed anyway.
+///
+/// Callers MUST route ALL THREE derivations through this so the pubkey issued at
+/// makeCredential and the key used at every assertion / enumeration path agree —
+/// a single site left on the box would make v2 passkeys fail to verify.
+pub(crate) fn resident_key_input<'a>(
+    cred_box: &'a [u8],
+    resident_id: Option<&'a [u8]>,
+) -> &'a [u8] {
+    match resident_id {
+        Some(rid)
+            if rid.len() == CRED_RESIDENT_LEN
+                && rid[RESIDENT_VERSION_IDX] == RESIDENT_VERSION_V2 =>
+        {
+            rid
+        }
+        _ => cred_box,
+    }
 }
 
 /// A resident record is `rp_id_hash(32) ‖ resident_id(42) ‖ full_cred_id`.

--- a/crates/rsk-fido/src/credential_tests.rs
+++ b/crates/rsk-fido/src/credential_tests.rs
@@ -174,21 +174,35 @@ fn resident_id_format_and_determinism() {
     assert!(is_resident(&r1));
 }
 
-// The v2 marker sits OUTSIDE the [10..42] hash chain, so flipping it does not
-// perturb the id's entropy: an id built with a v1 marker (0) shares the [10..42]
-// tail with the v2 id for the same box. This is what makes the flip forward-safe
-// for already-stored v1 ids.
+// The v2 marker sits OUTSIDE the [10..42] HMAC chain, so it never feeds the id's
+// entropy. Prove it by recomputing the chain independently from ONLY its documented
+// inputs — the serial-derived header tail and the box — with the version byte
+// nowhere in the seed. If a refactor ever folded offset 8 into the chain, the real
+// id would diverge from this recomputation. (Flipping byte 8 on a COPY of the output
+// and comparing the tail proves nothing — the tail is below the mutated index by
+// construction, so it is equal for any array.)
 #[test]
 fn resident_version_marker_is_outside_the_hash_chain() {
     let d = dev();
     let cred_id = [0x55u8; 80];
-    let v2 = derive_resident(&cred_id, &d);
-    let mut v1 = v2;
-    v1[RESIDENT_VERSION_IDX] = 0;
+    let id = derive_resident(&cred_id, &d);
+    assert_eq!(id[RESIDENT_VERSION_IDX], RESIDENT_VERSION_V2);
+
+    // Seed = the pre-chain contents of outk[10..42]: the serial HMAC's tail
+    // (h0[10..32]) then zeroes. The version byte at offset 8 is not part of it.
+    let h0 = hmac_sha256(&[0u8; 32], d.serial_id);
+    let mut seed = [0u8; CRED_RESIDENT_LEN - CRED_RESIDENT_HEADER_LEN];
+    let tail = &h0[CRED_RESIDENT_HEADER_LEN..];
+    seed[..tail.len()].copy_from_slice(tail);
+
+    let mut chain = hmac_sha256(&seed, b"SLIP-0022");
+    chain = hmac_sha256(&chain, &cred_id[..PROTO_LEN]);
+    chain = hmac_sha256(&chain, b"resident");
+    chain = hmac_sha256(&chain, &cred_id);
     assert_eq!(
-        v1[CRED_RESIDENT_HEADER_LEN..],
-        v2[CRED_RESIDENT_HEADER_LEN..],
-        "marker byte must not change the [10..42] chain"
+        &id[CRED_RESIDENT_HEADER_LEN..],
+        &chain[..],
+        "the [10..42] chain must not read the version byte at offset 8"
     );
 }
 

--- a/crates/rsk-fido/src/credential_tests.rs
+++ b/crates/rsk-fido/src/credential_tests.rs
@@ -168,7 +168,89 @@ fn resident_id_format_and_determinism() {
     assert_eq!(r1, r2);
     assert_eq!(r1.len(), CRED_RESIDENT_LEN);
     assert_eq!(&r1[4..8], CRED_PROTO_RESIDENT);
+    // New resident ids are stamped v2 (byte 8), in the header before the chain.
+    assert_eq!(r1[RESIDENT_VERSION_IDX], RESIDENT_VERSION_V2);
+    assert_eq!(r1[9], 0);
     assert!(is_resident(&r1));
+}
+
+// The v2 marker sits OUTSIDE the [10..42] hash chain, so flipping it does not
+// perturb the id's entropy: an id built with a v1 marker (0) shares the [10..42]
+// tail with the v2 id for the same box. This is what makes the flip forward-safe
+// for already-stored v1 ids.
+#[test]
+fn resident_version_marker_is_outside_the_hash_chain() {
+    let d = dev();
+    let cred_id = [0x55u8; 80];
+    let v2 = derive_resident(&cred_id, &d);
+    let mut v1 = v2;
+    v1[RESIDENT_VERSION_IDX] = 0;
+    assert_eq!(
+        v1[CRED_RESIDENT_HEADER_LEN..],
+        v2[CRED_RESIDENT_HEADER_LEN..],
+        "marker byte must not change the [10..42] chain"
+    );
+}
+
+// The reseal-stability fix at the derivation level: a v2 resident id is the key
+// input regardless of the (resealed) box, so the signing / hmac-secret /
+// largeBlobKey derivations are identical across an updateUserInformation box
+// swap; a v1 id (older firmware) still follows the box; a non-resident box has no
+// id. Also pins per-credential key uniqueness.
+#[test]
+fn resident_key_input_v2_is_reseal_stable_v1_follows_box() {
+    use crate::keyderiv::fido_load_key;
+    let d = dev();
+    // Two DIFFERENT boxes, as an updateUserInformation reseal (fresh IV) yields.
+    let box1 = [0x55u8; 80];
+    let box2 = [0xAAu8; 80];
+
+    let rid = derive_resident(&box1, &d);
+    assert_eq!(rid[RESIDENT_VERSION_IDX], RESIDENT_VERSION_V2);
+
+    // v2: the key input is the STABLE id, independent of the box.
+    assert_eq!(resident_key_input(&box1, Some(&rid[..])), &rid[..]);
+    assert_eq!(resident_key_input(&box2, Some(&rid[..])), &rid[..]);
+    let (ki1, ki2) = (
+        resident_key_input(&box1, Some(&rid[..])),
+        resident_key_input(&box2, Some(&rid[..])),
+    );
+    assert_eq!(
+        fido_load_key(&SEED, ki1),
+        fido_load_key(&SEED, ki2),
+        "signing key stable across reseal"
+    );
+    assert_eq!(
+        derive_hmac_key(&SEED, ki1),
+        derive_hmac_key(&SEED, ki2),
+        "hmac-secret stable across reseal"
+    );
+    assert_eq!(
+        derive_large_blob_key(&SEED, ki1),
+        derive_large_blob_key(&SEED, ki2),
+        "largeBlobKey stable across reseal"
+    );
+
+    // v1 (marker 0): the key input is the box, so the RP's box-derived pubkey
+    // keeps verifying — no rotation, no regression for older credentials.
+    let mut rid_v1 = rid;
+    rid_v1[RESIDENT_VERSION_IDX] = 0;
+    assert_eq!(resident_key_input(&box1, Some(&rid_v1[..])), &box1[..]);
+    assert_eq!(resident_key_input(&box2, Some(&rid_v1[..])), &box2[..]);
+
+    // Non-resident credential: no resident id → the box.
+    assert_eq!(resident_key_input(&box1, None), &box1[..]);
+
+    // Uniqueness: two distinct credentials get distinct v2 ids → distinct keys.
+    let rid_other = derive_resident(&box2, &d);
+    assert_ne!(
+        rid[CRED_RESIDENT_HEADER_LEN..],
+        rid_other[CRED_RESIDENT_HEADER_LEN..]
+    );
+    assert_ne!(
+        fido_load_key(&SEED, &rid[..]),
+        fido_load_key(&SEED, &rid_other[..])
+    );
 }
 
 #[test]

--- a/crates/rsk-fido/src/credmgmt.rs
+++ b/crates/rsk-fido/src/credmgmt.rs
@@ -25,8 +25,8 @@ use crate::consts::{
 };
 use crate::credential::{
     CRED_BOX_MAX, CRED_REC_MAX, CRED_RESIDENT_LEN, CredInput, RECORD_PREFIX, RP_PREFIX, RP_REC_MAX,
-    USER_NAME_MAX, credential_create, credential_load, derive_large_blob_key, slot_map,
-    truncate_utf8, unseal_rp_id,
+    USER_NAME_MAX, credential_create, credential_load, derive_large_blob_key, resident_key_input,
+    slot_map, truncate_utf8, unseal_rp_id,
 };
 use crate::ec::CredKey;
 use crate::error::{CtapError, CtapResult};
@@ -412,12 +412,15 @@ fn enumerate_creds_response(
 ) -> CtapResult {
     let resident_id = &rec[32..RECORD_PREFIX];
     let cred_box = &rec[RECORD_PREFIX..];
+    // The enumerated pubkey must be the one getAssertion signs with: a v2
+    // credential keys off its stable resident id, so both agree across a reseal.
+    let key_input = resident_key_input(cred_box, Some(resident_id));
 
     let mut scratch = [0u8; CRED_REC_MAX];
     let cred =
         credential_load(seed, cred_box, rp_id_hash, &mut scratch).ok_or(CtapError::NotAllowed)?;
 
-    let mut raw = fido_load_key(seed, cred_box).ok_or(CtapError::NotAllowed)?;
+    let mut raw = fido_load_key(seed, key_input).ok_or(CtapError::NotAllowed)?;
     let key = CredKey::from_raw(cred.curve, &raw).ok_or(CtapError::NotAllowed)?;
     raw.zeroize();
 
@@ -429,7 +432,7 @@ fn enumerate_creds_response(
     // 0x0B largeBlobKey (derived, when the credential opted in), 0x0C
     // thirdPartyPayment (always).
     let large_blob_key = if cred.ext.large_blob_key {
-        Some(derive_large_blob_key(seed, cred_box))
+        Some(derive_large_blob_key(seed, key_input))
     } else {
         None
     };
@@ -571,8 +574,9 @@ pub(crate) fn decrement_rp<S: Storage>(
 /// 0x07 updateUserInformation: reseal the credential with a new user name /
 /// display name (same rp + user id). Replies with only the status byte.
 ///
-/// Quirk: resealing draws a fresh IV, so the credential box — and hence its
-/// derived resident id — changes, staling the platform's stored credentialId.
+/// The stored resident id (the platform's credentialId) and — for a v2
+/// credential — the signing / hmac-secret / largeBlobKey keys all stay stable
+/// across the reseal; see [`reseal_user`].
 fn update_user<S: Storage, R: Rng>(
     ctx: &mut Ctx<S, R>,
     cred_id: &[u8],
@@ -622,10 +626,13 @@ fn update_user<S: Storage, R: Rng>(
 /// platform's recorded id misses the (rotated) stored id → NO_CREDENTIALS
 /// (conformance CredMgmt-UpdateAndDelete P-2).
 ///
-/// Known limitation: the signing key, hmac-secret and largeBlobKey are all
-/// derived from the (now changed) box, so they DO rotate on an update. Keeping
-/// them stable too needs a per-credential nonce decoupled from the IV — a
-/// deferred, box-format-changing refactor — and is not required for conformance.
+/// The credential's signing key, hmac-secret and largeBlobKey stay stable too:
+/// v2 credentials derive them from the preserved resident id
+/// ([`credential::resident_key_input`]), not the box, so the RP's stored pubkey
+/// keeps verifying after an update. Legacy v1 credentials (created before that
+/// marker) still key off the box and so DO rotate on an update — the id derived
+/// from a v1 box is not re-issued, so this only affects passkeys made by older
+/// firmware, not any created since.
 #[allow(clippy::too_many_arguments)]
 fn reseal_user<S: Storage, R: Rng>(
     ctx: &mut Ctx<S, R>,

--- a/crates/rsk-fido/src/credmgmt_tests.rs
+++ b/crates/rsk-fido/src/credmgmt_tests.rs
@@ -456,11 +456,13 @@ fn enumerate_emits_extension_fields() {
     }
     assert_eq!(cp, Some(3), "credProtect");
     assert_eq!(tpp, Some(false), "thirdPartyPayment always emitted");
-    // 0x0B is the derived largeBlobKey of the stored credential.
+    // 0x0B is the derived largeBlobKey of the stored credential. A v2 resident
+    // credential keys it off the stable resident id (rec[32..RECORD_PREFIX]), not
+    // the box, so that prefix is the expected derivation input.
     let mut rec = [0u8; 1024];
-    let m = fs.read(EF_CRED, &mut rec).unwrap();
+    let _m = fs.read(EF_CRED, &mut rec).unwrap();
     let seed = crate::seed::load_keydev(&dev(), &mut fs).unwrap();
-    let expected = derive_large_blob_key(&seed, &rec[RECORD_PREFIX..m]);
+    let expected = derive_large_blob_key(&seed, &rec[32..RECORD_PREFIX]);
     assert_eq!(lbk.as_deref(), Some(&expected[..]));
 }
 
@@ -1127,4 +1129,203 @@ fn update_user_reseals_maximal_box() {
     )
     .unwrap();
     assert_eq!(cred_user_name(&out[..n]), new_name);
+}
+
+// A getAssertion over allowList=[id] must sign authData‖clientDataHash under the
+// ECDSA public key (x, y). Proves the signing key is the one makeCredential
+// issued — used before AND after an updateUserInformation reseal.
+fn assert_ga_signs_under(fs: &mut Fs<RamStorage>, id: &[u8], x: &[u8; 32], y: &[u8; 32]) {
+    use p256::EncodedPoint;
+    use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+    let mut buf = [0u8; 256];
+    let req = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(3).unwrap();
+        e.u8(1).unwrap().str("example.com").unwrap();
+        e.u8(2).unwrap().bytes(&CDH).unwrap();
+        e.u8(3).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.str("id").unwrap().bytes(id).unwrap();
+        e.writer().position()
+    };
+    let mut out = [0u8; 1024];
+    let mut st = FidoState::new();
+    let mut rng = SeqRng(7);
+    let n = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs,
+            rng: &mut rng,
+            state: &mut st,
+            now_ms: 20,
+        };
+        crate::getassertion::get_assertion(&mut ctx, &buf[..req], &mut out).unwrap()
+    };
+    let mut d = Decoder::new(&out[..n]);
+    d.map().unwrap();
+    assert_eq!(d.u8().unwrap(), 1);
+    d.skip().unwrap(); // {id, type}
+    assert_eq!(d.u8().unwrap(), 2);
+    let ad = d.bytes().unwrap().to_vec();
+    assert_eq!(d.u8().unwrap(), 3);
+    let sig = d.bytes().unwrap().to_vec();
+    let pt = EncodedPoint::from_affine_coordinates(x.into(), y.into(), false);
+    let vk = VerifyingKey::from_encoded_point(&pt).unwrap();
+    let mut signed = ad;
+    signed.extend_from_slice(&CDH);
+    vk.verify(&signed, &Signature::from_der(&sig).unwrap())
+        .expect("assertion verifies under the original credential key");
+}
+
+// The largeBlobKey (enumerate field 0x0B) of an enumerateCredentials response.
+fn enum_largeblobkey(resp: &[u8]) -> Option<std::vec::Vec<u8>> {
+    let mut d = Decoder::new(resp);
+    let fields = d.map().unwrap().unwrap();
+    let mut lbk = None;
+    for _ in 0..fields {
+        if d.u8().unwrap() == 0x0B {
+            lbk = Some(d.bytes().unwrap().to_vec());
+        } else {
+            d.skip().unwrap();
+        }
+    }
+    lbk
+}
+
+// #3 end to end: updateUserInformation used to reseal the box and rotate its
+// box-derived signing key, so the RP's stored pubkey stopped verifying. v2
+// credentials key off the stable resident id — makeCredential's pubkey,
+// enumerateCredentials' pubkey and getAssertion's signing key all stay put across
+// the reseal.
+#[test]
+fn update_preserves_signing_key_end_to_end() {
+    let (mut fs, mut rng) = setup();
+    let (id, x, y) = register(&mut fs, &mut rng, "example.com", &[1, 1], "alice");
+    assert_eq!(id[8], 1, "new resident credential carries the v2 marker");
+    let rp_hash = sha256(b"example.com");
+
+    // Before the update, getAssertion already signs under the registered key.
+    assert_ga_signs_under(&mut fs, &id, &x, &y);
+
+    // updateUserInformation reseals the box (fresh IV → new box).
+    let mut state = armed(PERM_CM);
+    let mut out = [0u8; 512];
+    run(
+        &mut fs,
+        &mut state,
+        &cm_request(
+            0x07,
+            Some(&subpara_update(&id, &[1, 1], "alice2", "Alice Two")),
+            &TOKEN,
+        ),
+        &mut out,
+    )
+    .unwrap();
+
+    // enumerateCredentials reports the SAME pubkey after the reseal.
+    let n = run(
+        &mut fs,
+        &mut state,
+        &cm_request(0x04, Some(&subpara_rpidhash(&rp_hash)), &TOKEN),
+        &mut out,
+    )
+    .unwrap();
+    let (_uid, x2, y2, _t) = parse_cred(&out[..n], true);
+    assert_eq!((x2, y2), (x, y), "enumerate pubkey stable across update");
+
+    // And getAssertion STILL signs under the original key (the actual fix).
+    assert_ga_signs_under(&mut fs, &id, &x, &y);
+}
+
+// The largeBlobKey likewise survives the reseal (v2 keys off the stable id).
+#[test]
+fn update_preserves_largeblobkey() {
+    let (mut fs, mut rng) = setup();
+    let rp_hash = sha256(b"example.com");
+    // register() offers no extensions, so build a resident cred with largeBlobKey.
+    let mut buf = [0u8; 512];
+    let req = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(6).unwrap();
+        e.u8(1).unwrap().bytes(&CDH).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str("example.com")
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[8, 8]).unwrap();
+        e.str("name").unwrap().str("a").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(6).unwrap().map(1).unwrap();
+        e.str("largeBlobKey").unwrap().bool(true).unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    let mut out = [0u8; 1024];
+    {
+        let mut state = FidoState::new();
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 10,
+        };
+        make_credential(&mut ctx, &buf[..req], &mut out).unwrap();
+    }
+    let mut state = armed(PERM_CM);
+
+    // enumerate → capture id + largeBlobKey (0x0B).
+    let n = run(
+        &mut fs,
+        &mut state,
+        &cm_request(0x04, Some(&subpara_rpidhash(&rp_hash)), &TOKEN),
+        &mut out,
+    )
+    .unwrap();
+    let id = enumerated_cred_id(&out[..n]);
+    let lbk0 = enum_largeblobkey(&out[..n]);
+    assert!(lbk0.is_some(), "largeBlobKey present");
+
+    // updateUserInformation, then re-enumerate: same largeBlobKey.
+    run(
+        &mut fs,
+        &mut state,
+        &cm_request(
+            0x07,
+            Some(&subpara_update(&id, &[8, 8], "a2", "A Two")),
+            &TOKEN,
+        ),
+        &mut out,
+    )
+    .unwrap();
+    let n = run(
+        &mut fs,
+        &mut state,
+        &cm_request(0x04, Some(&subpara_rpidhash(&rp_hash)), &TOKEN),
+        &mut out,
+    )
+    .unwrap();
+    let lbk1 = enum_largeblobkey(&out[..n]);
+    assert_eq!(
+        lbk0, lbk1,
+        "largeBlobKey stable across updateUserInformation"
+    );
 }

--- a/crates/rsk-fido/src/getassertion.rs
+++ b/crates/rsk-fido/src/getassertion.rs
@@ -342,6 +342,12 @@ fn enforce_pin<S: Storage, R: Rng>(
             {
                 return Err(CtapError::PinAuthInvalid);
             }
+            // Bind an unscoped token to this rpId on first use (CTAP 2.1 §6.2.2),
+            // as makeCredential does — else it stays reusable across RPs.
+            if !ctx.state.paut.has_rp_id {
+                ctx.state.paut.rp_id_hash = *rp_id_hash;
+                ctx.state.paut.has_rp_id = true;
+            }
             Ok(true)
         }
         // alwaysUv forces user verification (CTAP 2.1 alwaysUv); otherwise an
@@ -694,8 +700,11 @@ fn get_assertion_inner<S: Storage, R: Rng>(
         }
     }
     if multi {
+        // Clamp to what the getNextAssertion queue can actually serve
+        // (MAX_ASSERTION_CREDS): over-reporting strands the excess credentials
+        // behind a premature NOT_ALLOWED.
         enc.u8(5)
-            .and_then(|e| e.u32(best.found))
+            .and_then(|e| e.u32(best.found.min(MAX_ASSERTION_CREDS as u32)))
             .map_err(|_| CtapError::Other)?;
     }
     if let Some(lbk) = large_blob_key {

--- a/crates/rsk-fido/src/getassertion.rs
+++ b/crates/rsk-fido/src/getassertion.rs
@@ -23,7 +23,8 @@ use crate::consts::{
 };
 use crate::credential::{
     CRED_BOX_MAX, CRED_REC_MAX, CRED_RESIDENT_LEN, Credential, RECORD_PREFIX, USER_ID_MAX,
-    USER_NAME_MAX, credential_load, derive_large_blob_key, is_resident, slot_map,
+    USER_NAME_MAX, credential_load, derive_large_blob_key, is_resident, resident_key_input,
+    slot_map,
 };
 use crate::ec::{CredKey, MAX_SIG_LEN};
 use crate::error::{CtapError, CtapResult};
@@ -557,6 +558,15 @@ fn get_assertion_inner<S: Storage, R: Rng>(
     let sel_large_blob = sel.as_ref().map(|c| c.ext.large_blob_key).unwrap_or(false);
     let curve = sel.as_ref().map_or(CURVE_P256 as i64, |c| c.curve);
 
+    // The signing / hmac-secret / largeBlobKey key-derivation input: a v2 resident
+    // credential keys off its STABLE resident id (so an updateUserInformation
+    // reseal doesn't rotate the keys), everything else off the box — the same
+    // choice makeCredential made when it issued the RP's pubkey.
+    let key_input = resident_key_input(
+        &best.id[..best.len],
+        best.resident.then_some(&best.resident_id[..]),
+    );
+
     // hmac-secret output (needs the clientPIN ephemeral key + the RNG for the IV).
     let mut hs = [0u8; SALT_ENC_MAX];
     let hs_len = if req.hmac_secret.present {
@@ -565,7 +575,7 @@ fn get_assertion_inner<S: Storage, R: Rng>(
             &req.hmac_secret,
             &ephemeral,
             seed,
-            &best.id[..best.len],
+            key_input,
             uv,
             ctx.rng,
             &mut hs,
@@ -588,7 +598,7 @@ fn get_assertion_inner<S: Storage, R: Rng>(
     // largeBlobKey response field (0x07) — only when the request and the stored
     // credential both opted in.
     let large_blob_key = if req.ext_large_blob_key == Some(true) && sel_large_blob {
-        Some(derive_large_blob_key(seed, &best.id[..best.len]))
+        Some(derive_large_blob_key(seed, key_input))
     } else {
         None
     };
@@ -604,7 +614,7 @@ fn get_assertion_inner<S: Storage, R: Rng>(
         scalar.zeroize();
         key
     } else {
-        let mut raw = fido_load_key(seed, &best.id[..best.len]).ok_or(CtapError::Other)?;
+        let mut raw = fido_load_key(seed, key_input).ok_or(CtapError::Other)?;
         let key = CredKey::from_raw(curve, &raw).ok_or(CtapError::Other)?;
         raw.zeroize();
         key
@@ -829,6 +839,9 @@ fn next_assertion_response<S: Storage, R: Rng>(
     let cred = credential_load(seed, cred_box, rp_id_hash, &mut scratch)
         .ok_or(CtapError::NoCredentials)?;
     let curve = cred.curve;
+    // getNextAssertion only walks resident discovery, so a v2 credential keys off
+    // its stable resident id here too (matching the first assertion's key).
+    let key_input = resident_key_input(cred_box, Some(resident_id));
 
     // getNextAssertion only ever walks a multi-credential resident discovery;
     // name / displayName are user-identifiable and returned only when the user
@@ -860,7 +873,7 @@ fn next_assertion_response<S: Storage, R: Rng>(
             salt_auth: &salt_auth[..sa],
         };
         let ephemeral = *ctx.state.ephemeral_scalar();
-        hmacsecret::eval(&req, &ephemeral, seed, cred_box, uv, ctx.rng, &mut hs)?
+        hmacsecret::eval(&req, &ephemeral, seed, key_input, uv, ctx.rng, &mut hs)?
     } else {
         0
     };
@@ -876,7 +889,7 @@ fn next_assertion_response<S: Storage, R: Rng>(
     )?;
     let ed = if ext_len > 0 { FLAG_ED } else { 0 };
 
-    let mut raw = fido_load_key(seed, cred_box).ok_or(CtapError::Other)?;
+    let mut raw = fido_load_key(seed, key_input).ok_or(CtapError::Other)?;
     let key = CredKey::from_raw(curve, &raw).ok_or(CtapError::Other)?;
     raw.zeroize();
 

--- a/crates/rsk-fido/src/getassertion_tests.rs
+++ b/crates/rsk-fido/src/getassertion_tests.rs
@@ -207,6 +207,119 @@ fn assertion_with_pin_sets_uv_flag() {
     assert_eq!(ad[32] & FLAG_UV, FLAG_UV, "UV flag must be set");
 }
 
+#[test]
+fn unscoped_pin_token_binds_rpid_on_first_getassertion() {
+    // A GA-capable token minted without an rpId (legacy getPinToken) must bind
+    // to the request's rpId on first use (CTAP 2.1 §6.2.2), so it can't be
+    // replayed across RPs for its whole lifetime.
+    let (mut fs, mut rng) = setup();
+    let mut state = crate::FidoState::new();
+    let mut out = [0u8; 1024];
+    let cred_id = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 10,
+        };
+        let n = make_credential(&mut ctx, &mc_request(true), &mut out).unwrap();
+        parse_mc(&out[..n]).0
+    };
+    let token = arm_pin(&mut fs, &mut state);
+    assert!(!state.paut.has_rp_id, "token starts unscoped");
+    let mut param = [0u8; 32];
+    let plen = rsk_crypto::pinproto::authenticate(PinProto::Two, &token, &CDH, &mut param).unwrap();
+    {
+        let req = ga_request_pin(&cred_id, &param[..plen], 2);
+        let mut o = [0u8; 1024];
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 20,
+        };
+        get_assertion(&mut ctx, &req, &mut o).unwrap();
+    }
+    assert!(
+        state.paut.has_rp_id,
+        "unscoped token must bind on first use"
+    );
+    // A second GA for a DIFFERENT rpId is rejected before credential lookup.
+    let mut buf = [0u8; 512];
+    let m = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(4).unwrap();
+        e.u8(1).unwrap().str("other.example").unwrap();
+        e.u8(2).unwrap().bytes(&CDH).unwrap();
+        e.u8(6).unwrap().bytes(&param[..plen]).unwrap();
+        e.u8(7).unwrap().u64(2).unwrap();
+        e.writer().position()
+    };
+    let mut o = [0u8; 1024];
+    let mut presence = crate::AlwaysConfirm;
+    let mut ctx = Ctx {
+        presence: &mut presence,
+        dev: dev(),
+        fs: &mut fs,
+        rng: &mut rng,
+        state: &mut state,
+        now_ms: 30,
+    };
+    assert_eq!(
+        get_assertion(&mut ctx, &buf[..m], &mut o).unwrap_err(),
+        CtapError::PinAuthInvalid,
+        "a token bound to example.com must reject other.example"
+    );
+}
+
+#[test]
+fn numberofcredentials_clamped_to_queue_capacity() {
+    // With more resident creds for one rp than the getNextAssertion queue holds
+    // (MAX_ASSERTION_CREDS), numberOfCredentials must be clamped to what is
+    // servable, not over-report and strand the excess behind a NOT_ALLOWED.
+    let (mut fs, mut rng) = setup();
+    let mut state = crate::FidoState::new();
+    let mut out = [0u8; 1024];
+    for i in 0..(crate::state::MAX_ASSERTION_CREDS + 1) {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 10,
+        };
+        make_credential(&mut ctx, &mc_request_user(&[i as u8; 16]), &mut out).unwrap();
+    }
+    let req = ga_request(None); // discovery, no allowList
+    let mut o = [0u8; 1024];
+    let n = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 20,
+        };
+        get_assertion(&mut ctx, &req, &mut o).unwrap()
+    };
+    let (_user, count) = user_and_count(&o[..n]);
+    assert_eq!(
+        count,
+        Some(crate::state::MAX_ASSERTION_CREDS as u32),
+        "count clamped to what the queue can serve"
+    );
+}
+
 fn ga_request(allow: Option<&[u8]>) -> std::vec::Vec<u8> {
     let mut buf = [0u8; 512];
     let n = {

--- a/crates/rsk-fido/src/getassertion_tests.rs
+++ b/crates/rsk-fido/src/getassertion_tests.rs
@@ -1576,6 +1576,198 @@ fn run_mc_state(
     out[..n].to_vec()
 }
 
+// An updateUserInformation (credMgmt 0x07) request that reseals `cred_id`'s box
+// with a new name (same user id), MAC'd under `token` (protocol 2). The
+// subCommandParams are encoded once and embedded verbatim — the device re-MACs
+// exactly those bytes, so the request must carry the identical encoding.
+fn cm_update_request(
+    cred_id: &[u8],
+    uid: &[u8],
+    name: &str,
+    token: &[u8; 32],
+) -> std::vec::Vec<u8> {
+    use rsk_crypto::pinproto::authenticate;
+    let mut sp = [0u8; 256];
+    let spn = {
+        let mut e = Encoder::new(Cursor::new(&mut sp[..]));
+        e.map(2).unwrap();
+        e.u8(2).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(cred_id).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(3).unwrap().map(3).unwrap();
+        e.str("id").unwrap().bytes(uid).unwrap();
+        e.str("name").unwrap().str(name).unwrap();
+        e.str("displayName").unwrap().str(name).unwrap();
+        e.writer().position()
+    };
+    let subpara = &sp[..spn];
+
+    let mut payload = std::vec![0x07u8];
+    payload.extend_from_slice(subpara);
+    let mut mac = [0u8; 32];
+    let mlen = authenticate(PinProto::Two, token, &payload, &mut mac).unwrap();
+
+    let mut req = std::vec::Vec::new();
+    req.push(0xA4); // map(4)
+    req.extend_from_slice(&[0x01, 0x07]); // 1: subCommand = updateUserInformation
+    req.push(0x02); // 2: subCommandParams (raw, re-MAC'd verbatim)
+    req.extend_from_slice(subpara);
+    req.extend_from_slice(&[0x03, 0x02]); // 3: pinUvAuthProtocol = 2
+    req.push(0x04); // 4: pinUvAuthParam
+    req.push(0x58); // byte string, 1-byte length prefix
+    req.push(mlen as u8);
+    req.extend_from_slice(&mac[..mlen]);
+    req
+}
+
+// Drive updateUserInformation to reseal `cred_id` (fresh IV → new box), under a
+// freshly-armed credentialManagement token.
+fn reseal_credential(
+    fs: &mut Fs<RamStorage>,
+    rng: &mut SeqRng,
+    cred_id: &[u8],
+    uid: &[u8],
+    name: &str,
+) {
+    let token = [0x99u8; 32];
+    let mut state = crate::FidoState::new();
+    state.paut.token = token;
+    state.paut.permissions = crate::state::PERM_CM;
+    state.begin_using_token(false);
+    let req = cm_update_request(cred_id, uid, name, &token);
+    let mut out = [0u8; 512];
+    let mut presence = crate::AlwaysConfirm;
+    let mut ctx = Ctx {
+        presence: &mut presence,
+        dev: dev(),
+        fs,
+        rng,
+        state: &mut state,
+        now_ms: 50,
+    };
+    let n = crate::credmgmt::cred_mgmt(&mut ctx, &req, &mut out).unwrap();
+    assert_eq!(
+        n, 0,
+        "updateUserInformation replies with only the status byte"
+    );
+}
+
+// The decrypted (IV-stripped) hmac-secret extension output carried in an
+// assertion's authData, under the platform's shared secret.
+fn hmac_secret_plaintext(resp: &[u8], shared: &[u8]) -> std::vec::Vec<u8> {
+    let ad = assertion_auth_data(resp);
+    assert_eq!(ad[32] & FLAG_ED, FLAG_ED, "extension output present");
+    let mut d = Decoder::new(&ad[37..]);
+    assert_eq!(d.map().unwrap().unwrap(), 1);
+    assert_eq!(d.str().unwrap(), "hmac-secret");
+    let ct = d.bytes().unwrap();
+    let mut dec = [0u8; 32];
+    let n = rsk_crypto::pinproto::decrypt(PinProto::Two, shared, ct, &mut dec).unwrap();
+    dec[..n].to_vec()
+}
+
+// #3 hmac-secret, end to end across a REAL updateUserInformation reseal. Register
+// a resident credential with hmac-secret, evaluate hmac-secret through
+// getAssertion (the full ECDH + hmacsecret::eval path), run updateUserInformation
+// — which reseals the box with a fresh IV — then evaluate hmac-secret AGAIN. The
+// decrypted secret must be identical: a v2 credential keys cred_random off the
+// STABLE resident id, not the (rotated) box, so the platform's stored secret
+// survives the update. Neuter the marker (v2→v1) and this fails — the box changes
+// and dec2 diverges from dec1. This complements the derivation-level unit test
+// [`credential::resident_key_input`] with the full command path.
+#[test]
+fn hmac_secret_survives_updateuserinfo_reseal_end_to_end() {
+    use rsk_crypto::pinproto::{authenticate, ecdh, encrypt, public_xy};
+    let (mut fs, mut rng) = setup();
+    let mut state = crate::FidoState::new();
+    state.regenerate(&mut rng); // the clientPIN getKeyAgreement ephemeral key
+    let (ax, ay) = state.ephemeral_public().unwrap();
+
+    let mc = run_mc_state(&mut fs, &mut rng, &mut state, &mc_request_lbk_hmac());
+    let (resident_id, ..) = parse_mc(&mc);
+    assert_eq!(
+        resident_id[8], 1,
+        "new resident credential carries the v2 marker"
+    );
+
+    // Platform half (protocol two): ECDH against the authenticator ephemeral,
+    // encrypt the salt, MAC it. Fixed across both evaluations.
+    let plat = {
+        let mut s = [0u8; 32];
+        s[0] = 0x22;
+        s[31] = 0x22;
+        s
+    };
+    let (px, py) = public_xy(&plat).unwrap();
+    let mut shared = [0u8; 64];
+    let slen = ecdh(PinProto::Two, &plat, &ax, &ay, &mut shared).unwrap();
+    let salt = [0x77u8; 32];
+    let iv = [0x01u8; 16];
+    let mut se = [0u8; 48];
+    let ne = encrypt(PinProto::Two, &shared[..slen], &iv, &salt, &mut se).unwrap();
+    let mut sa = [0u8; 32];
+    let na = authenticate(PinProto::Two, &shared[..slen], &se[..ne], &mut sa).unwrap();
+    let req = ga_request_hmac(&resident_id, &px, &py, &se[..ne], &sa[..na]);
+
+    // First evaluation (before the reseal).
+    let dec1 = {
+        let mut out = [0u8; 1024];
+        let n = {
+            let mut presence = crate::AlwaysConfirm;
+            let mut ctx = Ctx {
+                presence: &mut presence,
+                dev: dev(),
+                fs: &mut fs,
+                rng: &mut rng,
+                state: &mut state,
+                now_ms: 20,
+            };
+            get_assertion(&mut ctx, &req, &mut out).unwrap()
+        };
+        hmac_secret_plaintext(&out[..n], &shared[..slen])
+    };
+
+    // updateUserInformation reseals the box with a fresh IV — the stored box MUST
+    // change, else box-derived keys could pass this test spuriously.
+    let box_before = stored_box_and_seed(&mut fs).0;
+    reseal_credential(&mut fs, &mut rng, &resident_id, &[9, 8, 7, 6], "bob2");
+    let box_after = stored_box_and_seed(&mut fs).0;
+    assert_ne!(
+        box_before, box_after,
+        "reseal must rotate the box (fresh IV)"
+    );
+
+    // Second evaluation (after the reseal). A fresh per-call IV makes the
+    // ciphertext differ, but the decrypted secret must be identical.
+    let dec2 = {
+        let mut out = [0u8; 1024];
+        let n = {
+            let mut presence = crate::AlwaysConfirm;
+            let mut ctx = Ctx {
+                presence: &mut presence,
+                dev: dev(),
+                fs: &mut fs,
+                rng: &mut rng,
+                state: &mut state,
+                now_ms: 30,
+            };
+            get_assertion(&mut ctx, &req, &mut out).unwrap()
+        };
+        hmac_secret_plaintext(&out[..n], &shared[..slen])
+    };
+
+    // The property this test adds: the hmac-secret secret survives the reseal.
+    assert_eq!(
+        dec1, dec2,
+        "hmac-secret output must survive an updateUserInformation reseal"
+    );
+    // And it is the correct HMAC(CredRandomWithoutUV, salt), keyed off the STABLE
+    // resident id rather than the rotated box.
+    let seed = crate::seed::load_keydev(&dev(), &mut fs).unwrap();
+    let cr = crate::credential::derive_hmac_key(&seed, &resident_id[..]);
+    assert_eq!(dec1, rsk_crypto::hmac_sha256(&cr[..32], &salt).to_vec());
+}
+
 #[test]
 fn large_blob_key_in_assertion() {
     let (mut fs, mut rng) = setup();
@@ -2371,4 +2563,176 @@ fn discovery_and_getnext_sign_with_credential_keys() {
     assert_ne!(u1, u2, "two different credentials");
     let (x2, y2) = pick(&u2);
     verify_assertion(&o2[..n2], &x2, &y2);
+}
+
+// A resident makeCredential request (custom user id) that opts into hmac-secret.
+fn mc_request_hmac_user(uid: &[u8]) -> std::vec::Vec<u8> {
+    let mut buf = [0u8; 512];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(6).unwrap();
+        e.u8(1).unwrap().bytes(&CDH).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str("example.com")
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(uid).unwrap();
+        e.str("name").unwrap().str("user").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(6)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("hmac-secret")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+// A discovery (no allowList) getAssertion carrying an hmac-secret extension.
+fn ga_request_hmac_discovery(
+    px: &[u8; 32],
+    py: &[u8; 32],
+    se: &[u8],
+    sa: &[u8],
+) -> std::vec::Vec<u8> {
+    let mut buf = [0u8; 512];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(3).unwrap();
+        e.u8(1).unwrap().str("example.com").unwrap();
+        e.u8(2).unwrap().bytes(&CDH).unwrap();
+        e.u8(4).unwrap().map(1).unwrap();
+        e.str("hmac-secret").unwrap().map(4).unwrap();
+        e.u8(1).unwrap();
+        cose_xy(&mut e, px, py);
+        e.u8(2).unwrap().bytes(se).unwrap();
+        e.u8(3).unwrap().bytes(sa).unwrap();
+        e.u8(4).unwrap().u8(2).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+// #3 getNextAssertion path: the hmac-secret cred_random for the SECOND and later
+// credentials in a resident discovery walk is evaluated in next_assertion_response
+// — a site the single-entry-allowList hmac tests (which resolve inside
+// get_assertion_inner) never reach. A v2 credential keys it off its stable resident
+// id, so this pins that getNextAssertion, not just the first getAssertion, uses the
+// credential's own resident-id-derived secret. Revert that site to the box and dec2
+// stops matching the resident-id derivation.
+#[test]
+fn getnextassertion_hmac_secret_keys_off_resident_id() {
+    use rsk_crypto::pinproto::{authenticate, ecdh, encrypt, public_xy};
+    let (mut fs, mut rng) = setup();
+    let mut state = crate::FidoState::new();
+    state.regenerate(&mut rng); // the clientPIN getKeyAgreement ephemeral key
+    let (ax, ay) = state.ephemeral_public().unwrap();
+
+    // Two resident creds for one RP with hmac-secret (distinct users + times, so
+    // discovery yields the newest and getNextAssertion the older).
+    for (uid, t) in [(&[9u8, 8, 7, 6][..], 10u64), (&[1u8, 1, 1, 1][..], 20u64)] {
+        let mut out = [0u8; 1024];
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: t,
+        };
+        make_credential(&mut ctx, &mc_request_hmac_user(uid), &mut out).unwrap();
+    }
+
+    // Platform half (protocol two), shared across both evaluations.
+    let plat = {
+        let mut s = [0u8; 32];
+        s[0] = 0x22;
+        s[31] = 0x22;
+        s
+    };
+    let (px, py) = public_xy(&plat).unwrap();
+    let mut shared = [0u8; 64];
+    let slen = ecdh(PinProto::Two, &plat, &ax, &ay, &mut shared).unwrap();
+    let salt = [0x77u8; 32];
+    let iv = [0x01u8; 16];
+    let mut se = [0u8; 48];
+    let ne = encrypt(PinProto::Two, &shared[..slen], &iv, &salt, &mut se).unwrap();
+    let mut sa = [0u8; 32];
+    let na = authenticate(PinProto::Two, &shared[..slen], &se[..ne], &mut sa).unwrap();
+    let req = ga_request_hmac_discovery(&px, &py, &se[..ne], &sa[..na]);
+
+    let seed = crate::seed::load_keydev(&dev(), &mut fs).unwrap();
+    let expected = |cred_id: &[u8]| {
+        let cr = crate::credential::derive_hmac_key(&seed, cred_id);
+        rsk_crypto::hmac_sha256(&cr[..32], &salt).to_vec()
+    };
+
+    // Discovery getAssertion → newest credential; its hmac output keys off its id.
+    let mut o1 = [0u8; 1024];
+    let n1 = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 30,
+        };
+        get_assertion(&mut ctx, &req, &mut o1).unwrap()
+    };
+    let id1 = cred_id_of(&o1[..n1]);
+    let dec1 = hmac_secret_plaintext(&o1[..n1], &shared[..slen]);
+    assert_eq!(
+        dec1,
+        expected(&id1),
+        "first assertion keys hmac off its resident id"
+    );
+
+    // getNextAssertion → the older credential — the next_assertion_response site.
+    let mut o2 = [0u8; 1024];
+    let n2 = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 31,
+        };
+        get_next_assertion(&mut ctx, &mut o2).unwrap()
+    };
+    let id2 = cred_id_of(&o2[..n2]);
+    let dec2 = hmac_secret_plaintext(&o2[..n2], &shared[..slen]);
+    assert_ne!(id1, id2, "two distinct credentials");
+    assert_eq!(
+        dec2,
+        expected(&id2),
+        "getNextAssertion must key hmac-secret off the credential's stable resident id"
+    );
+    assert_ne!(
+        dec1, dec2,
+        "distinct credentials → distinct hmac-secret outputs"
+    );
 }

--- a/crates/rsk-fido/src/getassertion_tests.rs
+++ b/crates/rsk-fido/src/getassertion_tests.rs
@@ -1549,8 +1549,10 @@ fn hmac_secret_assertion_end_to_end() {
     rsk_crypto::pinproto::decrypt(PinProto::Two, &shared[..slen], hmac_out, &mut dec).unwrap();
 
     // It must equal HMAC(CredRandomWithoutUV, salt) for the stored credential.
-    let (cred_box, seed) = stored_box_and_seed(&mut fs);
-    let cr = crate::credential::derive_hmac_key(&seed, &cred_box);
+    // A v2 resident credential keys hmac-secret off the stable resident id, not
+    // the box, so the reseal-stable id is the expected derivation input.
+    let (_cred_box, seed) = stored_box_and_seed(&mut fs);
+    let cr = crate::credential::derive_hmac_key(&seed, &resident_id[..]);
     assert_eq!(&dec[..], &rsk_crypto::hmac_sha256(&cr[..32], &salt)[..]);
 }
 
@@ -1626,8 +1628,9 @@ fn large_blob_key_in_assertion() {
             d.skip().unwrap();
         }
     }
-    let (cred_box, seed) = stored_box_and_seed(&mut fs);
-    let expected = crate::credential::derive_large_blob_key(&seed, &cred_box);
+    // v2 resident: largeBlobKey keys off the stable resident id, not the box.
+    let (_cred_box, seed) = stored_box_and_seed(&mut fs);
+    let expected = crate::credential::derive_large_blob_key(&seed, &resident_id[..]);
     assert_eq!(lbk.as_deref(), Some(&expected[..]));
 }
 
@@ -2290,4 +2293,82 @@ fn overlong_rpid_or_userid_rejected() {
             Err(CtapError::InvalidLength)
         );
     }
+}
+
+// Resident discovery + getNextAssertion must each sign with the credential's OWN
+// key. For v2 credentials that key derives from the stable resident id, so this
+// pins that BOTH signing sites (get_assertion and get_next_assertion) use it and
+// agree with makeCredential's pubkey — get_next_assertion had no such
+// signature-verify coverage before.
+#[test]
+fn discovery_and_getnext_sign_with_credential_keys() {
+    let (mut fs, mut rng) = setup();
+    let mut state = crate::FidoState::new();
+
+    // Register two resident creds for the same rp; capture each (uid, pubkey).
+    let mut keys: std::vec::Vec<([u8; 4], [u8; 32], [u8; 32])> = std::vec::Vec::new();
+    for (uid, t) in [(&[9u8, 8, 7, 6][..], 10u64), (&[1u8, 1, 1, 1][..], 20u64)] {
+        let mut out = [0u8; 1024];
+        let n = {
+            let mut presence = crate::AlwaysConfirm;
+            let mut ctx = Ctx {
+                presence: &mut presence,
+                dev: dev(),
+                fs: &mut fs,
+                rng: &mut rng,
+                state: &mut state,
+                now_ms: t,
+            };
+            make_credential(&mut ctx, &mc_request_user(uid), &mut out).unwrap()
+        };
+        let (_id, x, y) = parse_mc(&out[..n]);
+        let mut u = [0u8; 4];
+        u.copy_from_slice(uid);
+        keys.push((u, x, y));
+    }
+    let pick = |uid: &[u8]| -> ([u8; 32], [u8; 32]) {
+        for (u, x, y) in &keys {
+            if &u[..] == uid {
+                return (*x, *y);
+            }
+        }
+        panic!("uid not registered");
+    };
+
+    // Discovery getAssertion → newest credential; verify under its key.
+    let mut o1 = [0u8; 1024];
+    let n1 = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 30,
+        };
+        get_assertion(&mut ctx, &ga_request(None), &mut o1).unwrap()
+    };
+    let (u1, _c1) = user_and_count(&o1[..n1]);
+    let (x1, y1) = pick(&u1);
+    verify_assertion(&o1[..n1], &x1, &y1);
+
+    // getNextAssertion → the older credential; verify under ITS key.
+    let mut o2 = [0u8; 1024];
+    let n2 = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 31,
+        };
+        get_next_assertion(&mut ctx, &mut o2).unwrap()
+    };
+    let (u2, _c2) = user_and_count(&o2[..n2]);
+    assert_ne!(u1, u2, "two different credentials");
+    let (x2, y2) = pick(&u2);
+    verify_assertion(&o2[..n2], &x2, &y2);
 }

--- a/crates/rsk-fido/src/makecredential.rs
+++ b/crates/rsk-fido/src/makecredential.rs
@@ -33,7 +33,8 @@ use crate::consts::{
 use crate::credential::{
     CRED_BOX_MAX, CRED_REC_MAX, CRED_RESIDENT_LEN, CredExt, CredInput, Credential, RECORD_PREFIX,
     RP_ID_MAX, USER_ID_MAX, USER_NAME_MAX, credential_create, credential_load, credential_store,
-    derive_large_blob_key, derive_resident, is_resident, slot_map, truncate_utf8,
+    derive_large_blob_key, derive_resident, is_resident, resident_key_input, slot_map,
+    truncate_utf8,
 };
 use crate::ec::{CredKey, MAX_SIG_LEN, P256Key};
 use crate::error::{CtapError, CtapResult};
@@ -494,8 +495,19 @@ fn make_credential_inner<S: Storage, R: Rng>(
     let box_len = credential_create(seed, &ctx.dev, &input, rp_id_hash, &iv, &mut cred_box)
         .map_err(|_| CtapError::Other)?;
 
-    // Derive the credential keypair from the box for the selected curve.
-    let mut raw = fido_load_key(seed, &cred_box[..box_len]).ok_or(CtapError::Other)?;
+    // Compute the resident id up front (resident keys only): the signing key,
+    // hmac-secret and largeBlobKey all derive from `key_input` — the STABLE
+    // resident id for a resident credential, the box for a non-resident one — so
+    // they survive an updateUserInformation reseal (see `resident_key_input`). It
+    // must be the same input the assertion / enumeration paths use, and the same
+    // id echoed into authData below.
+    let resident = req
+        .rk
+        .then(|| derive_resident(&cred_box[..box_len], &ctx.dev));
+    let key_input = resident_key_input(&cred_box[..box_len], resident.as_ref().map(|r| &r[..]));
+
+    // Derive the credential keypair for the selected curve.
+    let mut raw = fido_load_key(seed, key_input).ok_or(CtapError::Other)?;
     let key = CredKey::from_raw(req.sel_curve, &raw).ok_or(CtapError::Other)?;
     raw.zeroize();
 
@@ -507,7 +519,7 @@ fn make_credential_inner<S: Storage, R: Rng>(
             &req.hmac_secret_mc,
             &ephemeral,
             seed,
-            &cred_box[..box_len],
+            key_input,
             uv,
             ctx.rng,
             &mut hs,
@@ -550,11 +562,10 @@ fn make_credential_inner<S: Storage, R: Rng>(
     p += 4;
     ad[p..p + 16].copy_from_slice(&AAGUID);
     p += 16;
-    if req.rk {
-        let rid = derive_resident(&cred_box[..box_len], &ctx.dev);
+    if let Some(rid) = &resident {
         ad[p..p + 2].copy_from_slice(&(rid.len() as u16).to_be_bytes());
         p += 2;
-        ad[p..p + rid.len()].copy_from_slice(&rid);
+        ad[p..p + rid.len()].copy_from_slice(rid);
         p += rid.len();
     } else {
         ad[p..p + 2].copy_from_slice(&(box_len as u16).to_be_bytes());
@@ -598,7 +609,7 @@ fn make_credential_inner<S: Storage, R: Rng>(
 
     // largeBlobKey response field (0x05) — resident credentials only.
     let large_blob_key = if req.ext_large_blob_key == Some(true) && req.rk {
-        Some(derive_large_blob_key(seed, &cred_box[..box_len]))
+        Some(derive_large_blob_key(seed, key_input))
     } else {
         None
     };

--- a/crates/rsk-fido/src/makecredential_tests.rs
+++ b/crates/rsk-fido/src/makecredential_tests.rs
@@ -952,10 +952,12 @@ fn large_blob_key_in_make_credential() {
         }
     }
     let mut rec = [0u8; 1024];
-    let n = fs.read(crate::consts::EF_CRED, &mut rec).unwrap();
+    let _n = fs.read(crate::consts::EF_CRED, &mut rec).unwrap();
     let seed = crate::seed::load_keydev(&dev(), &mut fs).unwrap();
-    let cred_box = &rec[crate::credential::RECORD_PREFIX..n];
-    let expected = crate::credential::derive_large_blob_key(&seed, cred_box);
+    // v2 resident: largeBlobKey keys off the stable resident id (rec[32..74]),
+    // not the box.
+    let resident_id = &rec[32..crate::credential::RECORD_PREFIX];
+    let expected = crate::credential::derive_large_blob_key(&seed, resident_id);
     assert_eq!(lbk.as_deref(), Some(&expected[..]));
 }
 

--- a/crates/rsk-fido/src/vendor.rs
+++ b/crates/rsk-fido/src/vendor.rs
@@ -304,10 +304,17 @@ fn att_state<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, out: &mut [u8]) -> CtapRes
 }
 
 /// `AUDIT_READ`: export the journal window (`journal::vendor_read`). Gated on a
-/// PIN token (when a PIN is set) only — the entries are pseudonymous and no key
-/// material moves, so no MSE channel and no touch.
+/// PIN token when a PIN is set; a touch otherwise — with no PIN `pin_gate` is a
+/// no-op, and the per-entry detail is a reversible 64-bit rpId-hash prefix (not
+/// truly pseudonymous), so an ungated read lets a silent host harvest the
+/// RP-usage history. No MSE channel: no key material moves.
 fn audit_read<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, req: &Req, out: &mut [u8]) -> CtapResult {
     pin_gate(ctx, req)?;
+    if !ctx.fs.has_data(EF_PIN)
+        && !ctx.check_user_presence(crate::Confirm::titled("Read audit log?"))
+    {
+        return Err(CtapError::OperationDenied);
+    }
     journal::vendor_read(ctx, out)
 }
 

--- a/crates/rsk-fido/src/vendor_tests.rs
+++ b/crates/rsk-fido/src/vendor_tests.rs
@@ -1395,3 +1395,35 @@ fn config_write_led_rejects_short_block() {
         Err(CtapError::InvalidLength)
     );
 }
+
+#[test]
+fn audit_read_without_pin_requires_touch() {
+    let (mut fs, mut rng, mut st) = setup(); // no PIN configured → pin_gate is a no-op
+    let mut req = [0u8; 16];
+    let n = one_byte_req(&mut req, VENDOR_AUDIT_READ);
+    let mut out = [0u8; 3072];
+    // A silent host on a no-PIN device must not be able to harvest the journal.
+    assert_eq!(
+        call(
+            &mut fs,
+            &mut rng,
+            &mut st,
+            &mut Decline,
+            &req[..n],
+            &mut out
+        ),
+        Err(CtapError::OperationDenied)
+    );
+    // The user's physical touch unlocks the same read.
+    assert!(
+        call(
+            &mut fs,
+            &mut rng,
+            &mut st,
+            &mut AlwaysConfirm,
+            &req[..n],
+            &mut out
+        )
+        .is_ok()
+    );
+}

--- a/crates/rsk-fs/src/fs.rs
+++ b/crates/rsk-fs/src/fs.rs
@@ -170,6 +170,9 @@ impl<S: Storage> Fs<S> {
             }
             let is_static = table.iter().any(|d| d.fid == fid);
             if !is_static && !dynamic.contains(&fid) {
+                // `put`/`new_file` reject a dynamic file past the cap before it
+                // reaches flash, so the store can never hold more than fit here.
+                debug_assert!(!dynamic.is_full(), "dynamic overflow on rescan");
                 let _ = dynamic.push(fid);
             }
         });
@@ -294,10 +297,18 @@ impl<S: Storage> Fs<S> {
 
     /// Store file contents, registering a dynamic file if new.
     pub fn put(&mut self, fid: u16, data: &[u8]) -> Result<()> {
+        // A new dynamic file that would overflow the set is rejected *before* the
+        // flash write: registering only after committing would strand the value
+        // on flash — readable yet unregistered — and leave `scan` to re-drop it
+        // at the same cap on every reboot.
+        let register = !self.is_static(fid) && !self.dynamic.contains(&fid);
+        if register && self.dynamic.is_full() {
+            return Err(Error::NoMemory);
+        }
         self.storage.write(fid, data)?;
         self.mark_present(fid);
-        if !self.is_static(fid) && !self.dynamic.contains(&fid) {
-            self.dynamic.push(fid).map_err(|_| Error::NoMemory)?;
+        if register {
+            let _ = self.dynamic.push(fid); // cap checked above — cannot fail
         }
         Ok(())
     }

--- a/crates/rsk-fs/src/fs_tests.rs
+++ b/crates/rsk-fs/src/fs_tests.rs
@@ -146,6 +146,30 @@ fn dynamic_files_and_reboot() {
 }
 
 #[test]
+fn put_over_dynamic_cap_commits_nothing() {
+    // A `put` that overflows the dynamic-file set must fail atomically: reject
+    // before touching flash, not commit the bytes and then report NoMemory —
+    // otherwise the value is stranded on flash, readable yet unregistered, and
+    // survives a reboot as a phantom (`scan` re-drops it at the same cap).
+    let mut fs = fs();
+    for i in 0..MAX_DYNAMIC_FILES as u16 {
+        fs.put(0xD000 + i, b"x").unwrap();
+    }
+    let overflow = 0xD000 + MAX_DYNAMIC_FILES as u16;
+    assert_eq!(fs.put(overflow, b"orphan"), Err(Error::NoMemory));
+
+    // The rejected value left no trace: unknown, absent, unreadable — this run
+    // and across a modelled reboot.
+    let mut buf = [0u8; 8];
+    assert!(fs.search(overflow).is_none());
+    assert!(fs.read(overflow, &mut buf).is_none());
+    let mut fs2 = Fs::new(fs.into_storage(), TABLE);
+    fs2.scan();
+    assert!(fs2.search(overflow).is_none());
+    assert!(fs2.read(overflow, &mut buf).is_none());
+}
+
+#[test]
 fn delete_removes() {
     let mut fs = fs();
     fs.put(0xCF02, b"x").unwrap();

--- a/crates/rsk-openpgp/src/dispatch_getdata_tests.rs
+++ b/crates/rsk-openpgp/src/dispatch_getdata_tests.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! Does the on-device dispatch path handle a no-command-data (ISO-7816 Case-1 /
+//! Case-2) GET DATA, or does it drop it to `6D00`?
+//!
+//! On real hardware (Waveshare RP2350-Zero, macOS PC/SC) `GET DATA` returned
+//! `6D 00` (INS not supported) while data-bearing commands (VERIFY, PSO, PIV
+//! GET DATA) reached the applet. `6D00` is only reachable via the applet's
+//! `_ => INS_NOT_SUPPORTED` fall-through, i.e. `apdu.ins != 0xCA` — impossible if
+//! the byte on the wire is `CA`. This test drives the exact bytes through the
+//! REAL [`Dispatcher`] (the same dispatch the CCID transport calls via
+//! `handle_apdu`), not the direct `applet.process()` the other tests use, to pin
+//! whether the firmware code path itself mangles a Case-1/2 APDU. If these pass,
+//! the firmware dispatch is correct and the on-device `6D00` is a host-side
+//! (macOS CCID) artifact, not a firmware bug.
+
+use super::*;
+use rsk_fs::storage::ram::RamStorage;
+use rsk_sdk::Dispatcher;
+
+struct CountRng(u8);
+impl Rng for CountRng {
+    fn fill(&mut self, buf: &mut [u8]) {
+        for b in buf.iter_mut() {
+            *b = self.0;
+            self.0 = self.0.wrapping_add(1);
+        }
+    }
+}
+
+const SERIAL_ID: [u8; 8] = [0xAA, 0xBB, 0xCC, 0xDD, 5, 6, 7, 8];
+const SERIAL_HASH: [u8; 32] = [0x22; 32];
+
+fn setup() -> Fs<RamStorage> {
+    let mut fs = Fs::new(RamStorage::new(), &[]);
+    fs.scan();
+    let dev = Device {
+        serial_hash: &SERIAL_HASH,
+        serial_id: &SERIAL_ID,
+        otp_key: None,
+    };
+    scan_files(&dev, &mut fs, &mut CountRng(0)).unwrap();
+    fs
+}
+
+/// Drive one raw APDU through the real dispatcher (the exact call the CCID
+/// transport's `handle_apdu` makes on-device) and return `(body, sw)`.
+fn dispatch(
+    disp: &mut Dispatcher,
+    applets: &mut [&mut dyn rsk_sdk::Applet<Fs<RamStorage>>],
+    fs: &mut Fs<RamStorage>,
+    raw: &[u8],
+) -> (Vec<u8>, Sw) {
+    let mut buf = [0u8; 2048];
+    let mut res = ResBuf::new(&mut buf);
+    let sw = disp.process(raw, applets, fs, &mut res);
+    (res.as_slice().to_vec(), sw)
+}
+
+// The OpenPGP SELECT-by-AID APDU (Case-4: has data).
+const SELECT_OPENPGP: &[u8] = &[
+    0x00, 0xA4, 0x04, 0x00, 0x06, 0xD2, 0x76, 0x00, 0x01, 0x24, 0x01,
+];
+
+#[test]
+fn getdata_aid_case2_via_dispatcher_returns_aid_not_6d00() {
+    let mut fs = setup();
+    let rng = RefCell::new(CountRng(0));
+    let presence = RefCell::new(crate::AlwaysConfirm);
+    let mut app = OpenpgpApplet::new(SERIAL_ID, SERIAL_HASH, None, &rng, &presence);
+    let mut disp = Dispatcher::default();
+    let mut applets: [&mut dyn rsk_sdk::Applet<Fs<RamStorage>>; 1] = [&mut app];
+
+    assert_eq!(
+        dispatch(&mut disp, &mut applets, &mut fs, SELECT_OPENPGP).1,
+        Sw::OK
+    );
+
+    // Case-2 GET DATA 0x4F (Le=0 → 256) — the exact byte string that gave 6D00
+    // on hardware.
+    let (aid, sw) = dispatch(
+        &mut disp,
+        &mut applets,
+        &mut fs,
+        &[0x00, 0xCA, 0x00, 0x4F, 0x00],
+    );
+    assert_eq!(sw, Sw::OK, "Case-2 GET DATA 0x4F must return OK, not 6D00");
+    assert_eq!(aid.len(), 16, "the AID DO is 16 bytes");
+    assert_eq!(
+        &aid[..6],
+        &[0xD2, 0x76, 0x00, 0x01, 0x24, 0x01],
+        "OpenPGP AID prefix"
+    );
+    assert_eq!(
+        &aid[10..14],
+        &SERIAL_ID[..4],
+        "device serial spliced at offset 10"
+    );
+
+    // Case-1 GET DATA 0x4F (no Le) — the 4-byte form, also 6D00 on hardware.
+    let (aid1, sw1) = dispatch(&mut disp, &mut applets, &mut fs, &[0x00, 0xCA, 0x00, 0x4F]);
+    assert_eq!(sw1, Sw::OK, "Case-1 GET DATA 0x4F must return OK, not 6D00");
+    assert_eq!(aid1, aid, "Case-1 and Case-2 return the same AID");
+}
+
+#[test]
+fn getdata_pw_status_case2_via_dispatcher_returns_ok() {
+    // GET DATA 0xC4 (PW status) — another Case-2 command gpg issues on connect.
+    let mut fs = setup();
+    let rng = RefCell::new(CountRng(0));
+    let presence = RefCell::new(crate::AlwaysConfirm);
+    let mut app = OpenpgpApplet::new(SERIAL_ID, SERIAL_HASH, None, &rng, &presence);
+    let mut disp = Dispatcher::default();
+    let mut applets: [&mut dyn rsk_sdk::Applet<Fs<RamStorage>>; 1] = [&mut app];
+
+    assert_eq!(
+        dispatch(&mut disp, &mut applets, &mut fs, SELECT_OPENPGP).1,
+        Sw::OK
+    );
+    let (body, sw) = dispatch(
+        &mut disp,
+        &mut applets,
+        &mut fs,
+        &[0x00, 0xCA, 0x00, 0xC4, 0x00],
+    );
+    assert_eq!(sw, Sw::OK, "Case-2 GET DATA 0xC4 must return OK, not 6D00");
+    assert_eq!(&body, &[0x01, 127, 127, 127, 3, 0, 3], "PW status DO");
+}
+
+#[test]
+fn verify_default_pw1_via_dispatcher_is_ok() {
+    // The on-device path for VERIFY (Case-3), to confirm SELECT sets the active
+    // applet and a provisioned EF_PW1 verifies through the dispatcher — the
+    // hardware returned 6A88 here (EF_PW1 not found), so on host (provisioned)
+    // it must return OK, isolating the hardware result as a provisioning/host
+    // question rather than a dispatch bug.
+    let mut fs = setup();
+    let rng = RefCell::new(CountRng(0));
+    let presence = RefCell::new(crate::AlwaysConfirm);
+    let mut app = OpenpgpApplet::new(SERIAL_ID, SERIAL_HASH, None, &rng, &presence);
+    let mut disp = Dispatcher::default();
+    let mut applets: [&mut dyn rsk_sdk::Applet<Fs<RamStorage>>; 1] = [&mut app];
+
+    assert_eq!(
+        dispatch(&mut disp, &mut applets, &mut fs, SELECT_OPENPGP).1,
+        Sw::OK
+    );
+    // VERIFY PW1 (mode 0x81) with the default "123456".
+    let verify = [
+        0x00, 0x20, 0x00, 0x81, 0x06, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
+    ];
+    assert_eq!(
+        dispatch(&mut disp, &mut applets, &mut fs, &verify).1,
+        Sw::OK,
+        "default PW1 must verify through the dispatcher on a provisioned FS"
+    );
+}

--- a/crates/rsk-openpgp/src/keys.rs
+++ b/crates/rsk-openpgp/src/keys.rs
@@ -939,6 +939,13 @@ impl RsaKeygen {
     /// [`offer`](RsaKeygen::offer) from little-endian bytes (the inter-core
     /// transport format); scrubs `bytes` after the conversion.
     pub fn offer_le(&mut self, bytes: &mut [u8]) -> RsaStep {
+        // Belt-and-suspenders: a byte-transport find must be exactly this key's
+        // half size — a wrong length is a stale prime from a prior different-size
+        // job (mailbox scrubbed on engage, so never fires today); pooling corrupts n.
+        if bytes.len() != self.half_bytes {
+            bytes.zeroize();
+            return RsaStep::More;
+        }
         let cand = BigUint::from_bytes_le(bytes);
         bytes.zeroize();
         self.offer(cand)

--- a/crates/rsk-openpgp/src/keys_rsa_tests.rs
+++ b/crates/rsk-openpgp/src/keys_rsa_tests.rs
@@ -170,6 +170,37 @@ fn keygen_bpsw_split_matches_library() {
 }
 
 #[test]
+fn keygen_pool_le_rejects_wrong_size_prime() {
+    // Belt-and-suspenders: a wrong-length byte-transport find (a stale prime from
+    // a prior different-size job) must be dropped and scrubbed, leaving the pool
+    // intact — feeding it would corrupt the modulus.
+    let mut kg = RsaKeygen::new(2048); // half = 128 bytes
+    assert_eq!(kg.half_bytes(), 128);
+    let mut under = hex(P_HEX);
+    under.truncate(64); // 64 < 128: an under-size stale prime
+    assert!(matches!(kg.offer_le(&mut under), RsaStep::More));
+    assert!(
+        under.iter().all(|&b| b == 0),
+        "rejected buffer not scrubbed"
+    );
+    // …and an over-size stale prime — pins the guard at `!=`, not `<`.
+    let mut over = hex(P_HEX);
+    over.extend_from_slice(&hex(Q_HEX)[..64]); // 192 > 128
+    assert!(matches!(kg.offer_le(&mut over), RsaStep::More));
+    assert!(over.iter().all(|&b| b == 0), "rejected buffer not scrubbed");
+    // Pool untouched: a correct-size pair still assembles the exact modulus. (Were
+    // either wrong prime pooled, this first offer would already return Done.)
+    let (mut p_le, mut q_le) = (hex(P_HEX), hex(Q_HEX));
+    p_le.reverse();
+    q_le.reverse();
+    assert!(matches!(kg.offer_le(&mut p_le), RsaStep::More));
+    match kg.offer_le(&mut q_le) {
+        RsaStep::Done(k) => assert_eq!(k.n().to_bytes_be(), hex(N_HEX)),
+        _ => panic!("correct-size primes must complete the key after a reject"),
+    }
+}
+
+#[test]
 fn keygen_pool_rejects_duplicate_prime() {
     let p = BigUint::from_bytes_be(&hex(P_HEX));
     let mut kg = RsaKeygen::new(2048);

--- a/crates/rsk-openpgp/src/lib.rs
+++ b/crates/rsk-openpgp/src/lib.rs
@@ -486,3 +486,11 @@ impl<S: Storage> Applet<Fs<S>> for OpenpgpApplet<'_> {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+#[path = "serial_identity_tests.rs"]
+mod serial_identity_tests;
+
+#[cfg(test)]
+#[path = "dispatch_getdata_tests.rs"]
+mod dispatch_getdata_tests;

--- a/crates/rsk-openpgp/src/pin.rs
+++ b/crates/rsk-openpgp/src/pin.rs
@@ -196,8 +196,10 @@ pub fn check_pin<S: Storage>(
     if let Err(sw) = pin_reset_retries(fs, fid, false) {
         return sw;
     }
-    sess.has_pw1 = false;
-    sess.has_pw2 = false;
+    // PW1.81 (PSO:CDS), PW1.82 (DECIPHER/INTERNAL AUTH) and PW3 are INDEPENDENT
+    // access latches: a successful VERIFY raises only its own, never clears a
+    // sibling. gpg/scdaemon verifies one PIN entry into both PW1 modes (82 then
+    // 81); clearing here dropped PW1.82 and bricked the next DECIPHER with 6982 (#25).
     if fid == EF_PW1 {
         if p2 == PW1_MODE81 {
             sess.has_pw1 = true;

--- a/crates/rsk-openpgp/src/pin.rs
+++ b/crates/rsk-openpgp/src/pin.rs
@@ -326,8 +326,10 @@ pub fn verify<S: Storage>(
         return Sw::WRONG_P1P2;
     }
     let mut fid = pw_fid(p2);
-    if fid == EF_RC && !data.is_empty() {
-        fid = EF_PW1; // PW2 (p2 = 0x82) verifies against the PW1 verifier
+    if fid == EF_RC {
+        // PW2 (p2 = 0x82) shares the PW1 verifier and its retry counter — for a
+        // status query too, else an empty-data probe reads the (absent) EF_RC.
+        fid = EF_PW1;
     }
     let mut rec = [0u8; 64];
     let size = match fs.read(fid, &mut rec) {

--- a/crates/rsk-openpgp/src/pin_tests.rs
+++ b/crates/rsk-openpgp/src/pin_tests.rs
@@ -263,6 +263,51 @@ fn logout_clears_flag() {
 }
 
 #[test]
+fn pw1_modes_are_independent_latches_issue25() {
+    // Reproduces #25: gpg/scdaemon verifies one PIN entry into BOTH PW1 modes
+    // back-to-back (82 then 81) before a decrypt. PW1.82 (the DECIPHER latch,
+    // pso.rs `has_pw3 || has_pw2`) must survive the following PW1.81 verify —
+    // else the next PSO:DECIPHER returns 6982 and gpg reports "Bad PIN".
+    let mut fs = setup();
+    let mut sess = Session::new();
+    let d = dev();
+    let mut rng = CountRng(0);
+    assert_eq!(
+        verify(
+            &d,
+            &mut fs,
+            &mut sess,
+            &mut rng,
+            0x00,
+            PW1_MODE82,
+            PW1_DEFAULT
+        ),
+        Sw::OK
+    );
+    assert!(sess.has_pw2);
+    assert_eq!(
+        verify(
+            &d,
+            &mut fs,
+            &mut sess,
+            &mut rng,
+            0x00,
+            PW1_MODE81,
+            PW1_DEFAULT
+        ),
+        Sw::OK
+    );
+    assert!(sess.has_pw1, "PW1.81 raised");
+    assert!(
+        sess.has_pw2,
+        "PW1.82 must survive a later PW1.81 verify (else DECIPHER → 6982)"
+    );
+    // The DEK still unwraps under the surviving PW1 session.
+    let mut dek = [0u8; DEK_SIZE];
+    load_dek(&d, &mut fs, &sess, &mut dek).unwrap();
+}
+
+#[test]
 fn change_pw1_then_new_pin_works_and_dek_survives() {
     let mut fs = setup();
     let mut sess = Session::new();

--- a/crates/rsk-openpgp/src/pin_tests.rs
+++ b/crates/rsk-openpgp/src/pin_tests.rs
@@ -40,6 +40,25 @@ fn otp_dev() -> Device<'static> {
 }
 
 #[test]
+fn pw2_status_query_reports_pw1_retries() {
+    // An empty-data VERIFY in PW2 mode (p2 = 0x82) is a status query. PW2 shares
+    // the PW1 verifier and its retry counter, so it must report PW1's retries,
+    // not probe the (absent) reset-code EF and answer REFERENCE_NOT_FOUND.
+    let mut fs = setup();
+    let mut sess = Session::new();
+    let sw = verify(
+        &dev(),
+        &mut fs,
+        &mut sess,
+        &mut CountRng(0),
+        0x00,
+        PW1_MODE82,
+        &[],
+    );
+    assert_eq!(sw, Sw::retries(PW_RETRIES_DEFAULT));
+}
+
+#[test]
 fn pin_and_dek_migrate_to_otp_kbase_at_verify() {
     // State written by a pre-OTP firmware…
     let mut fs = setup();

--- a/crates/rsk-openpgp/src/putdata.rs
+++ b/crates/rsk-openpgp/src/putdata.rs
@@ -56,7 +56,11 @@ pub fn put_pw_status<S: Storage>(fs: &mut Fs<S>, sess: &Session, data: &[u8]) ->
         Some(n) => n,
         None => return Sw::REFERENCE_NOT_FOUND,
     };
-    let m = data.len().min(n);
+    // Only the leading bytes (flag + 3 max-length bytes) are writable via PUT
+    // DATA; the retry counters that follow (indices PW1_RETRY_IDX..) are
+    // read-only. Capping at the first counter stops a long field from zeroing
+    // them and blocking every PIN across a power cycle.
+    let m = data.len().min(n).min(PW1_RETRY_IDX);
     pw[..m].copy_from_slice(&data[..m]);
     if fs.put(EF_PW_PRIV, &pw[..n]).is_err() {
         return Sw::MEMORY_FAILURE;

--- a/crates/rsk-openpgp/src/putdata_tests.rs
+++ b/crates/rsk-openpgp/src/putdata_tests.rs
@@ -128,6 +128,29 @@ fn put_pw_status_updates_flag_in_place() {
 }
 
 #[test]
+fn put_pw_status_cannot_overwrite_retry_counters() {
+    // A >=5-byte C4 field must update only the flag + 3 max-length bytes; the
+    // three retry counters that follow are read-only. A host writing a full
+    // 7-byte record must never zero them — that would block every PIN across a
+    // power cycle, recoverable only by a key-destroying TERMINATE DF.
+    let (mut fs, mut sess) = setup();
+    admin(&mut fs, &mut sess);
+    assert_eq!(
+        put_pw_status(&mut fs, &sess, &[0x01, 0x7F, 0x7F, 0x7F, 0, 0, 0]),
+        Sw::OK
+    );
+    let mut pw = [0u8; 7];
+    let n = fs.read(EF_PW_PRIV, &mut pw).unwrap();
+    assert_eq!(n, 7);
+    assert_eq!(
+        &pw[0..4],
+        &[0x01, 0x7F, 0x7F, 0x7F],
+        "flag + max-lengths written"
+    );
+    assert_eq!(&pw[4..7], &[3, 0, 3], "retry counters must be read-only");
+}
+
+#[test]
 fn generic_put_data_does_not_handle_specials() {
     // The reset code / PW status are routed away from the generic DO write.
     let (mut fs, mut sess) = setup();

--- a/crates/rsk-openpgp/src/serial_identity_tests.rs
+++ b/crates/rsk-openpgp/src/serial_identity_tests.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! Characterization test for a latent robustness weakness surfaced while
+//! investigating issue #25 (OpenPGP "Bad PIN" / card unusable after a replug on
+//! a Waveshare RP2350-Zero, secure boot off).
+//!
+//! On a board with no provisioned OTP key the OpenPGP PIN verifier and the card
+//! AID are both derived from the device serial: the PIN KDF roots on
+//! `serial_hash` (`kbase = HKDF(SALT_NOOTP, serial_hash)`, see
+//! `rsk_crypto::kdf`), and `full_aid` splices `serial_id[..4]` in at offset 10.
+//! `firmware/src/main.rs` computes both from a single boot-time read,
+//! `serial_id = get_chipid().unwrap_or(0)`, `serial_hash = sha256(serial_id)`.
+//!
+//! These tests pin the *consequence* of that coupling: if the boot serial ever
+//! differed across a power cycle, then against the SAME flash after a replug
+//!   * `pin_derive_verifier` yields a different verifier → the *correct* PIN is
+//!     rejected as `63 Cx` (gpg: `Bad PIN`), unrecoverably (no serial fallback in
+//!     `check_pin` on a no-OTP board), and
+//!   * `full_aid` carries a different serial → GET DATA `0x4F` returns a
+//!     different AID (scdaemon keys the card off this → "card not available").
+//!
+//! SCOPE — read before trusting this as issue #25's cause. These tests
+//! *demonstrate the consequence* by hardcoding the serial change (`CHIPID_B`);
+//! they do NOT establish that the serial actually changes across a replug — but
+//! that trigger is *plausible* (not, as first thought, implausible):
+//! `embassy_rp::otp::get_chipid` reads the chip id through the UNGUARDED ECC alias
+//! (`read_ecc_word`), which checks only the raw read for the all-ones permission
+//! lock and does NOT surface an uncorrectable ECC error on the corrected read. So a
+//! marginal/aging CHIPID OTP cell can silently return a *different* value across a
+//! power cycle (a 2-bit-or-worse fault is mis-corrected, not an `Err`), and
+//! `unwrap_or(0)` at `firmware/src/main.rs` only catches the `Err` path — a
+//! silently-wrong chip id flows straight into `serial_hash`. That is a real
+//! *fail-explicitly* smell AND a board-specific, intermittent brick matching #25
+//! (and why it does not reproduce on a healthy board). Competing hypotheses (torn
+//! KV persistence; host PC/SC artifact) stay open. Confirmation is device-side:
+//! read the chip id (`picotool otp get`) or the `GET DATA 0x4F` AID serial across a
+//! real replug — if it moves, this is the cause. Kept as a characterization +
+//! regression guard for the identity-stability fix.
+
+use super::*;
+use rsk_fs::storage::ram::RamStorage;
+
+/// Deterministic counter RNG, as in the sibling test modules.
+struct CountRng(u8);
+impl Rng for CountRng {
+    fn fill(&mut self, buf: &mut [u8]) {
+        for b in buf.iter_mut() {
+            *b = self.0;
+            self.0 = self.0.wrapping_add(1);
+        }
+    }
+}
+
+/// Two identities for the SAME physical board across two boots: `A` = the chip
+/// id read succeeded; `B` = it failed and `get_chipid().unwrap_or(0)` fell back
+/// to 0. `serial_hash = sha256(serial_id)` exactly as `firmware/src/main.rs`.
+const CHIPID_A: [u8; 8] = [0xCD, 0xC7, 0x0A, 0xF4, 0xD3, 0x74, 0x99, 0xA2];
+const CHIPID_B: [u8; 8] = [0u8; 8];
+
+fn boot(serial_id: [u8; 8]) -> ([u8; 8], [u8; 32]) {
+    (serial_id, rsk_crypto::sha256(&serial_id))
+}
+
+fn dev<'a>(serial_id: &'a [u8; 8], serial_hash: &'a [u8; 32]) -> Device<'a> {
+    Device {
+        serial_hash,
+        serial_id,
+        otp_key: None,
+    }
+}
+
+/// A fresh RAM-backed OpenPGP filesystem provisioned under `serial` — writes the
+/// default PIN verifiers + DEK bound to that serial's derivation.
+fn provision(serial_id: &[u8; 8], serial_hash: &[u8; 32]) -> Fs<RamStorage> {
+    let mut fs = Fs::new(RamStorage::new(), &[]);
+    fs.scan();
+    scan_files(&dev(serial_id, serial_hash), &mut fs, &mut CountRng(0)).unwrap();
+    fs
+}
+
+fn applet<'a>(
+    serial_id: [u8; 8],
+    serial_hash: [u8; 32],
+    rng: &'a RefCell<CountRng>,
+    presence: &'a RefCell<crate::AlwaysConfirm>,
+) -> OpenpgpApplet<'a> {
+    OpenpgpApplet::new(serial_id, serial_hash, None, rng, presence)
+}
+
+/// VERIFY PW1 (mode 0x81) with `pin`, through the full APDU dispatch — the exact
+/// path scdaemon drives.
+fn verify_pw1(app: &mut OpenpgpApplet, fs: &mut Fs<RamStorage>, pin: &[u8]) -> Sw {
+    let mut a = vec![
+        0x00,
+        consts::INS_VERIFY,
+        0x00,
+        consts::PW1_MODE81,
+        pin.len() as u8,
+    ];
+    a.extend_from_slice(pin);
+    let apdu = Apdu::parse(&a).unwrap();
+    let mut buf = [0u8; SCRATCH];
+    let mut res = ResBuf::new(&mut buf);
+    app.process(&apdu, fs, &mut res)
+}
+
+/// GET DATA `0x4F` → the 16-byte application AID (`D2 76 00 01 24 01 …
+/// serial(4) …`), the card serial scdaemon reads on connect.
+fn get_aid(app: &mut OpenpgpApplet, fs: &mut Fs<RamStorage>) -> Vec<u8> {
+    let apdu = Apdu::parse(&[0x00, consts::INS_GET_DATA, 0x00, 0x4F]).unwrap();
+    let mut buf = [0u8; SCRATCH];
+    let mut res = ResBuf::new(&mut buf);
+    assert_eq!(app.process(&apdu, fs, &mut res), Sw::OK, "GET DATA 0x4F");
+    res.as_slice().to_vec()
+}
+
+#[test]
+fn serial_change_rejects_the_correct_pin() {
+    let (id_a, hash_a) = boot(CHIPID_A);
+    let (id_b, hash_b) = boot(CHIPID_B);
+    let mut fs = provision(&id_a, &hash_a); // set up under boot A's serial
+
+    let rng = RefCell::new(CountRng(0));
+    let presence = RefCell::new(crate::AlwaysConfirm);
+
+    // Boot A (card still plugged in, as during setup): the default PIN verifies.
+    let mut app_a = applet(id_a, hash_a, &rng, &presence);
+    assert_eq!(
+        verify_pw1(&mut app_a, &mut fs, consts::PW1_DEFAULT),
+        Sw::OK,
+        "the correct PIN must work right after setup"
+    );
+
+    // A boot whose serial differs (modelled as the unwrap_or(0) fallback), same
+    // flash, same correct PIN → rejected as 63 C2 (gpg: "Bad PIN").
+    let mut app_b = applet(id_b, hash_b, &rng, &presence);
+    assert_eq!(
+        verify_pw1(&mut app_b, &mut fs, consts::PW1_DEFAULT),
+        Sw::new(0x63, 0xC2),
+        "a changed serial rejects the correct PIN (the verifier is serial-bound)"
+    );
+
+    // The stored PIN is fine: back on boot A the same PIN verifies (this success
+    // resets the counter the app_b miss decremented), so only the derived
+    // identity moved — not the PIN in flash.
+    let mut app_a2 = applet(id_a, hash_a, &rng, &presence);
+    assert_eq!(
+        verify_pw1(&mut app_a2, &mut fs, consts::PW1_DEFAULT),
+        Sw::OK,
+        "the PIN is unchanged in flash — only the serial-derived key differs"
+    );
+}
+
+#[test]
+fn serial_change_moves_the_card_aid() {
+    let (id_a, hash_a) = boot(CHIPID_A);
+    let (id_b, hash_b) = boot(CHIPID_B);
+    let mut fs = provision(&id_a, &hash_a);
+    let rng = RefCell::new(CountRng(0));
+    let presence = RefCell::new(crate::AlwaysConfirm);
+
+    let mut app_a = applet(id_a, hash_a, &rng, &presence);
+    let aid_a = get_aid(&mut app_a, &mut fs);
+
+    let mut app_b = applet(id_b, hash_b, &rng, &presence);
+    let aid_b = get_aid(&mut app_b, &mut fs);
+
+    // Same 6-byte OpenPGP AID prefix + version/manufacturer, but the 4-byte
+    // serial at offset 10..14 differs → scdaemon reads a different card serial.
+    assert_eq!(aid_a.len(), 16);
+    assert_eq!(
+        &aid_a[..10],
+        &aid_b[..10],
+        "only the serial region may differ"
+    );
+    assert_ne!(
+        &aid_a[10..14],
+        &aid_b[10..14],
+        "a changed serial moves the card AID/serial scdaemon keys on"
+    );
+}
+
+#[test]
+fn serial_change_burns_retries_and_blocks_the_good_boot() {
+    // Unrecoverable on a no-OTP board: check_pin has no serial fallback (only the
+    // OTP-generation one), so correct PINs under the wrong serial drain the
+    // counter to a hard block — the "card unusable" end state, not just one bad
+    // attempt.
+    let (id_a, hash_a) = boot(CHIPID_A);
+    let (id_b, hash_b) = boot(CHIPID_B);
+    let mut fs = provision(&id_a, &hash_a);
+    let rng = RefCell::new(CountRng(0));
+    let presence = RefCell::new(crate::AlwaysConfirm);
+
+    let mut app_b = applet(id_b, hash_b, &rng, &presence);
+    assert_eq!(
+        verify_pw1(&mut app_b, &mut fs, consts::PW1_DEFAULT),
+        Sw::new(0x63, 0xC2)
+    );
+    assert_eq!(
+        verify_pw1(&mut app_b, &mut fs, consts::PW1_DEFAULT),
+        Sw::new(0x63, 0xC1)
+    );
+    assert_eq!(
+        verify_pw1(&mut app_b, &mut fs, consts::PW1_DEFAULT),
+        Sw::PIN_BLOCKED
+    );
+
+    // The counter lives in shared flash, so once drained even the correct-serial
+    // boot with the correct PIN is locked out: a single serial change would brick
+    // OpenPGP, not just fail one attempt.
+    let mut app_a = applet(id_a, hash_a, &rng, &presence);
+    assert_eq!(
+        verify_pw1(&mut app_a, &mut fs, consts::PW1_DEFAULT),
+        Sw::PIN_BLOCKED,
+        "a serial glitch drains the retry counter and blocks the good boot too"
+    );
+}

--- a/crates/rsk-piv/src/auth.rs
+++ b/crates/rsk-piv/src/auth.rs
@@ -321,10 +321,16 @@ pub(crate) fn general_authenticate<S: Storage>(
     }
 
     let mut meta = [0u8; 8];
-    let Some(_meta_len) = fs.meta_find(key_fid(key_ref).get(), &mut meta) else {
-        mgm_key.zeroize();
-        return Sw::REFERENCE_NOT_FOUND;
-    };
+    // A key/mgmt slot's meta is [algo, pin_policy, touch_policy, (origin)] — every
+    // writer emits >= 3 bytes; reject a short record rather than read policy from
+    // the zero-fill (matches info::read_slot's n >= 3 guard).
+    match fs.meta_find(key_fid(key_ref).get(), &mut meta) {
+        Some(n) if n >= 3 => {}
+        _ => {
+            mgm_key.zeroize();
+            return Sw::REFERENCE_NOT_FOUND;
+        }
+    }
     let mut pinpol = meta[1];
     if pinpol == PINPOLICY_DEFAULT {
         pinpol = if key_ref == SLOT_SIGNATURE {

--- a/crates/rsk-piv/src/lib.rs
+++ b/crates/rsk-piv/src/lib.rs
@@ -825,6 +825,11 @@ impl PivApplet<'_> {
         if (!is_key(to) && to != 0xFF) || !is_key(from) {
             return Sw::INCORRECT_P1P2;
         }
+        // A self-move would write the key back then delete the source — the same
+        // slot — destroying it; reject before any write, as real hardware does.
+        if to == from {
+            return Sw::INCORRECT_P1P2;
+        }
         if is_retired(from) && is_active(to) {
             return Sw::INCORRECT_P1P2;
         }

--- a/crates/rsk-piv/src/lib.rs
+++ b/crates/rsk-piv/src/lib.rs
@@ -424,10 +424,11 @@ impl PivApplet<'_> {
         unblock_pin_with_puk(dev, fs, &apdu.data[..puk_len], &apdu.data[puk_len..])
     }
 
-    /// SET RETRIES (INS 0xFA, management-gated): resets both references to
-    /// their defaults with the new totals.
+    /// SET RETRIES (INS 0xFA): resets both references to their defaults with the
+    /// new totals. Requires the management key **and** the current PIN — it wipes
+    /// PIN/PUK, so mgmt alone must not reset an unknown PIN (matches YubiKey).
     fn set_retries<S: Storage>(&mut self, dev: &Device, fs: &mut Fs<S>, apdu: &Apdu) -> Sw {
-        if !self.sess.has_mgm {
+        if !self.sess.has_mgm || !self.sess.has_pin {
             return Sw::SECURITY_STATUS_NOT_SATISFIED;
         }
         if apdu.p1 == 0 || apdu.p2 == 0 {

--- a/crates/rsk-piv/src/tests.rs
+++ b/crates/rsk-piv/src/tests.rs
@@ -1364,6 +1364,82 @@ fn ed25519_generate_sign_and_self_signed_cert() {
     .unwrap();
 }
 
+/// A key slot whose metadata is shorter than the [algo, pin, touch] header
+/// (unreachable via normal writers — a defense-in-depth backstop) is rejected
+/// by GENERAL AUTHENTICATE rather than reading policy from the zero-fill, which
+/// would silently drop the touch gate.
+#[test]
+fn general_auth_rejects_short_meta() {
+    let rng = RefCell::new(TestRng(7));
+    let pres = RefCell::new(AlwaysConfirm);
+    let mut app = PivApplet::new(SERIAL, HASH, None, &rng, &pres);
+    let mut fs = new_fs();
+    select(&mut app, &mut fs);
+    auth_mgm(&mut app, &mut fs);
+    verify_pin(&mut app, &mut fs);
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_ASYM_KEYGEN,
+        0,
+        0x9A,
+        &gen_template(ALGO_ED25519),
+    );
+    assert_eq!(sw, Sw::OK);
+    // Control: with the normal (4-byte) meta the sign succeeds.
+    let message = [0x42u8; 32];
+    let mut msg = vec![0x7C, 0x24, 0x82, 0x00, 0x81, 0x20];
+    msg.extend_from_slice(&message);
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_AUTHENTICATE,
+        ALGO_ED25519,
+        0x9A,
+        &msg,
+    );
+    assert_eq!(sw, Sw::OK);
+    // Truncate the slot meta below the 3-byte [algo, pin, touch] header and
+    // repeat: the guard fires (without it the missing bytes read as the zero-fill
+    // and the sign would succeed, silently dropping the touch gate). Both 1- and
+    // 2-byte records must be rejected — this pins the threshold at 3, not 2.
+    for short in [&[ALGO_ED25519][..], &[ALGO_ED25519, PINPOLICY_ONCE][..]] {
+        fs.meta_delete(key_fid(0x9A).get()).unwrap();
+        fs.meta_add(key_fid(0x9A).get(), short).unwrap();
+        let (sw, _) = run(
+            &mut app,
+            &mut fs,
+            INS_AUTHENTICATE,
+            ALGO_ED25519,
+            0x9A,
+            &msg,
+        );
+        assert_eq!(
+            sw,
+            Sw::REFERENCE_NOT_FOUND,
+            "meta length {} must be rejected",
+            short.len()
+        );
+    }
+    // Exactly the 3-byte header is accepted (threshold is 3, not 4): a minimal
+    // [algo, pin, touch] meta signs again.
+    fs.meta_delete(key_fid(0x9A).get()).unwrap();
+    fs.meta_add(
+        key_fid(0x9A).get(),
+        &[ALGO_ED25519, PINPOLICY_ONCE, TOUCHPOLICY_NEVER],
+    )
+    .unwrap();
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_AUTHENTICATE,
+        ALGO_ED25519,
+        0x9A,
+        &msg,
+    );
+    assert_eq!(sw, Sw::OK);
+}
+
 /// Generate an X25519 key: it gets no self-signed certificate (it can't sign),
 /// and GENERAL AUTHENTICATE exponentiation (`ykman calculate-secret`) agrees a
 /// shared secret that matches the host side.

--- a/crates/rsk-piv/src/tests.rs
+++ b/crates/rsk-piv/src/tests.rs
@@ -1990,6 +1990,35 @@ fn move_and_delete_key() {
 }
 
 #[test]
+fn move_key_same_slot_rejected() {
+    // MOVE KEY onto its own slot (p1 == p2) must be rejected before any write:
+    // the source-delete would otherwise erase the very slot just rewritten,
+    // silently destroying the (possibly only) key while returning success.
+    let rng = RefCell::new(TestRng(7));
+    let pres = RefCell::new(AlwaysConfirm);
+    let mut app = PivApplet::new(SERIAL, HASH, None, &rng, &pres);
+    let mut fs = new_fs();
+    select(&mut app, &mut fs);
+    auth_mgm(&mut app, &mut fs);
+    verify_pin(&mut app, &mut fs);
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_ASYM_KEYGEN,
+        0,
+        0x9A,
+        &gen_template(ALGO_ECCP256),
+    );
+    assert_eq!(sw, Sw::OK);
+    let (sw, _) = run(&mut app, &mut fs, INS_MOVE_KEY, 0x9A, 0x9A, &[]);
+    assert_eq!(sw, Sw::INCORRECT_P1P2);
+    // The key survives the rejected self-move.
+    let (sw, md) = run(&mut app, &mut fs, INS_GET_METADATA, 0, 0x9A, &[]);
+    assert_eq!(sw, Sw::OK);
+    assert_eq!(find_tag(&md, 0x01).unwrap(), &[ALGO_ECCP256]);
+}
+
+#[test]
 fn set_retries_and_reset_card() {
     let rng = RefCell::new(TestRng(7));
     let pres = RefCell::new(AlwaysConfirm);

--- a/crates/rsk-piv/src/tests.rs
+++ b/crates/rsk-piv/src/tests.rs
@@ -2066,6 +2066,27 @@ fn set_retries_and_reset_card() {
 }
 
 #[test]
+fn set_retries_requires_pin_not_just_mgmt() {
+    let rng = RefCell::new(TestRng(7));
+    let pres = RefCell::new(AlwaysConfirm);
+    let mut app = PivApplet::new(SERIAL, HASH, None, &rng, &pres);
+    let mut fs = new_fs();
+    select(&mut app, &mut fs);
+    // Management alone (the public default key) must NOT reset the PIN: INS 0xFA
+    // wipes PIN/PUK to defaults, so it also requires the current PIN (YubiKey).
+    auth_mgm(&mut app, &mut fs);
+    let (sw, _) = run(&mut app, &mut fs, INS_SET_RETRIES, 5, 4, &[]);
+    assert_eq!(sw, Sw::SECURITY_STATUS_NOT_SATISFIED);
+    // With the PIN also verified it proceeds and applies the new totals.
+    verify_pin(&mut app, &mut fs);
+    let (sw, _) = run(&mut app, &mut fs, INS_SET_RETRIES, 5, 4, &[]);
+    assert_eq!(sw, Sw::OK);
+    let (sw, md) = run(&mut app, &mut fs, INS_GET_METADATA, 0, 0x80, &[]);
+    assert_eq!(sw, Sw::OK);
+    assert_eq!(find_tag(&md, 0x06).unwrap(), &[5, 5]);
+}
+
+#[test]
 fn management_gates() {
     let rng = RefCell::new(TestRng(7));
     let pres = RefCell::new(AlwaysConfirm);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,16 @@ the opaque credential ID a relying party stores, so its size caps the reported
 
 ![FIDO credential box — proto(4) iv(12) then a variable CBOR body, poly1305 tag(16) and silent tag(16); the four framing pieces are 48 bytes and the whole box is at most 748. Below it, the 42-byte resident id returned to the relying party](images/cred-box.svg)
 
+The 42-byte resident id carries a **version byte** at offset 8 — a reserved
+header byte outside the `[10..42]` HMAC chain, so it never changes the id's
+entropy. It is `1` (v2) for every resident credential created since RS-Key
+`0x0806`: a v2 credential derives its signing key, hmac-secret and largeBlobKey
+from this **stable** id, so an `updateUserInformation` reseal (which draws a
+fresh box IV) no longer rotates them and the relying party's stored public key
+keeps verifying. Resident credentials from older firmware carry an implicit `0`
+(v1) and keep deriving from the box, so an already-provisioned device stays
+compatible across the upgrade.
+
 ## Capacity — why the flash is mostly empty
 
 The KV store is a fixed 1.5 MB whatever the `FLASH_SIZE` ([build.md](build.md));

--- a/docs/guides/audit.md
+++ b/docs/guides/audit.md
@@ -11,16 +11,18 @@ rsk audit verify --expect-key <hex>   # also pin the enrolled attestation key
 ```
 
 `log` is a plain read — it pretty-prints the live window and the recomputed
-chain head, no touch, no signature. `verify` does the same read *and* asks the
-device to sign the head, so it is the command that actually proves the log is
-real. Use `log` for a quick glance, `verify` when the answer matters.
+chain head, no signature. It takes `--pin` on a device with a PIN, and a touch
+on one with none (the read is never fully open). `verify` does the same read
+*and* asks the device to sign the head, so it is the command that actually
+proves the log is real. Use `log` for a quick glance, `verify` when the answer
+matters.
 
 ## What it records
 
 | event | detail |
 |---|---|
 | `BOOT` | first journal touch of each power cycle |
-| `MAKE_CREDENTIAL` / `GET_ASSERTION` / `U2F_REGISTER` / `U2F_AUTH` | first 8 bytes of the rpIdHash (pseudonymous) |
+| `MAKE_CREDENTIAL` / `GET_ASSERTION` / `U2F_REGISTER` / `U2F_AUTH` | first 8 bytes of the rpIdHash (only *weakly* pseudonymous — see [Gating](#gating)) |
 | `RESET` | factory reset (survives it — see below) |
 | `PIN_SET` / `PIN_CHANGE` / `PIN_LOCKOUT` | lockout aux: 0 = retries exhausted, 1 = per-boot block |
 | `CFG_MIN_PIN` | aux = new minimum; detail[0] = forceChangePin |
@@ -134,13 +136,15 @@ checkpoint key, which is DEVK-derived) continue uninterrupted across resets, so
 
 | command | open device | PIN set |
 |---|---|---|
-| `audit log` / `AUDIT_READ` | open | pinUvAuthToken with the `acfg` permission |
+| `audit log` / `AUDIT_READ` | touch | pinUvAuthToken with the `acfg` permission |
 | `audit verify` / `AUDIT_CHECKPOINT` | touch | touch **+** `acfg` pinUvAuthToken |
 
-- **`AUDIT_READ` (export).** Open when no PIN is set; otherwise it needs a
-  pinUvAuthToken carrying the `acfg` (authenticator-config) permission. Entries
-  are pseudonymous either way — rpIdHash prefixes, never RP names or user
-  handles — so even an open read leaks no browsing history.
+- **`AUDIT_READ` (export).** With a PIN set it needs a pinUvAuthToken carrying
+  the `acfg` (authenticator-config) permission; with no PIN it needs a physical
+  touch. The entries are only *weakly* pseudonymous — a `detail` is a 64-bit
+  rpIdHash prefix, never an RP name or user handle, but short enough to be
+  dictionary-matched back to a domain — so the touch is what stops a silent host
+  from harvesting a no-PIN device's RP-usage history.
 - **`AUDIT_CHECKPOINT`.** The same PIN gate **plus a physical touch**, and it
   refuses entirely without a provisioned OTP DEVK — an attestation that anyone
   could re-derive would be theatre. The signing step is what the touch protects;

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -124,8 +124,9 @@ press of the BOOTSEL button while the LED blinks, within a 30-second window.
 `rsk` prints `touch the device …` to stderr before blocking. Touch-gated
 commands include `backup export`/`restore`/`finalize`, `audit verify`,
 `inventory verify`, `lock enable`/`disable`, and `fido attestation import`/
-`clear`. Read-only commands (`status`, `inventory list`, `*/status`,
-`audit log`) need no touch.
+`clear`. Read-only commands (`status`, `inventory list`, `*/status`) need no
+touch; `audit log` needs one only on a device with no PIN (the PIN token gates
+it otherwise).
 
 ### Machine-readable output
 

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -180,7 +180,7 @@ and a provisioned OTP DEVK — without the DEVK it says
 hash-chained sequence of events (`BOOT`, `MAKE_CREDENTIAL`, `GET_ASSERTION`,
 `PIN_SET`, `BACKUP_EXPORT`, `CHECKPOINT`, …) folded into an epoch, with the
 running chain `head`. It is read-only — the device never lets the host rewrite
-it — and asks for the FIDO2 PIN if one is set. The full cross-check against the
+it — and asks for the FIDO2 PIN if one is set, or a physical touch if not. The full cross-check against the
 signed head lives in `rsk audit verify`.
 
 **LED** reads the four LED states the firmware drives — `idle`, `processing`,

--- a/docs/images/cred-box.svg
+++ b/docs/images/cred-box.svg
@@ -92,7 +92,7 @@
     </g>
     <text class="cellsm" x="98"  y="398" text-anchor="middle">serial-derived</text>
     <text class="cellsm" x="214" y="398" text-anchor="middle">proto f1d00203</text>
-    <text class="cellsm" x="306" y="398" text-anchor="middle">00 00</text>
+    <text class="cellsm" x="306" y="398" text-anchor="middle">01 · 00</text>
     <text class="cell"   x="538" y="398" text-anchor="middle">HMAC-SHA256 chain over the box</text>
   </g>
   <g text-anchor="middle">

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -493,7 +493,7 @@ Keys 3/4 are present only when a PIN is set (see gating).
 | `04` | BACKUP_FINALIZE | — | — | touch |
 | `05` | BACKUP_STATE | — | `{1: sealed, 2: has_seed, 3: locked, 4: unlocked}` | **ungated** |
 | `06` | UNLOCK | `{1: blob(60)}` | — | MSE (the lock key *is* the auth) |
-| `07` | AUDIT_READ | — | journal window | PIN-token |
+| `07` | AUDIT_READ | — | journal window | PIN-token; **touch** if no PIN |
 | `08` | AUDIT_CHECKPOINT | `{1: nonce ≤32}` | DEVK signature over chain head ‖ nonce | PIN-token + touch |
 | `09` | ATT_IMPORT | `{1: blob(60), 2: DER chain}` | — | MSE + touch + PIN-token |
 | `0A` | ATT_CLEAR | — | — | MSE + touch + PIN-token |

--- a/firmware/src/ccid_handler.rs
+++ b/firmware/src/ccid_handler.rs
@@ -20,7 +20,11 @@ use rsk_sdk::{Apdu, Applet, Dispatcher, ResBuf, Sw};
 use crate::handler::{FidoRng, Store};
 use crate::vendor::VendorApplet;
 
-const RESP_CAP: usize = 2048;
+// A CCID XfrBlock frame carries MAX_CCID_MSG (2048) minus the 10-byte CCID
+// header = 2038 payload bytes. The applet response (body + 2-byte SW) must fit
+// one frame; sizing this to the full message let a large response (e.g. a long
+// OATH LIST) overrun the frame, and `run_xfr` silently dropped the tail incl. SW.
+const RESP_CAP: usize = 2038;
 
 /// Registration-order indices of the applets whose RSA keygen is fast-pathed.
 const IDX_OPENPGP: usize = 1;

--- a/firmware/src/core1.rs
+++ b/firmware/src/core1.rs
@@ -329,11 +329,19 @@ pub fn run_rsa_search_progress(
     while outcome.is_none() {
         // Observation hook (display spinner); time-gated by the caller, off the keygen state.
         on_tick();
-        // Core1's finds first (cheap to drain)…
-        let mut batch = MAILBOX.lock(|mb| {
-            let mut mb = mb.borrow_mut();
-            [mb.found[0].take(), mb.found[1].take()]
-        });
+        // Core1's finds first (cheap to drain) — but only when we actually
+        // engaged it this keygen. If the entry gate timed out (engaged=false),
+        // core1 is still on the PRIOR job, so anything in `found` is a stale
+        // prime for a different (possibly different-size) key; feeding it to this
+        // keygen would corrupt the modulus. Leave it for the wind-down scrub.
+        let mut batch = if engaged {
+            MAILBOX.lock(|mb| {
+                let mut mb = mb.borrow_mut();
+                [mb.found[0].take(), mb.found[1].take()]
+            })
+        } else {
+            [None, None]
+        };
         let mut had_finds = false;
         for f in batch.iter_mut().filter_map(Option::as_mut) {
             had_finds = true;

--- a/firmware/src/led.rs
+++ b/firmware/src/led.rs
@@ -387,7 +387,10 @@ fn effect_vapor(status: usize, tick: u32) -> [RGB8; MAX_LEDS] {
         (period - phase) * peak as u32 / half
     };
 
-    let c = color_rgb(color_idx, breathe as u8);
+    // Clamp before the u8 cast: for an odd period the falling ramp divides by
+    // `half` (floor) over `half+1` steps, so `breathe` can exceed `peak` at the
+    // apex and wrap to a dark value instead of the brightest.
+    let c = color_rgb(color_idx, breathe.min(peak as u32) as u8);
     let n = runtime_leds() as usize;
     let mut buf = [RGB8::default(); MAX_LEDS];
     for led in buf[..n].iter_mut() {

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x07FC;
+    let device_release: u16 = 0x0805;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0806;
+    let device_release: u16 = 0x0808;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0805;
+    let device_release: u16 = 0x0806;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0809;
+    let device_release: u16 = 0x080B;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0808;
+    let device_release: u16 = 0x0809;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/tools/rsk/__init__.py
+++ b/tools/rsk/__init__.py
@@ -8,4 +8,4 @@ backup, secure-boot provisioning, OTP-MKEK burn/lock, FIDO management, LED confi
 OpenPGP reset, and hands-free reboot. Run from `nix develop` (the flake provides
 `rsk` on PATH and all Python deps) or as `python -m rsk`.
 """
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/tools/rsk/__init__.py
+++ b/tools/rsk/__init__.py
@@ -8,4 +8,4 @@ backup, secure-boot provisioning, OTP-MKEK burn/lock, FIDO management, LED confi
 OpenPGP reset, and hands-free reboot. Run from `nix develop` (the flake provides
 `rsk` on PATH and all Python deps) or as `python -m rsk`.
 """
-__version__ = "0.3.8"
+__version__ = "0.3.9"

--- a/tools/rsk/audit.py
+++ b/tools/rsk/audit.py
@@ -9,7 +9,8 @@ hash-chained from an "epoch" accumulator that absorbs evicted history. The
 device signs the chain head with an ECDSA P-256 key derived from the OTP DEVK
 (vendor AUDIT_CHECKPOINT), so the log is verifiable end-to-end:
 
-  log     export and pretty-print the journal      (--pin if a PIN is set)
+  log     export and pretty-print the journal      (--pin if a PIN is set,
+                                                     else a touch)
   verify  log + signed checkpoint over a fresh
           challenge; checks the chain and the
           signature                                 (touch; --pin if a PIN is set)
@@ -106,8 +107,12 @@ def verify_checkpoint(m, challenge, distrust, badsig):
 
 def read_journal(dev, cid, pin):
     """AUDIT_READ → (start, seq_next, epoch, entries bytes)."""
+    if pin is None:
+        # No PIN backs the gate, so the firmware requires a touch instead.
+        print("touch the device (BOOTSEL) to read the journal…", file=sys.stderr)
     st, m = _vendor(dev, cid, _gated(AUDIT_READ, None, dev, cid, pin))
     _die_pin_required(st)
+    _die_touch_denied(st)
     if st != 0:
         die(f"audit read failed: {st:#x}")
     start, seq_next, epoch, entries = m[1], m[2], m[3], m[4]

--- a/tools/rsk/common.py
+++ b/tools/rsk/common.py
@@ -23,6 +23,20 @@ def sanitize(text):
     )
 
 
+def sanitize_join(seq, sep=", "):
+    """Join a device-controlled sequence for display. A hostile/old device may
+    send a scalar, None, or non-string elements where a list of strings is
+    expected — coerce to a list and sanitize each element so neither a
+    TypeError nor an injected terminal escape reaches the operator."""
+    if isinstance(seq, (list, tuple)):
+        items = seq
+    elif seq is None:
+        items = []
+    else:
+        items = [seq]
+    return sep.join(sanitize(v) for v in items)
+
+
 def confirm(token):
     """Interactive typed confirmation for an irreversible action."""
     print(f"\nThis is irreversible. Type exactly  {token}  to proceed.")

--- a/tools/rsk/inventory.py
+++ b/tools/rsk/inventory.py
@@ -25,7 +25,8 @@ import sys
 from . import ccid, ctaphid
 from .audit import AUDIT_CHECKPOINT, _fingerprint, verify_checkpoint
 from .backup import ERR_NOT_ALLOWED, _die_pin_required, _die_touch_denied, _gated, _vendor
-from .common import add_pin_arg, connect_fido, device_has_pin, die, resolve_pin, sanitize
+from .common import (add_pin_arg, connect_fido, device_has_pin, die,
+                     resolve_pin, sanitize, sanitize_join)
 from .fido import ATT_STATE  # vendor: org-attestation state (ungated)
 from .status import RESCUE_AID, VENDOR_STATE, _fw, rescue_read, rescue_serial
 
@@ -107,7 +108,7 @@ def _hid_records():
                 rec["fw"] = _fw(gi.get(14))
                 rec["versions"] = gi.get(1)
                 rec["aaguid"] = gi.get(3).hex() if gi.get(3) else None
-                rec["client_pin"] = (gi.get(4) or {}).get("clientPin")
+                rec["client_pin"] = bool((gi.get(4) or {}).get("clientPin"))
             st, m = _vendor(dev, cid, {1: VENDOR_STATE})
             if st == 0:
                 rec["backup"] = {"sealed": bool(m.get(1)), "has_seed": bool(m.get(2))}
@@ -156,7 +157,7 @@ def _print_record(rec):
     if fl:
         print(f"  flash      : {fl['used']}/{fl['kv_total']} B used, {fl['files']} files")
     if rec.get("versions") is not None:
-        print(f"  fido       : {sanitize(', '.join(rec['versions']))}  clientPin={rec.get('client_pin')}")
+        print(f"  fido       : {sanitize_join(rec['versions'])}  clientPin={rec.get('client_pin')}")
     b, lk = rec.get("backup"), rec.get("lock")
     if b:
         lock = ("LOCKED" if lk["locked"] else "off") if lk else "n/a"

--- a/tools/rsk/lock.py
+++ b/tools/rsk/lock.py
@@ -69,10 +69,14 @@ def _state(dev, cid):
     st, m = _vendor(dev, cid, {1: VENDOR_STATE})
     if st != 0:
         die(f"state read failed: {st:#x}")
-    # Firmware without soft-lock support answers with only {1: sealed, 2: has_seed}.
-    if 3 not in m:
+    # A hostile/old device may answer with a non-map or without the soft-lock
+    # fields; require the map and key 3 (the isinstance guard also stops a scalar
+    # reply from raising on `3 not in m`), then coerce to bool so a spoofed
+    # string value can't reach the terminal or a downstream check raw.
+    if not isinstance(m, dict) or 3 not in m:
         die("firmware too old — no soft-lock support (need bcdDevice >= 0x0742)")
-    return {"sealed": m[1], "has_seed": m[2], "locked": m[3], "unlocked": m[4]}
+    return {"sealed": bool(m.get(1)), "has_seed": bool(m.get(2)),
+            "locked": bool(m.get(3)), "unlocked": bool(m.get(4))}
 
 
 def _wrap_for_channel(key, aad, secret):

--- a/tools/rsk/status.py
+++ b/tools/rsk/status.py
@@ -11,7 +11,7 @@ import json
 
 from . import ccid, ctaphid
 from .backup import CTAP_VENDOR, STATE as VENDOR_STATE
-from .common import sanitize
+from .common import sanitize, sanitize_join
 
 RESCUE_AID = [0xA0, 0x58, 0x3F, 0xC1, 0x9B, 0x7E, 0x4F, 0x21]
 INS_RESCUE_READ = 0x1E
@@ -49,7 +49,7 @@ def _fido():
             out["aaguid"] = gi.get(3).hex() if gi.get(3) else None
             out["fw"] = _fw(gi.get(14))
             opts = gi.get(4) or {}
-            out["clientPin"] = opts.get("clientPin")
+            out["clientPin"] = bool(opts.get("clientPin"))
             out["options"] = sorted(k for k, v in opts.items() if v)
         rb = ctaphid.send_cbor(dev, cid, bytes([CTAP_VENDOR]) + ctaphid.enc({1: VENDOR_STATE}))
         if rb[0] == 0:
@@ -105,8 +105,8 @@ def run(args):
     if not f.get("present"):
         print("FIDO HID   : not found")
     else:
-        print(f"FIDO HID   : present  fw {f.get('fw')}  aaguid {f.get('aaguid', '')[:16]}…")
-        print(f"  versions : {sanitize(', '.join(f.get('versions') or []))}")
+        print(f"FIDO HID   : present  fw {f.get('fw')}  aaguid {(f.get('aaguid') or '')[:16]}…")
+        print(f"  versions : {sanitize_join(f.get('versions'))}")
         print(f"  clientPin: {f.get('clientPin')}")
         b = f.get("backup")
         if b:

--- a/tools/rsk/test_common.py
+++ b/tools/rsk/test_common.py
@@ -119,3 +119,26 @@ def test_sanitize_preserves_benign_text():
 
 def test_sanitize_coerces_non_str():
     assert common.sanitize(None) == "None"
+
+
+# --- sanitize_join: a hostile getInfo `versions` must not crash the CLI --------
+# status/inventory join device-controlled `versions` for display; a counterfeit
+# device can answer with non-strings, a scalar, or None instead of a str list.
+
+def test_sanitize_join_normal_list():
+    assert common.sanitize_join(["FIDO_2_0", "U2F_V2"]) == "FIDO_2_0, U2F_V2"
+
+
+def test_sanitize_join_non_string_elements():
+    # CBOR ints instead of text: must coerce, not raise TypeError.
+    assert common.sanitize_join([1, 2]) == "1, 2"
+
+
+def test_sanitize_join_scalar_and_none():
+    # A bare int / None where a list is expected: no "not iterable" crash.
+    assert common.sanitize_join(5) == "5"
+    assert common.sanitize_join(None) == ""
+
+
+def test_sanitize_join_strips_escapes_in_elements():
+    assert "\x1b" not in common.sanitize_join(["ok", "\x1b]0;pwn\x07"])

--- a/tools/tui/Cargo.lock
+++ b/tools/tui/Cargo.lock
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "rsk-tui"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "aes",
  "bip39",

--- a/tools/tui/Cargo.lock
+++ b/tools/tui/Cargo.lock
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "rsk-tui"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "aes",
  "bip39",

--- a/tools/tui/Cargo.toml
+++ b/tools/tui/Cargo.toml
@@ -2,7 +2,7 @@
 # table below detaches it from the parent so it builds for the host, not thumbv8m).
 [package]
 name = "rsk-tui"
-version = "0.2.8"
+version = "0.2.9"
 license = "AGPL-3.0-only"
 edition = "2024"
 description = "rs-key device dashboard — a self-contained ratatui cockpit"

--- a/tools/tui/Cargo.toml
+++ b/tools/tui/Cargo.toml
@@ -2,7 +2,7 @@
 # table below detaches it from the parent so it builds for the host, not thumbv8m).
 [package]
 name = "rsk-tui"
-version = "0.2.7"
+version = "0.2.8"
 license = "AGPL-3.0-only"
 edition = "2024"
 description = "rs-key device dashboard — a self-contained ratatui cockpit"

--- a/tools/tui/src/device.rs
+++ b/tools/tui/src/device.rs
@@ -784,7 +784,7 @@ pub fn reboot(bootsel: bool) -> Result<String, String> {
 // ===========================================================================
 
 /// Read the tamper-evident journal (vendor AUDIT_READ). Read-only; the device
-/// asks for a PIN if one is set. Returns `(title, pretty body)`.
+/// asks for a PIN if one is set, or a touch if not. Returns `(title, pretty body)`.
 pub fn audit_read(pin: Option<&str>) -> Result<(String, String), String> {
     let dev = hid_open().ok_or("no FIDO device")?;
     let cid = ctaphid_init(&dev).ok_or("CTAPHID init failed")?;
@@ -799,6 +799,12 @@ pub fn audit_read(pin: Option<&str>) -> Result<(String, String), String> {
     match st {
         0 => {}
         CTAP2_ERR_PIN_REQUIRED => return Err(MSG_PIN_REQUIRED.into()),
+        // No PIN set → the read is touch-gated instead (firmware ≥ 0x0808).
+        0x27 => {
+            return Err(
+                "no touch within the timeout — press the button when the LED blinks".into(),
+            );
+        }
         s => return Err(format!("status {s:#x}")),
     }
     let v = v.ok_or("decode failed")?;

--- a/tools/tui/src/model.rs
+++ b/tools/tui/src/model.rs
@@ -758,7 +758,22 @@ fn json_str(s: &str) -> String {
             '\n' => out.push_str("\\n"),
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            // Escape every control and non-ASCII char to \uXXXX (like the Python
+            // CLI's ensure_ascii): keeps output valid JSON while neutralizing a
+            // hostile device's DEL/C1/bidi bytes in a raw --json terminal view.
+            c if c.is_control() || !c.is_ascii() => {
+                let u = c as u32;
+                if u > 0xFFFF {
+                    let v = u - 0x10000;
+                    out.push_str(&format!(
+                        "\\u{:04x}\\u{:04x}",
+                        0xD800 + (v >> 10),
+                        0xDC00 + (v & 0x3FF)
+                    ));
+                } else {
+                    out.push_str(&format!("\\u{u:04x}"));
+                }
+            }
             c => out.push(c),
         }
     }

--- a/tools/tui/src/model_tests.rs
+++ b/tools/tui/src/model_tests.rs
@@ -16,6 +16,16 @@ fn json_escapes_and_nulls() {
 }
 
 #[test]
+fn json_str_escapes_controls_bidi_and_non_ascii() {
+    // A hostile device product/version string must not smuggle DEL, an 8-bit C1
+    // introducer, or a bidi override into a raw --json terminal view; every
+    // control and non-ASCII char escapes to \u (astral chars as a surrogate pair).
+    let out = json_str("a\u{7f}\u{9b}b\u{202e}c\u{1f600}");
+    assert!(!out.contains('\u{7f}') && !out.contains('\u{9b}') && !out.contains('\u{202e}'));
+    assert_eq!(out, "\"a\\u007f\\u009bb\\u202ec\\ud83d\\ude00\"");
+}
+
+#[test]
 fn summary_without_device() {
     let s = DeviceSnapshot::default();
     assert_eq!(s.summary(), "no device detected");


### PR DESCRIPTION
## RS-Key v0.3.4

First release since v0.3.3. Firmware bcdDevice `0x07FC` → `0x080B`.

### Highlights
- **issue #25** — OpenPGP decrypt survives a dual PW1 `VERIFY` (independent PW1.81/82/PW3 latches); fixes `Bad PIN` on decrypt after replug.
- **Correctness-audit pass** — 9 firmware defects fixed + reseal-stable FIDO resident keys (`updateUserInformation` no longer bricks a passkey).
- **run-15 audit** — PIV SET RETRIES now requires PIN (not just the default management key); FIDO AUDIT_READ requires a touch on a no-PIN device.
- **run-16 audit** — defense-in-depth hardening: PIV GENERAL AUTHENTICATE metadata-length gate + dual-core RSA keygen prime-size backstop (both with neuter-verified tests).
- **Host tooling** — `rsk` CLI + TUI hardened against hostile-device CBOR.

Full detail in the CHANGELOG `[0.3.4]` section.

Merge as a **merge commit** to keep the signed commits and develop↔main in sync.
