### PR TITLE
Release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **A wrong PIN in `rsk fido set-pin` / `list-passkeys` now prints a clean error,
+  not a Python traceback.** python-fido2 raises `CtapError` when the device
+  rejects a clientPIN operation; `change_pin`, `set_pin` and `get_pin_token` left
+  it uncaught, so mistyping the current PIN while changing it dumped a stack trace
+  instead of "wrong PIN". These now map the CTAP 2.1 §6.5.5 status to an operator
+  message — a wrong PIN reports how many attempts remain before it blocks, and the
+  blocked / auth-blocked / policy statuses get actionable text — via a shared
+  `common.die_ctap_pin_error`. `rsk` `0.3.10` → `0.3.11`; host-only, no firmware
+  change.
 - **`rsk` now finds the FIDO HID on Linux hosts where hidapi doesn't report a
   usage page (issue #28).** `ctaphid.find()` matched a device solely by its HID
   `usage_page == 0xF1D0`, but some Linux `hidapi` builds (the libusb backend, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Changed
+
+- **`makeCredential` now ships `fmt:"none"` attestation by default**, fixing
+  `ssh-keygen -t ed25519-sk` enrollment on Windows / OpenSSH 10.0p2 (issue #26).
+  RS-Key previously returned packed **self**-attestation, so an Ed25519 credential
+  carried an Ed25519 self-attestation signature. OpenSSH 10.0 added
+  `fido_cred_verify_self`, and the Windows WebAuthn API does not round-trip that
+  EdDSA signature faithfully, so the verify failed with `FIDO_ERR_INVALID_SIG` and
+  the enroll aborted with "Key enrollment failed: invalid format" (ES256 self-att
+  round-trips fine, so `ecdsa-sk` worked; a genuine YubiKey uses basic ES256 x5c
+  attestation and never hits the path). Self-attestation conveys no trust beyond
+  "none" (WebAuthn §6.5.2), so shipping "none" loses nothing and is more private.
+  An explicitly-requested **enterprise** attestation still emits its full x5c
+  statement, and the `fido-conformance` profile keeps packed self-attestation (its
+  MakeCredential tests cryptographically verify it). `getInfo.attestationFormats`
+  is now `["none","packed"]`. Firmware `bcdDevice` `0x080C` → `0x080D`.
+
 ### Fixed
 
 - **New passkey registration no longer hangs on the touch after a PIN is set.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.3.5] — 2026-07-14
+
 ### Changed
 
 - **`makeCredential` now ships `fmt:"none"` attestation by default**, fixing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,23 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   registering *before* setting a PIN worked). Both now return `PIN_INVALID`.
   Firmware `bcdDevice` `0x080B` → `0x080C`.
 
+### Security
+
+- **A counterfeit FIDO device can no longer inject terminal escapes through the
+  clientPIN retry count.** The wrong-PIN message added above reads the remaining
+  attempts from python-fido2's `get_pin_retries()`, which returns the device's
+  CBOR-encoded value without type-checking it. A hostile authenticator could
+  return that field as a text string of ANSI/OSC/bidi escapes instead of an
+  integer, and `pin_error_message` embedded it into the `error:` line that `die()`
+  prints to the terminal **without** the CLI's `sanitize()` filter — an operator
+  running `rsk fido set-pin`/`list-passkeys` with a wrong PIN against the device
+  would get those escapes interpreted (window-title spoof, OSC-52 clipboard write,
+  Trojan-Source bidi). The retry count is now embedded only when it is really an
+  `int`; anything else falls back to a plain `wrong PIN`. LOW (needs a malicious
+  device + a wrong-PIN attempt); same class as the run-11/12 host-tooling escapes.
+  Found by security-audit run-18. `rsk` `0.3.11` → `0.3.12`; host-only, no firmware
+  change.
+
 ## [0.3.4] — 2026-07-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **New passkey registration no longer hangs on the touch after a PIN is set.**
+  A zero-length `pinUvAuthParam` is the CTAP 2.1 §6.1.2 / §6.2.2 step-1 selection
+  probe: the authenticator takes a device-selection touch and then reports the PIN
+  state through the returned error. With a PIN configured it must return
+  `CTAP2_ERR_PIN_INVALID` (0x31) — the code a platform managing device selection
+  (Chrome) reads to advance from that touch to PIN entry. `makeCredential` and
+  `getAssertion` returned `CTAP2_ERR_PIN_AUTH_INVALID` (0x33) instead, so once a
+  PIN was set a fresh registration showed "press the button" and the press never
+  advanced (the no-PIN `PIN_NOT_SET` code was already correct, which is why
+  registering *before* setting a PIN worked). Both now return `PIN_INVALID`.
+  Firmware `bcdDevice` `0x080B` → `0x080C`.
+
 ## [0.3.4] — 2026-07-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **`rsk` now finds the FIDO HID on Linux hosts where hidapi doesn't report a
+  usage page (issue #28).** `ctaphid.find()` matched a device solely by its HID
+  `usage_page == 0xF1D0`, but some Linux `hidapi` builds (the libusb backend, and
+  older hidraw) enumerate the device with `usage_page` left `0`, so `rsk status`
+  (and every command behind it) reported `FIDO HID : not found` even with the key
+  plugged in. It now keeps the `usage_page` fast path and, when that field is
+  unset, confirms the FIDO usage page straight from each device's report
+  descriptor — VID/PID-agnostic, so it works for every build (the default
+  `0x1209:0x0001` identity and each `VIDPID` preset), unlike hard-coding a single
+  vendor's VID/PID. `rsk` `0.3.9` → `0.3.10`; host-only, no firmware change.
 - **New passkey registration no longer hangs on the touch after a PIN is set.**
   A zero-length `pinUvAuthParam` is the CTAP 2.1 §6.1.2 / §6.2.2 step-1 selection
   probe: the authenticator takes a device-selection touch and then reports the PIN

--- a/crates/rsk-fido/src/conformance/makecredential.rs
+++ b/crates/rsk-fido/src/conformance/makecredential.rs
@@ -9,14 +9,22 @@
 
 use super::{Authr, Resp, assert_ok, field_at, int_map_keys};
 use crate::consts::{
-    AAGUID, ALG_ES256, CTAP_MAKE_CREDENTIAL, FLAG_AT, FLAG_UP, MAX_CRED_ID_LENGTH,
+    AAGUID, ALG_EDDSA, ALG_ES256, CTAP_MAKE_CREDENTIAL, FLAG_AT, FLAG_UP, MAX_CRED_ID_LENGTH,
 };
 use crate::error::CtapError;
-use minicbor::Encoder;
 use minicbor::encode::write::Cursor;
+use minicbor::{Decoder, Encoder};
 use rsk_crypto::sha256;
 
 const RP_ID: &str = "example.com";
+
+/// makeCredential ships `fmt:"none"` by default and `fmt:"packed"` under
+/// `fido-conformance` (the packed self-attestation the conformance tool verifies).
+const ATT_FMT: &str = if cfg!(feature = "fido-conformance") {
+    "packed"
+} else {
+    "none"
+};
 
 /// A minimal single-algorithm makeCredential request over `RP_ID` (keys 1–4:
 /// clientDataHash, rp, user, pubKeyCredParams).
@@ -87,8 +95,8 @@ fn makecred_response_envelope() {
     let mut d = field_at(&r.body, 1).expect("fmt (0x01) present");
     assert_eq!(
         d.str().unwrap(),
-        "packed",
-        "attestation format must be packed"
+        ATT_FMT,
+        "attestation format must match the profile default"
     );
 }
 
@@ -133,23 +141,110 @@ fn makecred_authdata_structure() {
 fn makecred_attestation_statement() {
     let r = make_es256();
     let mut d = field_at(&r.body, 3).expect("attStmt (0x03) present");
-    // Packed self-attestation is exactly {alg, sig} — no x5c chain.
-    assert_eq!(
-        d.map().unwrap().unwrap(),
-        2,
-        "self-attestation attStmt is {{alg, sig}}"
+    if cfg!(feature = "fido-conformance") {
+        // Packed self-attestation is exactly {alg, sig} — no x5c chain.
+        assert_eq!(
+            d.map().unwrap().unwrap(),
+            2,
+            "self-attestation attStmt is {{alg, sig}}"
+        );
+        assert_eq!(d.str().unwrap(), "alg");
+        assert_eq!(
+            d.i64().unwrap(),
+            ALG_ES256,
+            "attStmt alg must match the credential key"
+        );
+        assert_eq!(d.str().unwrap(), "sig");
+        assert!(
+            !d.bytes().unwrap().is_empty(),
+            "attStmt signature must be present"
+        );
+    } else {
+        // Default ships fmt "none" (issue #26): no fragile self-attestation.
+        let mut f = field_at(&r.body, 1).expect("fmt (0x01) present");
+        assert_eq!(f.str().unwrap(), "none");
+        assert_eq!(d.map().unwrap().unwrap(), 0, "default attStmt is empty");
+    }
+}
+
+/// Reproduce GitHub issue #26: OpenSSH 10.0p2 (via libfido2) runs
+/// `fido_cred_verify_self` on the packed EdDSA self-attestation and rejects it with
+/// FIDO_ERR_INVALID_SIG, while ES256 self-attestation from the same device passes.
+/// libfido2 reconstructs the credential public key from the emitted COSE bytes and
+/// verifies the raw-64-byte Ed25519 signature over `authData ‖ clientDataHash`
+/// (PureEdDSA, no pre-hash). Do exactly that here — reconstructing the key from the
+/// wire bytes, NOT from the signing key object — so a sign/COSE mismatch or a
+/// wrong-message bug is caught the way an external verifier catches it.
+#[test]
+fn makecred_ed25519_self_attestation_verifies_independently() {
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+    let r = Authr::fresh().send(CTAP_MAKE_CREDENTIAL, &mc_request(ALG_EDDSA));
+    assert_ok(&r);
+
+    // Default ships fmt "none" precisely so no EdDSA self-attestation is emitted
+    // (this issue-#26 verification only applies to the packed conformance profile).
+    if !cfg!(feature = "fido-conformance") {
+        let mut f = field_at(&r.body, 1).expect("fmt (0x01) present");
+        assert_eq!(f.str().unwrap(), "none");
+        let mut s = field_at(&r.body, 3).expect("attStmt (0x03) present");
+        assert_eq!(s.map().unwrap().unwrap(), 0, "default attStmt is empty");
+        return;
+    }
+
+    let ad = {
+        let mut d = field_at(&r.body, 2).expect("authData (0x02) present");
+        d.bytes().unwrap().to_vec()
+    };
+    // attestedCredentialData: rpIdHash(32)|flags(1)|count(4)|aaguid(16)|credLen(2)|credId|COSEkey
+    let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    let cose = &ad[55 + cred_len..];
+    // OKP credentialPublicKey {1:1, 3:-8, -1:6, -2:<32-byte x>} — pull key -2 the way
+    // libfido2's cbor_decode_eddsa_pubkey does.
+    let mut x = [0u8; 32];
+    {
+        let mut d = Decoder::new(cose);
+        let n = d.map().unwrap().unwrap();
+        for _ in 0..n {
+            let key = d.i8().unwrap();
+            if key == -2 {
+                x.copy_from_slice(d.bytes().unwrap());
+            } else {
+                d.skip().unwrap();
+            }
+        }
+    }
+    let sig_bytes = {
+        let mut d = field_at(&r.body, 3).expect("attStmt (0x03) present");
+        let m = d.map().unwrap().unwrap();
+        let mut sig = Vec::new();
+        for _ in 0..m {
+            let key = d.str().unwrap().to_string();
+            if key == "sig" {
+                sig = d.bytes().unwrap().to_vec();
+            } else {
+                d.skip().unwrap();
+            }
+        }
+        sig
+    };
+
+    // Packed self-attestation signs authData ‖ clientDataHash; mc_request uses 0xCD*32.
+    let mut signed = ad.clone();
+    signed.extend_from_slice(&[0xCD; 32]);
+
+    let vk = VerifyingKey::from_bytes(&x).expect("emitted COSE -2 is a valid Ed25519 point");
+    let sig = Signature::from_slice(&sig_bytes).expect("attStmt sig is 64 bytes");
+    vk.verify(&signed, &sig).expect(
+        "RS-Key Ed25519 self-attestation must verify under the emitted COSE key over \
+         authData‖clientDataHash — exactly what OpenSSH 10.0p2 / libfido2 fido_cred_verify_self does",
     );
-    assert_eq!(d.str().unwrap(), "alg");
-    assert_eq!(
-        d.i64().unwrap(),
-        ALG_ES256,
-        "attStmt alg must match the credential key"
-    );
-    assert_eq!(d.str().unwrap(), "sig");
-    assert!(
-        !d.bytes().unwrap().is_empty(),
-        "attStmt signature must be present"
-    );
+    // Also strict: rejects a non-canonical A/R or a small-order component — so a
+    // stricter external verifier (LibreSSL) cannot reject what this accepts. If both
+    // pass, the on-wire signature is fully spec-clean and any Windows failure is a
+    // transport/webauthn re-serialization issue, not our bytes (GitHub issue #26).
+    vk.verify_strict(&signed, &sig)
+        .expect("RS-Key Ed25519 self-attestation must also pass strict verification");
 }
 
 #[test]
@@ -180,6 +275,15 @@ fn makecred_exclude_list_rejects_existing() {
 #[test]
 fn makecred_attestation_signature_verifies() {
     let r = make_es256();
+    // Default ships fmt "none" (empty attStmt); the packed self-attestation
+    // signature only exists in the conformance profile.
+    if !cfg!(feature = "fido-conformance") {
+        let mut f = field_at(&r.body, 1).expect("fmt (0x01) present");
+        assert_eq!(f.str().unwrap(), "none");
+        let mut s = field_at(&r.body, 3).expect("attStmt (0x03) present");
+        assert_eq!(s.map().unwrap().unwrap(), 0, "default attStmt is empty");
+        return;
+    }
     let ad = {
         let mut d = field_at(&r.body, 2).expect("authData (0x02) present");
         d.bytes().unwrap().to_vec()

--- a/crates/rsk-fido/src/conformance/multialg.rs
+++ b/crates/rsk-fido/src/conformance/multialg.rs
@@ -146,6 +146,19 @@ fn att_stmt(body: &[u8]) -> (i64, Vec<u8>) {
     (alg, d.bytes().unwrap().to_vec())
 }
 
+/// Assert the default-profile makeCredential shape: fmt "none" (field 1) with an
+/// empty attStmt map (field 3).
+fn assert_none_att_stmt(body: &[u8], name: &str) {
+    let mut f = field_at(body, 1).expect("fmt (0x01) present");
+    assert_eq!(f.str().unwrap(), "none", "{name}: default fmt is none");
+    let mut s = field_at(body, 3).expect("attStmt (0x03) present");
+    assert_eq!(
+        s.map().unwrap().unwrap(),
+        0,
+        "{name}: default attStmt is empty"
+    );
+}
+
 /// The assertion signature byte string at key 3 of a getAssertion reply.
 fn assertion_sig(body: &[u8]) -> Vec<u8> {
     let mut d = field_at(body, 3).expect("signature (0x03) present");
@@ -263,20 +276,26 @@ fn create_and_assert(spec: &AlgSpec) {
     );
     let ad = authdata(&mc.body);
     let key = cose_key(spec, &ad);
-    let (att_alg, att_sig) = att_stmt(&mc.body);
-    assert_eq!(
-        att_alg, spec.alg,
-        "{}: attStmt alg must match the credential key",
-        spec.name
-    );
-    // Packed self-attestation signs authData ‖ clientDataHash with the new key.
-    let mut att_signed = ad.clone();
-    att_signed.extend_from_slice(&CDH);
-    assert!(
-        verifies(spec.alg, &key, &att_signed, &att_sig),
-        "{}: packed self-attestation signature must verify",
-        spec.name
-    );
+    // Default ships fmt "none" with an empty attStmt; only the conformance
+    // profile emits (and lets us verify) the packed self-attestation.
+    if cfg!(feature = "fido-conformance") {
+        let (att_alg, att_sig) = att_stmt(&mc.body);
+        assert_eq!(
+            att_alg, spec.alg,
+            "{}: attStmt alg must match the credential key",
+            spec.name
+        );
+        // Packed self-attestation signs authData ‖ clientDataHash with the new key.
+        let mut att_signed = ad.clone();
+        att_signed.extend_from_slice(&CDH);
+        assert!(
+            verifies(spec.alg, &key, &att_signed, &att_sig),
+            "{}: packed self-attestation signature must verify",
+            spec.name
+        );
+    } else {
+        assert_none_att_stmt(&mc.body, spec.name);
+    }
 
     let cred_id = cred_id_of(&ad);
     let ga = a.send(CTAP_GET_ASSERTION, &ga_request(&cred_id));
@@ -330,20 +349,26 @@ fn tampered_authdata_fails_for_every_algorithm() {
     // A verification harness that never rejects would let every positive test
     // pass vacuously. Flipping the UP bit in the signed authData must break the
     // self-attestation for each algorithm, proving the signature binds authData.
+    // Only the conformance profile emits a self-attestation to tamper with; the
+    // default profile has an empty attStmt, so assert that shape instead.
     for spec in [&ES256, &ES384, &ES512, &EDDSA] {
         let mut a = Authr::fresh();
         let mc = a.send(CTAP_MAKE_CREDENTIAL, &mc_request(spec.alg));
         assert_ok(&mc);
         let ad = authdata(&mc.body);
         let key = cose_key(spec, &ad);
-        let (_, att_sig) = att_stmt(&mc.body);
-        let mut tampered = ad.clone();
-        tampered[32] ^= FLAG_UP;
-        tampered.extend_from_slice(&CDH);
-        assert!(
-            !verifies(spec.alg, &key, &tampered, &att_sig),
-            "{}: signature must not verify over mutated authData",
-            spec.name
-        );
+        if cfg!(feature = "fido-conformance") {
+            let (_, att_sig) = att_stmt(&mc.body);
+            let mut tampered = ad.clone();
+            tampered[32] ^= FLAG_UP;
+            tampered.extend_from_slice(&CDH);
+            assert!(
+                !verifies(spec.alg, &key, &tampered, &att_sig),
+                "{}: signature must not verify over mutated authData",
+                spec.name
+            );
+        } else {
+            assert_none_att_stmt(&mc.body, spec.name);
+        }
     }
 }

--- a/crates/rsk-fido/src/conformance/pin.rs
+++ b/crates/rsk-fido/src/conformance/pin.rs
@@ -7,7 +7,7 @@
 //! changePIN. The platform side runs the real pinUvAuthProtocol-2 primitives, so
 //! the exchange is verified end to end.
 
-use super::{Authr, assert_ok_empty, field_at};
+use super::{Authr, assert_ok, assert_ok_empty, field_at};
 use crate::consts::{CTAP_CLIENT_PIN, MAX_PIN_RETRIES};
 use crate::cose::cose_key_ecdh;
 use crate::error::{CTAP2_OK, CtapError};
@@ -129,6 +129,28 @@ impl PinClient {
         buf[..n].to_vec()
     }
 
+    /// getPinUvAuthTokenUsingPinWithPermissions (0x09) request:
+    /// `{1:2, 2:9, 3:keyAgreement, 6:pinHashEnc, 9:permissions, 10:rpId}` — the path
+    /// desktop Chrome takes (an rpId-bound, permission-scoped token).
+    fn get_token_perms(&self, pin: &[u8], permissions: u8, rp: &str) -> Vec<u8> {
+        let h = sha256(pin);
+        let phe = self.enc(&h[..16]);
+        let mut buf = [0u8; 256];
+        let n = {
+            let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+            e.map(6).unwrap();
+            e.u8(1).unwrap().u64(2).unwrap();
+            e.u8(2).unwrap().u64(9).unwrap();
+            e.u8(3).unwrap();
+            cose_key_ecdh(&mut e, &self.x, &self.y).unwrap();
+            e.u8(6).unwrap().bytes(&phe).unwrap();
+            e.u8(9).unwrap().u64(u64::from(permissions)).unwrap();
+            e.u8(10).unwrap().str(rp).unwrap();
+            e.writer().position()
+        };
+        buf[..n].to_vec()
+    }
+
     /// changePIN request: `{1:2, 2:4, 3:keyAgreement, 4:puap, 5:newPinEnc, 6:pinHashEnc}`.
     fn change_pin(&self, old: &[u8], new: &[u8]) -> Vec<u8> {
         let mut padded = [0u8; 64];
@@ -184,6 +206,283 @@ fn authenticator_public(body: &[u8]) -> ([u8; 32], [u8; 32]) {
     let mut y = [0u8; 32];
     y.copy_from_slice(d.bytes().unwrap());
     (x, y)
+}
+
+/// A no-PIN makeCredential over `rp` (up-only, keys 1–4).
+fn mc_nopin(rp: &str) -> Vec<u8> {
+    use crate::consts::ALG_ES256;
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(4).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(rp)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[1, 2, 3, 4]).unwrap();
+        e.str("name").unwrap().str("alice").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A makeCredential over `rp` carrying a pinUvAuthParam (keys 1–4, [7 rk], 8, 9):
+/// the MAC of the clientDataHash under `token` (protocol 2). Models what a browser
+/// sends once a PIN is configured; `rk` requests a discoverable (passkey) credential.
+fn mc_with_pin(rp: &str, token: &[u8; 32], rk: bool) -> Vec<u8> {
+    use crate::consts::ALG_ES256;
+    let cdh = [0xCEu8; 32];
+    let puap = super::pin_auth(token, &cdh);
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(if rk { 7 } else { 6 }).unwrap();
+        e.u8(1).unwrap().bytes(&cdh).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(rp)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[9, 9, 9, 9]).unwrap();
+        e.str("name").unwrap().str("bob").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        if rk {
+            e.u8(7)
+                .unwrap()
+                .map(1)
+                .unwrap()
+                .str("rk")
+                .unwrap()
+                .bool(true)
+                .unwrap();
+        }
+        e.u8(8).unwrap().bytes(&puap).unwrap();
+        e.u8(9).unwrap().u64(2).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A no-PIN discoverable (rk=true) makeCredential over `rp` (keys 1–4, 7).
+fn mc_nopin_rk(rp: &str) -> Vec<u8> {
+    use crate::consts::ALG_ES256;
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(5).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(rp)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[1, 2, 3, 4]).unwrap();
+        e.str("name").unwrap().str("alice").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(7)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("rk")
+            .unwrap()
+            .bool(true)
+            .unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A makeCredential over `rp` carrying a ZERO-LENGTH pinUvAuthParam (key 8 empty,
+/// key 9 protocol): the CTAP 2.1 §6.1.2 step-1 selection probe a platform sends to
+/// get a device-selection touch and learn the PIN state.
+fn mc_probe(rp: &str) -> Vec<u8> {
+    use crate::consts::ALG_ES256;
+    let mut buf = [0u8; 256];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(6).unwrap();
+        e.u8(1).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(2)
+            .unwrap()
+            .map(1)
+            .unwrap()
+            .str("id")
+            .unwrap()
+            .str(rp)
+            .unwrap();
+        e.u8(3).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&[1, 2, 3, 4]).unwrap();
+        e.str("name").unwrap().str("alice").unwrap();
+        e.u8(4).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("alg").unwrap().i64(ALG_ES256).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(8).unwrap().bytes(&[]).unwrap();
+        e.u8(9).unwrap().u64(2).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// A getAssertion over `rp` carrying a ZERO-LENGTH pinUvAuthParam (key 6 empty,
+/// key 7 protocol): the CTAP 2.1 §6.2.2 step-1 selection probe.
+fn ga_probe(rp: &str) -> Vec<u8> {
+    let mut buf = [0u8; 128];
+    let n = {
+        let mut e = Encoder::new(Cursor::new(&mut buf[..]));
+        e.map(4).unwrap();
+        e.u8(1).unwrap().str(rp).unwrap();
+        e.u8(2).unwrap().bytes(&[0xCD; 32]).unwrap();
+        e.u8(6).unwrap().bytes(&[]).unwrap();
+        e.u8(7).unwrap().u64(2).unwrap();
+        e.writer().position()
+    };
+    buf[..n].to_vec()
+}
+
+/// CTAP 2.1 §6.1.2 step 1 / §6.2.2 step 1: a zero-length pinUvAuthParam takes a
+/// device-selection touch, then reports the PIN state via the returned error — and
+/// with a PIN configured that MUST be CTAP2_ERR_PIN_INVALID (0x31), not
+/// PIN_AUTH_INVALID. Platforms managing device selection (Chrome) advance from the
+/// selection touch to PIN entry off exactly this code; the wrong code leaves the
+/// ceremony stuck on the touch. This is the field report: after a PIN is set, a new
+/// registration shows "press the button" and the press never advances.
+#[test]
+fn zero_length_pinuvauthparam_probe_reports_pin_invalid() {
+    let mut a = Authr::fresh();
+    let pc = PinClient::establish(&mut a);
+    assert_ok_empty(&a.send(CTAP_CLIENT_PIN, &pc.set_pin(PIN)));
+
+    let r = a.send(
+        crate::consts::CTAP_MAKE_CREDENTIAL,
+        &mc_probe("example.com"),
+    );
+    assert_eq!(
+        r.status,
+        CtapError::PinInvalid.as_u8(),
+        "makeCredential zero-length pinUvAuthParam with a PIN set must be PIN_INVALID (0x31), got 0x{:02x}",
+        r.status
+    );
+
+    let r = a.send(crate::consts::CTAP_GET_ASSERTION, &ga_probe("example.com"));
+    assert_eq!(
+        r.status,
+        CtapError::PinInvalid.as_u8(),
+        "getAssertion zero-length pinUvAuthParam with a PIN set must be PIN_INVALID (0x31), got 0x{:02x}",
+        r.status
+    );
+}
+
+/// The no-PIN counterpart is already correct and must stay CTAP2_ERR_PIN_NOT_SET
+/// (0x35) — the code Chrome reads as "no PIN, proceed user-presence-only", which is
+/// why step 3 (register before setting a PIN) works.
+#[test]
+fn zero_length_pinuvauthparam_probe_no_pin_reports_pin_not_set() {
+    let mut a = Authr::fresh();
+    let r = a.send(
+        crate::consts::CTAP_MAKE_CREDENTIAL,
+        &mc_probe("example.com"),
+    );
+    assert_eq!(
+        r.status,
+        CtapError::PinNotSet.as_u8(),
+        "no-PIN probe must be PIN_NOT_SET (0x35), got 0x{:02x}",
+        r.status
+    );
+}
+
+/// Field report: no-PIN device registers/logs in fine, user then sets a PIN, and a
+/// subsequent registration ("create another account") hangs on the touch. Drive
+/// the exact sequence: up-only makeCredential (register), setPIN, obtain a UV
+/// token (browser), then makeCredential with that token — it must reach the
+/// presence check and succeed (AlwaysConfirm stands in for the touch).
+#[test]
+fn makecred_after_setpin_still_registers() {
+    use crate::consts::CTAP_MAKE_CREDENTIAL;
+    let mut a = Authr::fresh();
+
+    // Step 3: register on a no-PIN device (up-only).
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_nopin("example.com")));
+
+    // Step 5: set a PIN.
+    let pc = PinClient::establish(&mut a);
+    assert_ok_empty(&a.send(CTAP_CLIENT_PIN, &pc.set_pin(PIN)));
+
+    // The browser obtains a UV token (legacy getPinToken → mc|ga permissions).
+    let r = a.send(CTAP_CLIENT_PIN, &pc.get_token(PIN));
+    assert_eq!(r.status, CTAP2_OK, "getPinToken with the correct PIN");
+    let token = pc.decrypt_token(&r.body);
+
+    // Step 6/7: create another account, now PIN-gated. Must succeed.
+    let r = a.send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_with_pin("other.example", &token, false),
+    );
+    assert_eq!(
+        r.status, CTAP2_OK,
+        "makeCredential after setPIN must succeed, got status 0x{:02x}",
+        r.status
+    );
+}
+
+/// The realistic desktop-Chrome passkey path: discoverable (rk=true) credentials
+/// throughout, and the PIN-gated registration uses an rpId-bound, mc-scoped token
+/// from getPinUvAuthTokenUsingPinWithPermissions (0x09) — the exact shape Chrome
+/// sends. Reproduces the field report end to end.
+#[test]
+fn makecred_passkey_after_setpin_perms_token() {
+    use crate::consts::CTAP_MAKE_CREDENTIAL;
+    use crate::state::PERM_MC;
+    let mut a = Authr::fresh();
+
+    // Step 3: register a passkey on a no-PIN device (up-only, discoverable).
+    assert_ok(&a.send(CTAP_MAKE_CREDENTIAL, &mc_nopin_rk("example.com")));
+
+    // Step 5: set a PIN.
+    let pc = PinClient::establish(&mut a);
+    assert_ok_empty(&a.send(CTAP_CLIENT_PIN, &pc.set_pin(PIN)));
+
+    // Chrome obtains an rpId-bound, mc-scoped token for the NEW account's RP.
+    let r = a.send(
+        CTAP_CLIENT_PIN,
+        &pc.get_token_perms(PIN, PERM_MC, "other.example"),
+    );
+    assert_eq!(
+        r.status, CTAP2_OK,
+        "getPinUvAuthTokenUsingPinWithPermissions"
+    );
+    let token = pc.decrypt_token(&r.body);
+
+    // Step 6/7: create another passkey, PIN-gated, token bound to its RP. Must succeed.
+    let r = a.send(
+        CTAP_MAKE_CREDENTIAL,
+        &mc_with_pin("other.example", &token, true),
+    );
+    assert_eq!(
+        r.status, CTAP2_OK,
+        "PIN-gated passkey registration must succeed, got status 0x{:02x}",
+        r.status
+    );
 }
 
 #[test]

--- a/crates/rsk-fido/src/getassertion.rs
+++ b/crates/rsk-fido/src/getassertion.rs
@@ -322,11 +322,13 @@ fn enforce_pin<S: Storage, R: Rng>(
 ) -> Result<bool, CtapError> {
     match req.pin_uv_auth_param {
         // Zero-length probe (selection gesture): touch, then report PIN state.
-        // With no button configured this confirms instantly.
+        // With no button configured this confirms instantly. CTAP 2.1 §6.2.2 step 1
+        // (mirrors makeCredential): PIN set → PIN_INVALID, unset → PIN_NOT_SET — the
+        // code a selection-managing platform reads to move on to PIN entry.
         Some(&[]) => {
             ctx.require_presence(crate::Confirm::titled("Use this key?"))?;
             Err(if ctx.fs.has_data(EF_PIN) {
-                CtapError::PinAuthInvalid
+                CtapError::PinInvalid
             } else {
                 CtapError::PinNotSet
             })

--- a/crates/rsk-fido/src/getassertion_tests.rs
+++ b/crates/rsk-fido/src/getassertion_tests.rs
@@ -24,6 +24,14 @@ impl Rng for SeqRng {
 
 const CDH: [u8; 32] = [0xCD; 32];
 
+// makeCredential ships `fmt:"none"` by default and `fmt:"packed"` under
+// `fido-conformance` (or for an enterprise attestation).
+const ATT_FMT: &str = if cfg!(feature = "fido-conformance") {
+    "packed"
+} else {
+    "none"
+};
+
 fn dev() -> Device<'static> {
     Device {
         serial_hash: &[0xAB; 32],
@@ -73,7 +81,7 @@ fn parse_mc(resp: &[u8]) -> (std::vec::Vec<u8>, [u8; 32], [u8; 32]) {
     // 3 base fields; a largeBlobKey credential adds field 0x05 (read 1 & 2 only).
     assert!(d.map().unwrap().unwrap() >= 3);
     assert_eq!(d.u8().unwrap(), 1);
-    assert_eq!(d.str().unwrap(), "packed");
+    assert_eq!(d.str().unwrap(), ATT_FMT);
     assert_eq!(d.u8().unwrap(), 2);
     let ad = d.bytes().unwrap();
     let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
@@ -1850,7 +1858,7 @@ fn parse_mc_ec2(resp: &[u8]) -> (std::vec::Vec<u8>, std::vec::Vec<u8>, std::vec:
     let mut d = Decoder::new(resp);
     assert!(d.map().unwrap().unwrap() >= 3);
     assert_eq!(d.u8().unwrap(), 1);
-    assert_eq!(d.str().unwrap(), "packed");
+    assert_eq!(d.str().unwrap(), ATT_FMT);
     assert_eq!(d.u8().unwrap(), 2);
     let ad = d.bytes().unwrap();
     let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
@@ -1944,7 +1952,7 @@ fn parse_mc_okp(resp: &[u8]) -> (std::vec::Vec<u8>, [u8; 32]) {
     let mut d = Decoder::new(resp);
     assert!(d.map().unwrap().unwrap() >= 3);
     assert_eq!(d.u8().unwrap(), 1);
-    assert_eq!(d.str().unwrap(), "packed");
+    assert_eq!(d.str().unwrap(), ATT_FMT);
     assert_eq!(d.u8().unwrap(), 2);
     let ad = d.bytes().unwrap();
     let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
@@ -2058,7 +2066,7 @@ fn parse_mc_akp(resp: &[u8]) -> (std::vec::Vec<u8>, i64, std::vec::Vec<u8>) {
     let mut d = Decoder::new(resp);
     assert!(d.map().unwrap().unwrap() >= 3);
     assert_eq!(d.u8().unwrap(), 1);
-    assert_eq!(d.str().unwrap(), "packed");
+    assert_eq!(d.str().unwrap(), ATT_FMT);
     assert_eq!(d.u8().unwrap(), 2);
     let ad = d.bytes().unwrap();
     let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
@@ -2100,6 +2108,29 @@ fn mc_att(resp: &[u8]) -> (i64, std::vec::Vec<u8>, std::vec::Vec<u8>) {
     (alg, sig, ad)
 }
 
+// Assert the default-profile makeCredential shape: fmt "none" (field 1) with an
+// empty attStmt map (field 3).
+fn assert_none_att_stmt(resp: &[u8]) {
+    let mut d = Decoder::new(resp);
+    let fields = d.map().unwrap().unwrap();
+    let mut saw_fmt = false;
+    let mut saw_empty_stmt = false;
+    for _ in 0..fields {
+        match d.u8().unwrap() {
+            1 => {
+                assert_eq!(d.str().unwrap(), "none");
+                saw_fmt = true;
+            }
+            3 => {
+                assert_eq!(d.map().unwrap().unwrap(), 0, "default attStmt is empty");
+                saw_empty_stmt = true;
+            }
+            _ => d.skip().unwrap(),
+        }
+    }
+    assert!(saw_fmt && saw_empty_stmt);
+}
+
 fn mldsa_verify(pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
     let pk: [u8; rsk_crypto::MLDSA44_PK_LEN] = pk.try_into().expect("AKP pk length");
     let sig: [u8; rsk_crypto::MLDSA44_SIG_LEN] = sig.try_into().expect("ML-DSA sig length");
@@ -2119,14 +2150,20 @@ fn mldsa44_register_then_login_verifies() {
     let (cred_id, alg, pk) = parse_mc_akp(&mc);
     assert_eq!(alg, ALG_MLDSA44);
     assert_eq!(pk.len(), rsk_crypto::MLDSA44_PK_LEN);
-    let (att_alg, att_sig, ad) = mc_att(&mc);
-    assert_eq!(att_alg, ALG_MLDSA44);
-    let mut signed = ad;
-    signed.extend_from_slice(&CDH);
-    assert!(
-        mldsa_verify(&pk, &signed, &att_sig),
-        "ML-DSA-44 self-attestation verifies"
-    );
+    // Default ships fmt "none" with an empty attStmt; only the conformance
+    // profile emits (and lets us verify) the packed self-attestation.
+    if cfg!(feature = "fido-conformance") {
+        let (att_alg, att_sig, ad) = mc_att(&mc);
+        assert_eq!(att_alg, ALG_MLDSA44);
+        let mut signed = ad;
+        signed.extend_from_slice(&CDH);
+        assert!(
+            mldsa_verify(&pk, &signed, &att_sig),
+            "ML-DSA-44 self-attestation verifies"
+        );
+    } else {
+        assert_none_att_stmt(&mc);
+    }
 
     // Login with the returned credential id; the assertion signature must
     // verify under the same key.
@@ -2164,14 +2201,20 @@ fn mldsa65_register_then_login_verifies() {
     let (cred_id, alg, pk) = parse_mc_akp(&mc);
     assert_eq!(alg, ALG_MLDSA65);
     assert_eq!(pk.len(), rsk_crypto::MLDSA65_PK_LEN);
-    let (att_alg, att_sig, ad) = mc_att(&mc);
-    assert_eq!(att_alg, ALG_MLDSA65);
-    let mut signed = ad;
-    signed.extend_from_slice(&CDH);
-    assert!(
-        mldsa65_verify(&pk, &signed, &att_sig),
-        "ML-DSA-65 self-attestation verifies"
-    );
+    // Default ships fmt "none" with an empty attStmt; only the conformance
+    // profile emits (and lets us verify) the packed self-attestation.
+    if cfg!(feature = "fido-conformance") {
+        let (att_alg, att_sig, ad) = mc_att(&mc);
+        assert_eq!(att_alg, ALG_MLDSA65);
+        let mut signed = ad;
+        signed.extend_from_slice(&CDH);
+        assert!(
+            mldsa65_verify(&pk, &signed, &att_sig),
+            "ML-DSA-65 self-attestation verifies"
+        );
+    } else {
+        assert_none_att_stmt(&mc);
+    }
 
     // Login with the returned credential id; the assertion signature must
     // verify under the same key.

--- a/crates/rsk-fido/src/getinfo.rs
+++ b/crates/rsk-fido/src/getinfo.rs
@@ -215,7 +215,15 @@ fn write_info<W: Write>(
     // slots (capacity minus the occupied EF_CRED slots), supplied by the caller.
     enc.u8(0x14)?.u16(remaining_rk)?;
 
-    // 0x16 attestationFormats — the attestation statement formats we emit.
+    // 0x16 attestationFormats — the attestation statement formats we emit. Default
+    // ships "none" (makeCredential self-attestation conveys no trust beyond it and a
+    // packed EdDSA self-attestation breaks Windows/OpenSSH `ed25519-sk` enroll —
+    // issue #26) and still emits "packed" for an enterprise attestation; the
+    // fido-conformance profile emits packed self-attestation (its MakeCredential
+    // tests verify it). Keep in sync with the metadata statements.
+    #[cfg(not(feature = "fido-conformance"))]
+    enc.u8(0x16)?.array(2)?.str("none")?.str("packed")?;
+    #[cfg(feature = "fido-conformance")]
     enc.u8(0x16)?.array(1)?.str("packed")?;
 
     // 0x1D maxPINLength — max PIN length in Unicode code points. The PIN is padded

--- a/crates/rsk-fido/src/getinfo_tests.rs
+++ b/crates/rsk-fido/src/getinfo_tests.rs
@@ -203,10 +203,17 @@ fn get_info_fields() {
     assert_eq!(d.u8().unwrap(), 0x14);
     assert_eq!(d.u16().unwrap(), 200);
 
-    // 0x16 attestationFormats ["packed"]
+    // 0x16 attestationFormats: default ["none", "packed"], `fido-conformance`
+    // ["packed"] (it emits packed self-attestation).
     assert_eq!(d.u8().unwrap(), 0x16);
-    assert_eq!(d.array().unwrap().unwrap(), 1);
-    assert_eq!(d.str().unwrap(), "packed");
+    if cfg!(feature = "fido-conformance") {
+        assert_eq!(d.array().unwrap().unwrap(), 1);
+        assert_eq!(d.str().unwrap(), "packed");
+    } else {
+        assert_eq!(d.array().unwrap().unwrap(), 2);
+        assert_eq!(d.str().unwrap(), "none");
+        assert_eq!(d.str().unwrap(), "packed");
+    }
 
     // 0x1D maxPINLength
     assert_eq!(d.u8().unwrap(), 0x1D);

--- a/crates/rsk-fido/src/makecredential.rs
+++ b/crates/rsk-fido/src/makecredential.rs
@@ -420,11 +420,14 @@ fn enforce_pin<S: Storage, R: Rng>(
     let pin_set = ctx.fs.has_data(EF_PIN);
     match req.pin_uv_auth_param {
         // Zero-length probe: a selection gesture — wait for a touch, then report
-        // the PIN state. With no button configured this confirms instantly.
+        // the PIN state. With no button configured this confirms instantly. CTAP 2.1
+        // §6.1.2 step 1 fixes the codes: PIN set → PIN_INVALID, unset → PIN_NOT_SET.
+        // A platform managing device selection (e.g. Chrome) advances from this
+        // touch to PIN entry off PIN_INVALID; PIN_AUTH_INVALID strands the ceremony.
         Some(&[]) => {
             ctx.require_presence(crate::Confirm::titled("Use this key?"))?;
             Err(if pin_set {
-                CtapError::PinAuthInvalid
+                CtapError::PinInvalid
             } else {
                 CtapError::PinNotSet
             })

--- a/crates/rsk-fido/src/makecredential.rs
+++ b/crates/rsk-fido/src/makecredential.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 RS-Key contributors
 
-//! `authenticatorMakeCredential`: packed **self-attestation** (no x5c) by
-//! default. Resident keys (rk) are stored; non-resident credentials carry the
-//! full box in authData. A configured PIN requires a verified `pinUvAuthParam`
+//! `authenticatorMakeCredential`: ships `fmt:"none"` by default — self-attestation
+//! conveys no trust beyond "none" (WebAuthn §6.5.2) and a packed EdDSA self-
+//! attestation is mishandled by the Windows WebAuthn API, breaking `ed25519-sk`
+//! enrollment on OpenSSH 10 (issue #26). The `fido-conformance` profile emits
+//! packed **self-attestation** (no x5c) so the conformance tool can verify it.
+//! Resident keys (rk) are stored; non-resident credentials carry the full box in
+//! authData. A configured PIN requires a verified `pinUvAuthParam`
 //! ([`enforce_pin`]), which sets the `uv` flag. Request extensions are sealed
 //! into the box and echoed in the authData extension output (ED flag);
 //! excludeList is credProtect-aware. Enterprise attestation (request field
@@ -586,10 +590,7 @@ fn make_credential_inner<S: Storage, R: Rng>(
     p += ext_len;
     let ad_len = p;
 
-    // Attestation over authData ‖ clientDataHash. Self-attestation (the default)
-    // signs with the credential key; enterprise level 2 produces a full ("basic")
-    // attestation signed by the device key, carrying its x5c cert and the `ep`
-    // response flag.
+    // Attestation over authData ‖ clientDataHash.
     ad[ad_len..ad_len + 32].copy_from_slice(req.client_data_hash);
     // `ea_performed` — platform-managed (type 2), or vendor-facilitated (type 1)
     // for an RP on the built-in enterprise list (empty in shipping firmware) —
@@ -599,16 +600,28 @@ fn make_credential_inner<S: Storage, R: Rng>(
     let ea_performed = req.enterprise_attestation == 2
         || (req.enterprise_attestation == 1 && rp_eligible_for_vendor_ea(req.rp_id));
     let full_attestation = req.enterprise_attestation > 0;
+    // Ship `fmt:"none"` by default: self-attestation conveys no trust beyond "none"
+    // (WebAuthn §6.5.2), and a packed EdDSA self-attestation is mishandled by the
+    // Windows WebAuthn API — it fails OpenSSH 10.0's fido_cred_verify_self and breaks
+    // `ssh-keygen -t ed25519-sk` enrollment (issue #26). An explicitly-requested
+    // enterprise attestation still emits its full x5c statement; the `fido-conformance`
+    // profile keeps packed self-attestation (the conformance MakeCredential tests
+    // cryptographically verify it).
+    let none_attestation = !full_attestation && cfg!(not(feature = "fido-conformance"));
     let mut att = AttBufs::new();
-    let (att_alg, sig_len, chain_len, certs) = make_attestation(
-        ctx,
-        seed,
-        &key,
-        &ad[..ad_len + 32],
-        ea_performed,
-        full_attestation,
-        &mut att,
-    )?;
+    let (att_alg, sig_len, chain_len, certs) = if none_attestation {
+        (0, 0, 0, 0)
+    } else {
+        make_attestation(
+            ctx,
+            seed,
+            &key,
+            &ad[..ad_len + 32],
+            ea_performed,
+            full_attestation,
+            &mut att,
+        )?
+    };
 
     // largeBlobKey response field (0x05) — resident credentials only.
     let large_blob_key = if req.ext_large_blob_key == Some(true) && req.rk {
@@ -617,25 +630,36 @@ fn make_credential_inner<S: Storage, R: Rng>(
         None
     };
 
-    // Response: { 1: "packed", 2: authData, 3: attStmt [, 4: ep] [, 5: largeBlobKey] }.
-    // attStmt = { alg, sig } for self-attestation, + x5c for any basic_full /
-    // enterprise attestation. `ep` (field 4) only when EA was actually performed.
+    // Response: { 1: fmt, 2: authData, 3: attStmt [, 4: ep] [, 5: largeBlobKey] }.
+    // Default: fmt "none" with an empty attStmt. Otherwise fmt "packed": attStmt
+    // = { alg, sig } for self-attestation, + x5c for any basic_full / enterprise
+    // attestation. `ep` (field 4) only when EA was actually performed.
     let resp_len = {
         let mut enc = Encoder::new(Cursor::new(&mut *out));
         enc.map(3 + u64::from(ea_performed) + u64::from(large_blob_key.is_some()))
-            .and_then(|e| e.u8(1)?.str("packed"))
+            .and_then(|e| {
+                e.u8(1)?
+                    .str(if none_attestation { "none" } else { "packed" })
+            })
             .and_then(|e| e.u8(2)?.bytes(&ad[..ad_len]))
-            .and_then(|e| e.u8(3)?.map(2 + u64::from(full_attestation)))
-            .and_then(|e| e.str("alg")?.i64(att_alg))
-            .and_then(|e| e.str("sig")?.bytes(&att.sig[..sig_len]))
+            .and_then(|e| e.u8(3))
             .map_err(|_| CtapError::Other)?;
-        if full_attestation {
-            enc.str("x5c")
-                .and_then(|e| e.array(u64::from(certs)))
+        if none_attestation {
+            enc.map(0).map_err(|_| CtapError::Other)?;
+        } else {
+            enc.map(2 + u64::from(full_attestation))
+                .and_then(|e| e.str("alg")?.i64(att_alg))
+                .and_then(|e| e.str("sig")?.bytes(&att.sig[..sig_len]))
                 .map_err(|_| CtapError::Other)?;
-            for i in 0..certs {
-                let c = cert::att_chain_cert(&att.chain[..chain_len], i).ok_or(CtapError::Other)?;
-                enc.bytes(c).map_err(|_| CtapError::Other)?;
+            if full_attestation {
+                enc.str("x5c")
+                    .and_then(|e| e.array(u64::from(certs)))
+                    .map_err(|_| CtapError::Other)?;
+                for i in 0..certs {
+                    let c =
+                        cert::att_chain_cert(&att.chain[..chain_len], i).ok_or(CtapError::Other)?;
+                    enc.bytes(c).map_err(|_| CtapError::Other)?;
+                }
             }
         }
         if ea_performed {

--- a/crates/rsk-fido/src/makecredential_tests.rs
+++ b/crates/rsk-fido/src/makecredential_tests.rs
@@ -20,6 +20,14 @@ impl Rng for SeqRng {
     }
 }
 
+// makeCredential ships `fmt:"none"` by default and `fmt:"packed"` under
+// `fido-conformance` (or for an enterprise attestation).
+const ATT_FMT: &str = if cfg!(feature = "fido-conformance") {
+    "packed"
+} else {
+    "none"
+};
+
 fn build_request(rk: bool) -> std::vec::Vec<u8> {
     let mut buf = [0u8; 512];
     let n = {
@@ -297,27 +305,37 @@ fn makecred_cancel_maps_keepalive_cancel() {
     );
 }
 
-// Parse the response, pull out authData + sig, and check the attestation
-// signature verifies under the credential public key embedded in authData.
+// Parse the response and pull out authData. Under `fido-conformance` the
+// attStmt is the packed self-attestation `{alg, sig}`, whose signature is
+// checked against the credential public key embedded in authData; by default
+// the attStmt is empty (fmt "none"), so only that shape is asserted (guarding
+// the issue #26 regression — no fragile EdDSA self-attestation).
 fn verify_response(resp: &[u8], client_data_hash: &[u8; 32]) -> std::vec::Vec<u8> {
     let mut d = Decoder::new(resp);
     // 3 base fields ({1,2,3}); a largeBlobKey credential adds field 0x05.
     assert!(d.map().unwrap().unwrap() >= 3);
     assert_eq!(d.u8().unwrap(), 1);
-    assert_eq!(d.str().unwrap(), "packed");
+    assert_eq!(d.str().unwrap(), ATT_FMT);
     assert_eq!(d.u8().unwrap(), 2);
     let auth_data = d.bytes().unwrap().to_vec();
     assert_eq!(d.u8().unwrap(), 3);
+
+    // authData layout: rpIdHash(32) flags(1) ctr(4) aaguid(16) credLen(2) credId COSEkey
+    assert_eq!(&auth_data[..32], &sha256(b"example.com")[..]);
+    // AT + UP always set; UV may also be set when a pinUvAuthParam was verified.
+    assert_eq!(auth_data[32] & (FLAG_AT | FLAG_UP), FLAG_AT | FLAG_UP);
+
+    if !cfg!(feature = "fido-conformance") {
+        assert_eq!(d.map().unwrap().unwrap(), 0, "default attStmt is empty");
+        return auth_data;
+    }
+
     assert_eq!(d.map().unwrap().unwrap(), 2);
     assert_eq!(d.str().unwrap(), "alg");
     assert_eq!(d.i64().unwrap(), ALG_ES256);
     assert_eq!(d.str().unwrap(), "sig");
     let sig = d.bytes().unwrap().to_vec();
 
-    // authData layout: rpIdHash(32) flags(1) ctr(4) aaguid(16) credLen(2) credId COSEkey
-    assert_eq!(&auth_data[..32], &sha256(b"example.com")[..]);
-    // AT + UP always set; UV may also be set when a pinUvAuthParam was verified.
-    assert_eq!(auth_data[32] & (FLAG_AT | FLAG_UP), FLAG_AT | FLAG_UP);
     let cred_len = u16::from_be_bytes([auth_data[37 + 16], auth_data[38 + 16]]) as usize;
     let cose_off = 39 + 16 + cred_len;
 
@@ -1067,7 +1085,9 @@ fn make_credential_bad_pin_auth_rejected() {
 
 // ---- PQC algorithm selection ----
 
-// makeCredential with a multi-entry pubKeyCredParams; returns the attStmt alg.
+// makeCredential with a multi-entry pubKeyCredParams; returns the alg of the
+// credential key selected (COSE label 3 in authData — present in both profiles,
+// unlike the attStmt alg which the default "none" fmt omits).
 fn selected_alg(algs: &[i64]) -> Result<i64, CtapError> {
     let mut buf = [0u8; 512];
     let n = {
@@ -1108,17 +1128,28 @@ fn selected_alg(algs: &[i64]) -> Result<i64, CtapError> {
     };
     let len = make_credential(&mut ctx, &buf[..n], &mut out)?;
 
+    // Pull authData (field 2), then read the COSE key alg (label 3) from it.
     let mut d = Decoder::new(&out[..len]);
     let fields = d.map().unwrap().unwrap();
+    let mut ad = None;
     for _ in 0..fields {
-        if d.u8().unwrap() == 3 {
-            d.map().unwrap();
-            assert_eq!(d.str().unwrap(), "alg");
-            return Ok(d.i64().unwrap());
+        if d.u8().unwrap() == 2 {
+            ad = Some(d.bytes().unwrap().to_vec());
+        } else {
+            d.skip().unwrap();
         }
-        d.skip().unwrap();
     }
-    panic!("attStmt missing");
+    let ad = ad.expect("authData present");
+    let cred_len = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    let mut cd = Decoder::new(&ad[55 + cred_len..]);
+    let entries = cd.map().unwrap().unwrap();
+    for _ in 0..entries {
+        if cd.i64().unwrap() == 3 {
+            return Ok(cd.i64().unwrap());
+        }
+        cd.skip().unwrap();
+    }
+    panic!("COSE key alg (label 3) missing");
 }
 
 #[test]

--- a/docs/guides/attestation.md
+++ b/docs/guides/attestation.md
@@ -1,9 +1,12 @@
 # Enterprise attestation (org provisioning)
 
-Out of the box ordinary `makeCredential` stays packed self-attestation with no
-certificate at all. RS-Key does carry a per-device self-signed certificate
-(a P-256 X.509 leaf with CN `RSK FIDO2`, built over the seed at first boot), but
-it presents that only on U2F registration and EA-level-2 requests. An
+Out of the box ordinary `makeCredential` returns `fmt:"none"` attestation (self-
+attestation conveys no trust beyond "none" per WebAuthn §6.5.2, and a packed EdDSA
+self-attestation breaks `ed25519-sk` enrollment on Windows / OpenSSH 10 — issue
+#26; the `fido-conformance` build keeps packed self-attestation for the conformance
+suite). RS-Key does carry a per-device self-signed certificate (a P-256 X.509 leaf
+with CN `RSK FIDO2`, built over the seed at first boot), but it presents that only
+on U2F registration and EA-level-2 requests. An
 organization can replace that device cert with its **own attestation key and
 certificate chain**, so its relying parties can verify "this credential was
 created on one of *our* keys" — the CTAP 2.1 enterprise-attestation (EA) feature.
@@ -77,8 +80,8 @@ rsk fido attestation clear [--pin …]
 - **U2F / CTAP1 registration** attests with the chain's **leaf** instead of the
   self-signed device cert (classic batch attestation — a U2F response carries
   exactly one certificate, so only the leaf travels).
-- **Ordinary makeCredential is untouched** — packed self-attestation, no chain,
-  no cross-site trackable identifier. EA fires only when the platform sets the
+- **Ordinary makeCredential is untouched** — `fmt:"none"`, no chain, no cross-site
+  trackable identifier. EA fires only when the platform sets the
   `enterpriseAttestation` request field *and* `enableEnterpriseAttestation` is
   on (below).
 
@@ -89,7 +92,7 @@ spec:
 
 | EA level | Without org key | With org key |
 |---|---|---|
-| (absent / 0) | self-attestation | self-attestation |
+| (absent / 0) | none | none |
 | 1 — vendor-facilitated | self-attestation | full org attestation |
 | 2 — platform-managed | full attestation by the **device key** + self-signed `RSK FIDO2` cert | full org attestation |
 
@@ -168,7 +171,7 @@ and chain is the explicit, gated `attestation clear` — nothing else clears the
 A shared org chain makes credentials linkable *to the organization* across its
 relying parties — that is the entire point of EA, and why the spec gates it
 behind both an explicit per-request field and a device-wide enable. Ordinary
-(non-EA) makeCredential stays self-attested and unlinkable; the org chain is
+(non-EA) makeCredential returns `fmt:"none"` and is unlinkable; the org chain is
 served only on explicit EA requests.
 
 ## Troubleshooting

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x080B;
+    let device_release: u16 = 0x080C;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -380,7 +380,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x080C;
+    let device_release: u16 = 0x080D;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/metadata/rs-key.metadata.json
+++ b/metadata/rs-key.metadata.json
@@ -91,7 +91,7 @@
     "transports": ["usb"],
     "maxRPIDsForSetMinPINLength": 8,
     "remainingDiscoverableCredentials": 256,
-    "attestationFormats": ["packed"],
+    "attestationFormats": ["none", "packed"],
     "maxPINLength": 63,
     "authenticatorConfigCommands": [1, 2, 3]
   }

--- a/tests/00_ctaphid_transport.py
+++ b/tests/00_ctaphid_transport.py
@@ -17,14 +17,35 @@ except ImportError:
     sys.exit("missing dependency: pip install hidapi")
 
 FIDO_USAGE_PAGE = 0xF1D0
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"  # Usage Page (0xF1D0) item in a HID report descriptor
 REPORT_LEN = 64
 
 
 def find():
-    for d in hid.enumerate():
+    devices = hid.enumerate()
+    for d in devices:
         if d.get("usage_page") == FIDO_USAGE_PAGE:
             return d
+    # hidapi may leave usage_page unset on Linux (libusb/older hidraw); confirm the
+    # FIDO usage page from the report descriptor instead (mirrors tools/rsk/ctaphid.py).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
+            return d
     return None
+
+
+def _declares_fido(path):
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write(dev, payload):

--- a/tests/01_flash_persistence.py
+++ b/tests/01_flash_persistence.py
@@ -20,6 +20,7 @@ except ImportError:
     sys.exit("missing dependency: pip install hidapi")
 
 FIDO_USAGE_PAGE = 0xF1D0
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"  # Usage Page (0xF1D0) item in a HID report descriptor
 REPORT_LEN = 64
 CTAPHID_MSG = 0x83
 CTAPHID_ERROR = 0xBF
@@ -32,10 +33,30 @@ SW_OK = b"\x90\x00"
 
 
 def find():
-    for d in hid.enumerate():
+    devices = hid.enumerate()
+    for d in devices:
         if d.get("usage_page") == FIDO_USAGE_PAGE:
             return d
+    # hidapi may leave usage_page unset on Linux (libusb/older hidraw); confirm the
+    # FIDO usage page from the report descriptor instead (mirrors tools/rsk/ctaphid.py).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
+            return d
     return None
+
+
+def _declares_fido(path):
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write_frame(dev, payload):

--- a/tests/10_fido_getinfo.py
+++ b/tests/10_fido_getinfo.py
@@ -18,6 +18,7 @@ except ImportError:
     sys.exit("missing dependency: pip install hidapi")
 
 FIDO_USAGE_PAGE = 0xF1D0
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"  # Usage Page (0xF1D0) item in a HID report descriptor
 REPORT_LEN = 64
 CTAPHID_INIT = 0x86
 CTAPHID_CBOR = 0x90
@@ -32,10 +33,30 @@ FIRMWARE_VERSION = 0x050704
 
 
 def find():
-    for d in hid.enumerate():
+    devices = hid.enumerate()
+    for d in devices:
         if d.get("usage_page") == FIDO_USAGE_PAGE:
             return d
+    # hidapi may leave usage_page unset on Linux (libusb/older hidraw); confirm the
+    # FIDO usage page from the report descriptor instead (mirrors tools/rsk/ctaphid.py).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
+            return d
     return None
+
+
+def _declares_fido(path):
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write(dev, payload):

--- a/tests/11_fido_makecredential.py
+++ b/tests/11_fido_makecredential.py
@@ -103,11 +103,34 @@ def decode(b):
     return v
 
 
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"  # Usage Page (0xF1D0) item in a HID report descriptor
+
+
 def find(dev_list_fn=hid.enumerate):
-    for d in dev_list_fn():
+    devices = dev_list_fn()
+    for d in devices:
         if d.get("usage_page") == FIDO_USAGE_PAGE:
             return d
+    # hidapi may leave usage_page unset on Linux (libusb/older hidraw); confirm the
+    # FIDO usage page from the report descriptor instead (mirrors tools/rsk/ctaphid.py).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
+            return d
     return None
+
+
+def _declares_fido(path):
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write(dev, payload):

--- a/tests/11_fido_makecredential.py
+++ b/tests/11_fido_makecredential.py
@@ -6,9 +6,12 @@
 
     nix develop -c python tests/11_fido_makecredential.py
 
-Registers a resident ES256 credential and checks the packed self-attestation
-response (status, fmt, authData fields, attStmt). The ECDSA signature itself is
-unit-tested; this confirms a well-formed response over real USB.
+Registers a resident ES256 credential and checks the makeCredential response
+(status, fmt, authData fields, attStmt). Shipping firmware returns fmt="none"
+with an empty attStmt by default; a `--features fido-conformance` build returns
+fmt="packed" self-attestation whose ECDSA signature this test then verifies (the
+signature maths is also unit-tested — this confirms a well-formed response over
+real USB). The self-attestation check is therefore conditional on fmt.
 """
 import hashlib
 import sys
@@ -159,7 +162,8 @@ def main():
         resp = send_cbor(dev, cid, req)
         assert resp[0] == 0x00, f"makeCredential status {resp[0]:#x}"
         m = decode(resp[1:])
-        assert m[1] == "packed", f"fmt={m[1]!r}"
+        fmt = m[1]
+        assert fmt in ("none", "packed"), f"fmt={fmt!r}"
 
         ad = m[2]
         assert ad[:32] == hashlib.sha256(RP_ID.encode()).digest(), "rpIdHash mismatch"
@@ -171,9 +175,14 @@ def main():
         assert cose[1] == 2 and cose[3] == -7, f"COSE key {cose}"
 
         att = m[3]
-        assert att["alg"] == -7 and isinstance(att["sig"], bytes), f"attStmt {att}"
-
-        print(f"makeCredential ok: fmt=packed credId={cred_len}B sig={len(att['sig'])}B")
+        if fmt == "none":
+            assert att == {}, f"fmt=none must carry an empty attStmt, got {att!r}"
+            print("SKIP: self-attestation verify needs a --features fido-conformance "
+                  "firmware (shipping firmware sends fmt=none)")
+            print(f"makeCredential ok: fmt=none credId={cred_len}B attStmt={{}}")
+        else:  # packed self-attestation
+            assert att["alg"] == -7 and isinstance(att["sig"], bytes), f"attStmt {att}"
+            print(f"makeCredential ok: fmt=packed credId={cred_len}B sig={len(att['sig'])}B")
         print("\nPASS")
     finally:
         dev.close()

--- a/tests/12_fido_getassertion.py
+++ b/tests/12_fido_getassertion.py
@@ -90,11 +90,34 @@ def decode(b):
     return _dec(b, 0)[0]
 
 
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"  # Usage Page (0xF1D0) item in a HID report descriptor
+
+
 def find():
-    for d in hid.enumerate():
+    devices = hid.enumerate()
+    for d in devices:
         if d.get("usage_page") == 0xF1D0:
             return d
+    # hidapi may leave usage_page unset on Linux (libusb/older hidraw); confirm the
+    # FIDO usage page from the report descriptor instead (mirrors tools/rsk/ctaphid.py).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
+            return d
     return None
+
+
+def _declares_fido(path):
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write(dev, payload):

--- a/tests/13_u2f.py
+++ b/tests/13_u2f.py
@@ -30,11 +30,34 @@ APP_ID = hashlib.sha256(b"https://example.com").digest()
 CHAL = hashlib.sha256(b"rs-key u2f challenge").digest()
 
 
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"  # Usage Page (0xF1D0) item in a HID report descriptor
+
+
 def find():
-    for d in hid.enumerate():
+    devices = hid.enumerate()
+    for d in devices:
         if d.get("usage_page") == 0xF1D0:
             return d
+    # hidapi may leave usage_page unset on Linux (libusb/older hidraw); confirm the
+    # FIDO usage page from the report descriptor instead (mirrors tools/rsk/ctaphid.py).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
+            return d
     return None
+
+
+def _declares_fido(path):
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write(dev, payload):

--- a/tests/15_u2f_vendor_msg_isolation.py
+++ b/tests/15_u2f_vendor_msg_isolation.py
@@ -31,11 +31,34 @@ SELECT_VENDOR = bytes([0x00, 0xA4, 0x04, 0x00, len(VENDOR_AID)]) + VENDOR_AID
 U2F_VERSION = bytes([0x00, 0x03, 0x00, 0x00, 0x00])  # short Le (case 2)
 
 
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"  # Usage Page (0xF1D0) item in a HID report descriptor
+
+
 def find():
-    for d in hid.enumerate():
+    devices = hid.enumerate()
+    for d in devices:
         if d.get("usage_page") == 0xF1D0:
             return d
+    # hidapi may leave usage_page unset on Linux (libusb/older hidraw); confirm the
+    # FIDO usage page from the report descriptor instead (mirrors tools/rsk/ctaphid.py).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
+            return d
     return None
+
+
+def _declares_fido(path):
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write(dev, payload):

--- a/tests/60_pqc_mldsa.py
+++ b/tests/60_pqc_mldsa.py
@@ -15,9 +15,11 @@ Flash the no-touch build (firmware-test.uf2) — this tool cannot press the butt
                                      strict-parser compat); advertise-pqc build:
                                      -48 leads; maxMsgSize 7609 either way
   3. makeCredential [-7, -48]     -> PQC preferred over the earlier classic entry:
-                                     AKP COSE key {1:7, 3:-48, -1:pub(1312)}; the
-                                     packed self-attestation (2420-byte sig)
-                                     verifies under dilithium-py
+                                     AKP COSE key {1:7, 3:-48, -1:pub(1312)}; under
+                                     a --features fido-conformance build the packed
+                                     self-attestation (2420-byte sig) verifies under
+                                     dilithium-py (shipping firmware sends fmt=none,
+                                     empty attStmt — the attStmt check is skipped)
   4. getAssertion (allowList)     -> assertion verifies; sign counter grows
   5. rk -7 then rk [-7,-48], same rp/user -> the resident slot upgrades to
                                      ML-DSA-44; discovery asserts with it
@@ -49,12 +51,12 @@ def ctap(dev, cid, cmd, fields=None):
 
 
 def parse_make_credential(resp):
-    """-> (credId, alg, pk, authData, attStmt) from a packed mc response."""
+    """-> (credId, alg, pk, authData, fmt, attStmt) from an mc response."""
     auth_data = resp[2]
     cred_len = int.from_bytes(auth_data[53:55], "big")
     cred_id = auth_data[55:55 + cred_len]
     cose = decode(auth_data[55 + cred_len:])
-    return cred_id, cose[3], cose.get(-1), auth_data, resp[3]
+    return cred_id, cose[3], cose.get(-1), auth_data, resp[1], resp[3]
 
 
 def make_credential(dev, cid, algs, uid=b"\x01\x02\x03\x04", rk=False):
@@ -117,11 +119,17 @@ def main():
         assert gi[5] == 7609, f"maxMsgSize {gi[5]}, want 7609"
 
         # 3. PQC-preferred registration: -48 wins despite -7 listed first.
-        (cred_id, alg, pk, auth_data, att), dt_mc = make_credential(dev, cid, [-7, -48])
+        (cred_id, alg, pk, auth_data, fmt, att), dt_mc = make_credential(dev, cid, [-7, -48])
         assert alg == -48, f"selected alg {alg}, want -48 (PQC priority)"
-        assert len(pk) == PK_LEN and att["alg"] == -48
-        assert len(att["sig"]) == SIG_LEN
-        assert ML_DSA_44.verify(pk, auth_data + CDH, att["sig"]), "attestation sig"
+        assert len(pk) == PK_LEN
+        if fmt == "none":
+            assert att == {}, f"fmt=none must carry an empty attStmt, got {att!r}"
+            print("SKIP: self-attestation verify needs a --features fido-conformance "
+                  "firmware (shipping firmware sends fmt=none)")
+        else:  # packed self-attestation
+            assert att["alg"] == -48
+            assert len(att["sig"]) == SIG_LEN
+            assert ML_DSA_44.verify(pk, auth_data + CDH, att["sig"]), "attestation sig"
 
         # 4. Assertion under the same credential; counter must grow.
         ad1, sig1, dt_ga = get_assertion(dev, cid, cred_id)
@@ -136,7 +144,7 @@ def main():
         # 5. Classic -> PQC resident upgrade for one rp/user.
         uid = b"\x42\x42"
         make_credential(dev, cid, [-7], uid=uid, rk=True)
-        (_, alg, pk2, _, _), _ = make_credential(dev, cid, [-7, -48], uid=uid, rk=True)
+        (_, alg, pk2, _, _, _), _ = make_credential(dev, cid, [-7, -48], uid=uid, rk=True)
         assert alg == -48
         ad3, sig3, _ = get_assertion(dev, cid)  # discovery, no allowList
         assert len(sig3) == SIG_LEN, "upgraded resident credential signs ML-DSA"

--- a/tests/61_pqc_thirdparty_client.py
+++ b/tests/61_pqc_thirdparty_client.py
@@ -14,6 +14,10 @@ python-fido2 2.2 has no ML-DSA CoseKey yet — the credential public key parses
 as `UnsupportedKey` (raw COSE map), so the AKP `pub` (-1) bytes are handed to
 OpenSSL directly.
 
+Shipping firmware returns fmt="none" with an empty attStmt, so the packed
+self-attestation verify only runs on a `--features fido-conformance` build; on a
+default board it is skipped and the getAssertion signature carries the check.
+
     python3 -m venv /tmp/fido2-latest
     /tmp/fido2-latest/bin/pip install fido2 cryptography
     /tmp/fido2-latest/bin/python tests/61_pqc_thirdparty_client.py
@@ -83,10 +87,16 @@ def main():
     assert cose[1] == 7 and cose[3] == -48, f"COSE key not AKP/ML-DSA-44: {cose.keys()}"
     pub = mldsa.MLDSA44PublicKey.from_public_bytes(bytes(cose[-1]))
 
-    assert att.att_stmt["alg"] == -48, f"attStmt alg {att.att_stmt['alg']}"
-    pub.verify(att.att_stmt["sig"], bytes(att.auth_data) + reg.response.client_data.hash)
-    print(f"registration: AKP key parsed by python-fido2, attestation verified by OpenSSL "
-          f"(credId {len(cred_data.credential_id)}B, sig {len(att.att_stmt['sig'])}B)")
+    if att.fmt == "none" or not att.att_stmt:
+        print("SKIP: self-attestation verify needs a --features fido-conformance "
+              "firmware (shipping firmware sends fmt=none)")
+        print(f"registration: AKP key parsed by python-fido2 "
+              f"(credId {len(cred_data.credential_id)}B, fmt=none)")
+    else:
+        assert att.att_stmt["alg"] == -48, f"attStmt alg {att.att_stmt['alg']}"
+        pub.verify(att.att_stmt["sig"], bytes(att.auth_data) + reg.response.client_data.hash)
+        print(f"registration: AKP key parsed by python-fido2, attestation verified by OpenSSL "
+              f"(credId {len(cred_data.credential_id)}B, sig {len(att.att_stmt['sig'])}B)")
 
     # Authenticate with the returned credential; verify under the same key.
     sel = client.get_assertion(

--- a/tests/64_pqc_crossverify.py
+++ b/tests/64_pqc_crossverify.py
@@ -13,6 +13,11 @@ host tests.
 Needs `hidapi` + `dilithium-py` + `cryptography` >= 44 (OpenSSL >= 3.5 backend
 for ML-DSA); all three are in the nix devshell python. Flash the no-touch build
 built `--features advertise-pqc`.
+
+Shipping firmware returns fmt="none" with an empty attStmt, so the attestation
+cross-verify only runs on a `--features fido-conformance` build (packed
+self-attestation); on a default board it is skipped and the assertion signature
+carries the cross-verify (including the tamper negative control).
 """
 import os
 import sys
@@ -54,7 +59,7 @@ def parse_mc(resp):
     ad = resp[2]
     clen = int.from_bytes(ad[53:55], "big")
     cose = decode(ad[55 + clen:])
-    return ad[55:55 + clen], cose[3], cose.get(-1), ad, resp[3]
+    return ad[55:55 + clen], cose[3], cose.get(-1), ad, resp[1], resp[3]
 
 
 def openssl_verify(cls, pk, msg, sig):
@@ -86,8 +91,17 @@ def main():
             }
             status, resp = ctap(dev, cid, 0x01, req)
             assert status == 0x00, f"{label} makeCredential {status:#x}"
-            cred_id, got_alg, pk, ad, att = parse_mc(resp)
-            assert got_alg == alg and len(pk) == pk_len and len(att["sig"]) == sig_len
+            cred_id, got_alg, pk, ad, fmt, att = parse_mc(resp)
+            assert got_alg == alg and len(pk) == pk_len
+            # Shipping firmware sends fmt=none (empty attStmt); packed self-attestation
+            # (with a device-signed attStmt) needs a --features fido-conformance build.
+            have_att = fmt != "none"
+            if have_att:
+                assert len(att["sig"]) == sig_len
+            else:
+                assert att == {}, f"{label} fmt=none must carry an empty attStmt, got {att!r}"
+                print(f"{label} SKIP: self-attestation verify needs a --features "
+                      "fido-conformance firmware (shipping firmware sends fmt=none)")
 
             # getAssertion under the same credential.
             status, ga = ctap(dev, cid, 0x02, {1: req[2]["id"], 2: CDH,
@@ -95,8 +109,10 @@ def main():
             assert status == 0x00, f"{label} getAssertion {status:#x}"
             ga_ad, ga_sig = ga[2], ga[3]
 
-            for what, msg, sig in [("attestation", ad + CDH, att["sig"]),
-                                   ("assertion", ga_ad + CDH, ga_sig)]:
+            checks = [("assertion", ga_ad + CDH, ga_sig)]
+            if have_att:
+                checks.insert(0, ("attestation", ad + CDH, att["sig"]))
+            for what, msg, sig in checks:
                 dpy = dil.verify(pk, msg, sig)
                 ossl = openssl_verify(pyca_cls, pk, msg, sig)
                 mark = "OK" if (dpy and ossl) else "FAIL"
@@ -104,11 +120,13 @@ def main():
                 assert dpy, f"{label} {what}: dilithium-py rejected a valid device signature"
                 assert ossl, f"{label} {what}: OpenSSL rejected a valid device signature"
 
-            # Negative control: a one-bit flip must be rejected by BOTH.
-            bad = bytearray(att["sig"])
+            # Negative control: a one-bit flip must be rejected by BOTH. When there
+            # is no attStmt (fmt=none), tamper the assertion signature instead.
+            good_ad, good_sig = (ad, att["sig"]) if have_att else (ga_ad, ga_sig)
+            bad = bytearray(good_sig)
             bad[100] ^= 0x01
-            assert not dil.verify(pk, ad + CDH, bytes(bad)), f"{label} dilithium-py accepted a tampered sig"
-            assert not openssl_verify(pyca_cls, pk, ad + CDH, bytes(bad)), f"{label} OpenSSL accepted a tampered sig"
+            assert not dil.verify(pk, good_ad + CDH, bytes(bad)), f"{label} dilithium-py accepted a tampered sig"
+            assert not openssl_verify(pyca_cls, pk, good_ad + CDH, bytes(bad)), f"{label} OpenSSL accepted a tampered sig"
 
         print("PASS (device ML-DSA-44 + -65 signatures verify under dilithium-py AND OpenSSL; tamper rejected)")
     finally:

--- a/tests/65_pqc_thirdparty_client65.py
+++ b/tests/65_pqc_thirdparty_client65.py
@@ -11,6 +11,10 @@ ML-DSA via pyca/cryptography (>= 48). Only this glue file is ours.
 python-fido2 2.2 has no ML-DSA CoseKey yet — the credential public key parses as
 a raw COSE map, so the AKP `pub` (-1) bytes are handed to OpenSSL directly.
 
+Shipping firmware returns fmt="none" with an empty attStmt, so the packed
+self-attestation verify only runs on a `--features fido-conformance` build; on a
+default board it is skipped and the getAssertion signature carries the check.
+
     python3 -m venv /tmp/fido2v
     /tmp/fido2v/bin/pip install fido2 cryptography
     /tmp/fido2v/bin/python tests/65_pqc_thirdparty_client65.py
@@ -77,11 +81,17 @@ def main():
     pub = mldsa.MLDSA65PublicKey.from_public_bytes(bytes(cose[-1]))
     assert len(bytes(cose[-1])) == 1952, "ML-DSA-65 pk length"
 
-    assert att.att_stmt["alg"] == -49, f"attStmt alg {att.att_stmt['alg']}"
-    assert len(att.att_stmt["sig"]) == 3309, "ML-DSA-65 sig length"
-    pub.verify(att.att_stmt["sig"], bytes(att.auth_data) + reg.response.client_data.hash)
-    print(f"registration: AKP key parsed by python-fido2, attestation verified by OpenSSL "
-          f"(credId {len(cred_data.credential_id)}B, sig {len(att.att_stmt['sig'])}B)")
+    if att.fmt == "none" or not att.att_stmt:
+        print("SKIP: self-attestation verify needs a --features fido-conformance "
+              "firmware (shipping firmware sends fmt=none)")
+        print(f"registration: AKP key parsed by python-fido2 "
+              f"(credId {len(cred_data.credential_id)}B, fmt=none)")
+    else:
+        assert att.att_stmt["alg"] == -49, f"attStmt alg {att.att_stmt['alg']}"
+        assert len(att.att_stmt["sig"]) == 3309, "ML-DSA-65 sig length"
+        pub.verify(att.att_stmt["sig"], bytes(att.auth_data) + reg.response.client_data.hash)
+        print(f"registration: AKP key parsed by python-fido2, attestation verified by OpenSSL "
+              f"(credId {len(cred_data.credential_id)}B, sig {len(att.att_stmt['sig'])}B)")
 
     # Authenticate with the returned credential; verify under the same key.
     sel = client.get_assertion(

--- a/tests/ctaphid.py
+++ b/tests/ctaphid.py
@@ -25,6 +25,11 @@ CTAPHID_INIT = 0x86
 CTAPHID_CBOR = 0x90
 CTAPHID_KEEPALIVE = 0xBB  # device-still-processing status frame
 CTAP_CLIENT_PIN = 0x06  # CTAP2 authenticatorClientPIN (naming mirrors tools/rsk/ctaphid.py)
+FIDO_USAGE_PAGE = 0xF1D0  # FIDO HID usage page (CTAPHID spec)
+# HID report-descriptor item for Usage Page 0xF1D0 — matches a FIDO device when hidapi
+# leaves `usage_page` unset (some Linux builds report 0), keeping detection
+# VID/PID-agnostic (mirrors tools/rsk/ctaphid.py).
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"
 # Bound the keepalive wait and CBOR recursion so a broken/hostile device cannot hang or
 # crash the test runner (mirrors tools/rsk/ctaphid.py).
 KEEPALIVE_DEADLINE_S = 120
@@ -108,10 +113,33 @@ def decode(b):
 
 
 def find():
-    for d in hid.enumerate():
-        if d.get("usage_page") == 0xF1D0:
+    devices = hid.enumerate()
+    for d in devices:
+        if d.get("usage_page") == FIDO_USAGE_PAGE:
+            return d
+    # hidapi left usage_page unset (0/None) — read each such device's report
+    # descriptor and match the FIDO usage-page item directly, rather than guessing
+    # by VID/PID (RS-Key ships several presets, so no fixed pair to key off).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
             return d
     return None
+
+
+def _declares_fido(path):
+    """Open `path` and report whether its HID report descriptor names the FIDO
+    usage page. Passive read; any hidapi error means "treat as non-FIDO, skip"."""
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write(dev, payload):

--- a/tools/rsk/__init__.py
+++ b/tools/rsk/__init__.py
@@ -8,4 +8,4 @@ backup, secure-boot provisioning, OTP-MKEK burn/lock, FIDO management, LED confi
 OpenPGP reset, and hands-free reboot. Run from `nix develop` (the flake provides
 `rsk` on PATH and all Python deps) or as `python -m rsk`.
 """
-__version__ = "0.3.11"
+__version__ = "0.3.12"

--- a/tools/rsk/__init__.py
+++ b/tools/rsk/__init__.py
@@ -8,4 +8,4 @@ backup, secure-boot provisioning, OTP-MKEK burn/lock, FIDO management, LED confi
 OpenPGP reset, and hands-free reboot. Run from `nix develop` (the flake provides
 `rsk` on PATH and all Python deps) or as `python -m rsk`.
 """
-__version__ = "0.3.10"
+__version__ = "0.3.11"

--- a/tools/rsk/__init__.py
+++ b/tools/rsk/__init__.py
@@ -8,4 +8,4 @@ backup, secure-boot provisioning, OTP-MKEK burn/lock, FIDO management, LED confi
 OpenPGP reset, and hands-free reboot. Run from `nix develop` (the flake provides
 `rsk` on PATH and all Python deps) or as `python -m rsk`.
 """
-__version__ = "0.3.9"
+__version__ = "0.3.10"

--- a/tools/rsk/common.py
+++ b/tools/rsk/common.py
@@ -93,6 +93,49 @@ def resolve_pin(args, *, has_pin=None, prompt="FIDO2 PIN: ", required=False):
     return entered
 
 
+# --- clientPIN error reporting ------------------------------------------------
+# python-fido2 raises CtapError on a PIN operation the device rejected (wrong PIN,
+# blocked, policy). Left uncaught it surfaces as a Python traceback; map the CTAP
+# 2.1 §6.5.5 status to an operator-facing message instead.
+
+CTAP_PIN_INVALID = 0x31
+CTAP_PIN_BLOCKED = 0x32
+CTAP_PIN_AUTH_BLOCKED = 0x34
+CTAP_PIN_POLICY_VIOLATION = 0x37
+
+
+def pin_error_message(code, retries=None):
+    """Friendly text for a CTAP2 clientPIN error status (int), or None when the
+    status isn't a recognised PIN error (the caller reports the raw code then)."""
+    if code == CTAP_PIN_INVALID:
+        if retries is not None:
+            return f"wrong PIN — {retries} attempt(s) left before it blocks"
+        return "wrong PIN"
+    if code == CTAP_PIN_AUTH_BLOCKED:
+        return "too many wrong PINs this session — unplug and replug the device, then try again"
+    if code == CTAP_PIN_BLOCKED:
+        return "PIN blocked by too many wrong attempts — reset the FIDO app to set a PIN again"
+    if code == CTAP_PIN_POLICY_VIOLATION:
+        return "new PIN rejected by the device (too long, or a forbidden/too-simple value)"
+    return None
+
+
+def die_ctap_pin_error(exc, cp=None):
+    """Turn a python-fido2 CtapError from a clientPIN operation into a clean `die`.
+
+    `cp` (a ClientPin), when given, is queried for the remaining attempts on a
+    wrong PIN so the message can say how many tries are left."""
+    code = int(getattr(exc, "code", 0) or 0)
+    retries = None
+    if code == CTAP_PIN_INVALID and cp is not None:
+        try:
+            r = cp.get_pin_retries()
+            retries = r[0] if isinstance(r, (tuple, list)) else r
+        except Exception:
+            retries = None
+    die(pin_error_message(code, retries) or f"PIN operation failed (CTAP status {code:#04x})")
+
+
 def picotool(*args, check=True):
     """Run picotool (in the dev shell); die on failure unless check=False."""
     r = subprocess.run(["picotool", *args], capture_output=True, text=True)

--- a/tools/rsk/common.py
+++ b/tools/rsk/common.py
@@ -108,7 +108,9 @@ def pin_error_message(code, retries=None):
     """Friendly text for a CTAP2 clientPIN error status (int), or None when the
     status isn't a recognised PIN error (the caller reports the raw code then)."""
     if code == CTAP_PIN_INVALID:
-        if retries is not None:
+        # retries is device-reported; trust it only when it is really an int, so a
+        # hostile authenticator can't smuggle a string (terminal escapes) into die().
+        if isinstance(retries, int):
             return f"wrong PIN — {retries} attempt(s) left before it blocks"
         return "wrong PIN"
     if code == CTAP_PIN_AUTH_BLOCKED:

--- a/tools/rsk/ctaphid.py
+++ b/tools/rsk/ctaphid.py
@@ -26,6 +26,10 @@ CTAPHID_CBOR = 0x90
 CTAPHID_KEEPALIVE = 0xBB  # CTAPHID_KEEPALIVE status frame (device still processing)
 CTAP_GET_INFO = 0x04  # CTAP2 authenticatorGetInfo
 FIDO_USAGE_PAGE = 0xF1D0  # FIDO HID usage page (CTAPHID spec)
+# The Usage Page (0xF1D0) item as it appears in a HID report descriptor. Used to
+# confirm a FIDO device when hidapi leaves `usage_page` unset (some Linux
+# libusb/hidraw builds report 0), so detection stays VID/PID-agnostic.
+FIDO_USAGE_PAGE_ITEM = b"\x06\xd0\xf1"
 # Ceiling on the keepalive wait: a hostile device can stream keepalives forever, so bail
 # past any legitimate ceremony (30s presence window + flash-GC slack) rather than hang.
 KEEPALIVE_DEADLINE_S = 120
@@ -113,10 +117,33 @@ def decode(b):
 
 
 def find():
-    for d in hid.enumerate():
+    devices = hid.enumerate()
+    for d in devices:
         if d.get("usage_page") == FIDO_USAGE_PAGE:
             return d
+    # hidapi left usage_page unset (0/None) — read each such device's report
+    # descriptor and match the FIDO usage-page item directly, rather than guessing
+    # by VID/PID (RS-Key ships several presets, so no fixed pair to key off).
+    for d in devices:
+        if not d.get("usage_page") and _declares_fido(d.get("path")):
+            return d
     return None
+
+
+def _declares_fido(path):
+    """Open `path` and report whether its HID report descriptor names the FIDO
+    usage page. Passive read; any hidapi error means "treat as non-FIDO, skip"."""
+    if not path:
+        return False
+    dev = hid.device()
+    try:
+        dev.open_path(path)
+        desc = bytes(dev.get_report_descriptor())
+    except (OSError, ValueError, TypeError, AttributeError):
+        return False
+    finally:
+        dev.close()
+    return FIDO_USAGE_PAGE_ITEM in desc
 
 
 def write(dev, payload):

--- a/tools/rsk/fido.py
+++ b/tools/rsk/fido.py
@@ -9,9 +9,10 @@ list-passkeys: list discoverable credentials via credentialManagement (needs PIN
 import sys
 from getpass import getpass
 
-from .common import add_pin_arg, device_has_pin, die, resolve_pin, sanitize
+from .common import add_pin_arg, device_has_pin, die, die_ctap_pin_error, resolve_pin, sanitize
 
 try:
+    from fido2.ctap import CtapError
     from fido2.hid import CtapHidDevice
     from fido2.ctap2 import Ctap2
     from fido2.ctap2.pin import ClientPin
@@ -72,10 +73,16 @@ def set_pin(args):
         die("PIN too short (min 4)")
     if has_pin:
         current = resolve_pin(args, has_pin=True, prompt="Current PIN: ", required=True)
-        cp.change_pin(current, new)
+        try:
+            cp.change_pin(current, new)
+        except CtapError as e:
+            die_ctap_pin_error(e, cp)
         print("FIDO2 PIN changed.")
     else:
-        cp.set_pin(new)
+        try:
+            cp.set_pin(new)
+        except CtapError as e:
+            die_ctap_pin_error(e, cp)
         print("FIDO2 PIN set.")
     print("clientPin now:", _ctap().info.options.get("clientPin"))
 
@@ -88,7 +95,10 @@ def list_passkeys(args):
         die("no FIDO2 PIN set — set one first (rsk fido set-pin)")
     cp = ClientPin(ctap)
     pin = resolve_pin(args, has_pin=True, required=True)
-    token = cp.get_pin_token(pin, ClientPin.PERMISSION.CREDENTIAL_MGMT)
+    try:
+        token = cp.get_pin_token(pin, ClientPin.PERMISSION.CREDENTIAL_MGMT)
+    except CtapError as e:
+        die_ctap_pin_error(e, cp)
     cm = CM(ctap, cp.protocol, token)
     meta = cm.get_metadata()
     existing = meta[CM.RESULT.EXISTING_CRED_COUNT]

--- a/tools/rsk/test_common.py
+++ b/tools/rsk/test_common.py
@@ -217,3 +217,22 @@ def test_die_ctap_pin_error_unknown_code_reports_hex(capsys):
         common.die_ctap_pin_error(_exc(0x99), None)
     err = capsys.readouterr().err
     assert "PIN operation failed" in err and "0x99" in err
+
+
+# A counterfeit device can return the PIN_RETRIES field as a text string (python-fido2
+# does not coerce it); it must NOT reach the terminal — only an int count is trusted.
+
+def test_pin_error_message_drops_non_int_retries():
+    evil = "\x1b]0;pwn\x07"  # OSC window-title escape smuggled as the "retry count"
+    assert common.pin_error_message(common.CTAP_PIN_INVALID, evil) == "wrong PIN"
+    assert "\x1b" not in common.pin_error_message(common.CTAP_PIN_INVALID, evil)
+    assert common.pin_error_message(common.CTAP_PIN_INVALID, 5).endswith("before it blocks")
+
+
+def test_die_ctap_pin_error_hostile_string_retries_not_printed(capsys):
+    evil = "\x1b]52;c;ZXZpbA==\x07"  # OSC-52 clipboard write
+    with pytest.raises(SystemExit):
+        common.die_ctap_pin_error(_exc(common.CTAP_PIN_INVALID), _FakeCp((evil, None)))
+    err = capsys.readouterr().err
+    assert err.strip() == "error: wrong PIN"
+    assert "\x1b" not in err

--- a/tools/rsk/test_common.py
+++ b/tools/rsk/test_common.py
@@ -9,6 +9,7 @@ Every gated command routes its PIN through resolve_pin, so the precedence
 behaviour the whole CLI's consistency rests on — pin them here. No device.
 """
 import argparse
+import types
 
 import pytest
 
@@ -142,3 +143,77 @@ def test_sanitize_join_scalar_and_none():
 
 def test_sanitize_join_strips_escapes_in_elements():
     assert "\x1b" not in common.sanitize_join(["ok", "\x1b]0;pwn\x07"])
+
+
+# --- clientPIN error reporting: a wrong PIN reads as "wrong PIN", not a
+# python-fido2 traceback (rsk fido set-pin / list-passkeys) --------------------
+
+def test_pin_error_message_wrong_pin():
+    assert common.pin_error_message(common.CTAP_PIN_INVALID) == "wrong PIN"
+
+
+def test_pin_error_message_wrong_pin_with_retries():
+    msg = common.pin_error_message(common.CTAP_PIN_INVALID, 7)
+    assert "wrong PIN" in msg and "7" in msg
+
+
+def test_pin_error_message_blocked_variants():
+    assert "unplug" in common.pin_error_message(common.CTAP_PIN_AUTH_BLOCKED)
+    assert "reset" in common.pin_error_message(common.CTAP_PIN_BLOCKED)
+
+
+def test_pin_error_message_policy():
+    assert "rejected" in common.pin_error_message(common.CTAP_PIN_POLICY_VIOLATION)
+
+
+def test_pin_error_message_unknown_is_none():
+    assert common.pin_error_message(0x99) is None
+
+
+class _FakeCp:
+    """Duck of fido2's ClientPin.get_pin_retries; an Exception value is raised."""
+
+    def __init__(self, retries):
+        self._r = retries
+
+    def get_pin_retries(self):
+        if isinstance(self._r, Exception):
+            raise self._r
+        return self._r
+
+
+def _exc(code):
+    return types.SimpleNamespace(code=code)  # duck of fido2 CtapError (.code)
+
+
+def test_die_ctap_pin_error_wrong_pin_shows_retries(capsys):
+    with pytest.raises(SystemExit):
+        common.die_ctap_pin_error(_exc(common.CTAP_PIN_INVALID), _FakeCp((5, None)))
+    err = capsys.readouterr().err
+    assert "wrong PIN" in err and "5" in err
+    assert "Traceback" not in err
+
+
+def test_die_ctap_pin_error_retries_as_bare_int(capsys):
+    with pytest.raises(SystemExit):
+        common.die_ctap_pin_error(_exc(common.CTAP_PIN_INVALID), _FakeCp(3))
+    assert "3" in capsys.readouterr().err
+
+
+def test_die_ctap_pin_error_no_cp_omits_retries(capsys):
+    with pytest.raises(SystemExit):
+        common.die_ctap_pin_error(_exc(common.CTAP_PIN_INVALID), None)
+    assert capsys.readouterr().err.strip() == "error: wrong PIN"
+
+
+def test_die_ctap_pin_error_retries_query_failure_is_tolerated(capsys):
+    with pytest.raises(SystemExit):
+        common.die_ctap_pin_error(_exc(common.CTAP_PIN_INVALID), _FakeCp(OSError("boom")))
+    assert "wrong PIN" in capsys.readouterr().err  # no crash, retry-less fallback
+
+
+def test_die_ctap_pin_error_unknown_code_reports_hex(capsys):
+    with pytest.raises(SystemExit):
+        common.die_ctap_pin_error(_exc(0x99), None)
+    err = capsys.readouterr().err
+    assert "PIN operation failed" in err and "0x99" in err

--- a/tools/rsk/test_ctaphid_find.py
+++ b/tools/rsk/test_ctaphid_find.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+"""Host tests for rsk.ctaphid.find() device detection (no real hidapi).
+
+Run from tools/:  python -m pytest rsk/test_ctaphid_find.py
+
+Pins that find() locates a FIDO device by its usage page even when hidapi leaves
+`usage_page` unset (the Linux libusb/hidraw case behind issue #28), by falling
+back to the HID report descriptor — VID/PID-agnostic, since RS-Key ships several
+VID/PID presets and hard-coding one (as the issue's workaround did) breaks the
+rest.
+"""
+import sys
+import types
+
+# find()/`_declares_fido` touch `hid` only; stub it before importing rsk.ctaphid,
+# which sys.exits at import if hidapi is missing. Handles are installed per test.
+sys.modules.setdefault("hid", types.ModuleType("hid"))
+
+import pytest
+
+from rsk import ctaphid
+
+# A minimal FIDO report descriptor: Usage Page (0xF1D0), Usage (0x01),
+# Collection (Application), End Collection.
+FIDO_DESC = b"\x06\xd0\xf1\x09\x01\xa1\x01\xc0"
+# A keyboard: Usage Page (Generic Desktop), Usage (Keyboard) — no FIDO item.
+KEYBOARD_DESC = b"\x05\x01\x09\x06\xa1\x01\xc0"
+
+
+class _FakeDev:
+    """Stand-in for hid.device(); serves descriptors keyed by enumerate() path.
+
+    A descriptor value that is an Exception instance is raised from
+    get_report_descriptor() to exercise the error branches of _declares_fido.
+    """
+
+    def __init__(self, descriptors, opened):
+        self._descriptors = descriptors
+        self._opened = opened
+        self._path = None
+
+    def open_path(self, path):
+        if path not in self._descriptors:
+            raise OSError("access denied")  # no permission / device busy
+        self._path = path
+        self._opened.append(path)
+
+    def get_report_descriptor(self):
+        desc = self._descriptors[self._path]
+        if isinstance(desc, Exception):
+            raise desc
+        return desc
+
+    def close(self):
+        self._path = None
+
+
+def _install(monkeypatch, enum, descriptors):
+    """Wire hid.enumerate()/hid.device() and return the list of probed paths."""
+    opened = []
+    monkeypatch.setattr(ctaphid.hid, "enumerate", lambda: enum, raising=False)
+    monkeypatch.setattr(
+        ctaphid.hid, "device", lambda: _FakeDev(descriptors, opened), raising=False
+    )
+    return opened
+
+
+def test_fast_path_matches_usage_page_without_opening(monkeypatch):
+    enum = [
+        {"usage_page": 0x0001, "path": b"/kbd"},
+        {"usage_page": ctaphid.FIDO_USAGE_PAGE, "path": b"/fido", "vendor_id": 0x1209},
+    ]
+
+    def no_open():
+        raise AssertionError("fast path must not open any device")
+
+    monkeypatch.setattr(ctaphid.hid, "enumerate", lambda: enum, raising=False)
+    monkeypatch.setattr(ctaphid.hid, "device", no_open, raising=False)
+    assert ctaphid.find()["path"] == b"/fido"
+
+
+def test_fallback_reads_report_descriptor_when_usage_page_zero(monkeypatch):
+    # The libusb/hidraw case: enumerate lists the device but usage_page is 0.
+    enum = [{"usage_page": 0, "path": b"/fido"}]
+    opened = _install(monkeypatch, enum, {b"/fido": FIDO_DESC})
+    assert ctaphid.find()["path"] == b"/fido"
+    assert opened == [b"/fido"]
+
+
+def test_fallback_skips_non_fido_devices(monkeypatch):
+    enum = [
+        {"usage_page": 0, "path": b"/kbd"},
+        {"usage_page": None, "path": b"/fido"},
+    ]
+    opened = _install(monkeypatch, enum, {b"/kbd": KEYBOARD_DESC, b"/fido": FIDO_DESC})
+    assert ctaphid.find()["path"] == b"/fido"
+    assert opened == [b"/kbd", b"/fido"]  # probed the keyboard, rejected it, went on
+
+
+def test_fallback_only_probes_usage_page_unset(monkeypatch):
+    # A populated non-FIDO usage_page is settled by the fast path and never opened.
+    enum = [
+        {"usage_page": 0x0001, "path": b"/kbd"},
+        {"usage_page": 0, "path": b"/fido"},
+    ]
+    opened = _install(monkeypatch, enum, {b"/kbd": KEYBOARD_DESC, b"/fido": FIDO_DESC})
+    assert ctaphid.find()["path"] == b"/fido"
+    assert opened == [b"/fido"]
+
+
+def test_unopenable_device_is_tolerated(monkeypatch):
+    # A device we can't open (no descriptor mapping → OSError) is skipped, not fatal.
+    enum = [
+        {"usage_page": 0, "path": b"/locked"},
+        {"usage_page": 0, "path": b"/fido"},
+    ]
+    opened = _install(monkeypatch, enum, {b"/fido": FIDO_DESC})
+    assert ctaphid.find()["path"] == b"/fido"
+    assert opened == [b"/fido"]  # /locked raised on open() and was skipped
+
+
+def test_returns_none_when_no_fido_present(monkeypatch):
+    enum = [{"usage_page": 0, "path": b"/kbd"}]
+    _install(monkeypatch, enum, {b"/kbd": KEYBOARD_DESC})
+    assert ctaphid.find() is None
+
+
+def test_empty_path_is_skipped(monkeypatch):
+    enum = [{"usage_page": 0, "path": None}]
+    opened = _install(monkeypatch, enum, {})
+    assert ctaphid.find() is None
+    assert opened == []  # never tried to open a pathless entry
+
+
+def test_report_descriptor_error_is_tolerated(monkeypatch):
+    # get_report_descriptor() raising (ValueError/TypeError, e.g. a hidapi C-call
+    # failure or a None result) skips that device instead of crashing find().
+    enum = [
+        {"usage_page": 0, "path": b"/flaky"},
+        {"usage_page": 0, "path": b"/fido"},
+    ]
+    _install(monkeypatch, enum, {b"/flaky": ValueError("read failed"), b"/fido": FIDO_DESC})
+    assert ctaphid.find()["path"] == b"/fido"
+
+
+def test_device_without_report_descriptor_method_is_tolerated(monkeypatch):
+    # An older/other hid backend whose device lacks get_report_descriptor()
+    # raises AttributeError, which the fallback swallows.
+    class _NoDescDev:
+        def open_path(self, path):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(ctaphid.hid, "enumerate", lambda: [{"usage_page": 0, "path": b"/x"}], raising=False)
+    monkeypatch.setattr(ctaphid.hid, "device", _NoDescDev, raising=False)
+    assert ctaphid.find() is None


### PR DESCRIPTION
Release **v0.3.5** — everything on `develop` since v0.3.4.

## Firmware (bcdDevice → `0x080D`)
- **`f490ee8`** — return `PIN_INVALID` (0x31, not 0x33) for the zero-length
  `pinUvAuthParam` selection probe when a PIN is set, so passkey registration no
  longer hangs on the touch after a PIN is set (Chrome/Linux). `0x080B`→`0x080C`.
- **`afe97d2`** — `makeCredential` ships `fmt:"none"` attestation by default,
  fixing `ssh-keygen -t ed25519-sk` on Windows / OpenSSH 10 (**issue #26**).
  Enterprise x5c untouched; `fido-conformance` keeps packed. `0x080C`→`0x080D`.

## Host CLI (`rsk` → `0.3.12`, host-only)
- **`bc64534`** — `rsk` finds the FIDO HID on Linux hosts where hidapi omits the
  usage page, by falling back to the HID report descriptor — VID/PID-agnostic
  (**issue #28**). Same fallback synced into the on-device test scripts.
- **`955bc7b`** — a wrong PIN in `rsk fido set-pin` / `list-passkeys` now prints a
  clean error (with attempts remaining) instead of a python-fido2 traceback.
- **`6c8c4c1`** — security-audit **run-18**: guard the device-reported clientPIN
  retry count so a counterfeit device can't inject terminal escapes through it
  (LOW; same class as the run-11/12 host-tooling escapes).

## Verification
- `nix develop -c ./scripts/check.sh` green on the firmware commits (default +
  fido-conformance profiles); host tests pass (`test_ctaphid_find` 9/9,
  `test_common` 30/30).
- HW-verified 2026-07-14 on a board (bcd 0x080D): #28 find() fast-path + fallback
  against the real descriptor; wrong-PIN → clean `wrong PIN — N attempts left`.
- Security-audit run-18: 1 LOW (fixed here), firmware out of scope (runs 1–17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
