### PR TITLE
Release v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-07-19
+
 ### Fixed
 
 - **KV store no longer rolls a key back to an older value on a power-cut mid-delete.**
@@ -1851,7 +1853,8 @@ family that keeps the "enterprise" features in the open tree.
   signature of it, and a CycloneDX SBOM. See
   [docs/releases.md](docs/releases.md) to verify a download.
 
-[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.8...HEAD
+[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.9...HEAD
+[0.3.9]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.5...v0.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **KV store no longer rolls a key back to an older value on a power-cut mid-delete.**
+  The vendored `sequential-storage`'s `remove_item` erased a key's page copies starting
+  from `find_first_page(PartialOpen).unwrap_or_default()`, which falls back to page 0
+  whenever there is no partial-open page (the normal steady state: a closed frontier page
+  plus an open buffer page). That inverted the intended oldest-first erase order, so a
+  power loss during a delete could erase the newest copy first and leave an older copy
+  live — which the next read then returned (a rollback past the committed value). The
+  remove path now computes the newest page the same way the read path does, so the two
+  agree. On RS-Key this was fail-closed (every stored value is AEAD-sealed and read past a
+  length/tag gate, so a resurfaced stale/short blob is rejected, not used), but it is a
+  real durability defect in the store that holds all sealed secrets. Found by the
+  `kv_durability` fuzz target; an upstream `sequential-storage` bug (fix confined to the
+  vendored fork, `third_party/sequential-storage.patch` item 3). **bcdDevice → 0x082D.**
+
 ## [0.3.8] - 2026-07-19
 
 ### Added

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -440,7 +440,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x082C;
+    let device_release: u16 = 0x082D;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/third_party/sequential-storage.patch
+++ b/third_party/sequential-storage.patch
@@ -1,8 +1,8 @@
 # Local changes to sequential-storage 8.0.0, applied to the vendored copy under
 # third_party/sequential-storage/ and wired in via [patch.crates-io] in the root
-# and fuzz Cargo.toml. All confined to MapItemIter::next; the rest of the tree is
-# byte-identical to the published 8.0.0 (verified: diff -rq against the crates.io
-# source reports only src/map.rs differs).
+# and fuzz Cargo.toml. All confined to src/map.rs (MapItemIter::next and
+# remove_item_inner); the rest of the tree is byte-identical to the published 8.0.0
+# (verified: diff -rq against the crates.io source reports only src/map.rs differs).
 #
 # 1. Warm the key-pointer cache from the full-store scan the boot already runs, so
 #    the first credential enumeration after a power-cycle is O(1) per key instead of
@@ -16,11 +16,73 @@
 #    still continues, but any other Err (a genuine read fault that could hide a live
 #    page) aborts the walk, leaving the cache dirty so fetch_item's is_dirty() guard
 #    discards the partial warm.
+# 3. Fix a torn-remove rollback (an upstream durability bug, found by the kv_durability
+#    fuzz target): remove_item_inner erased pages starting from
+#    find_first_page(PartialOpen).unwrap_or_default(), which falls back to page 0 when
+#    there is no partial-open page (the normal steady state of a closed frontier page +
+#    an open buffer page). That inverted the intended oldest-first erase order, so a
+#    power cut mid-remove erased the NEWEST copy first and left an OLDER copy live —
+#    fetch_item then returned that stale value (a rollback past the committed value).
+#    Compute the last-used page exactly the way fetch_item_with_location already does,
+#    so remove and fetch agree on which page is newest. Worth reporting upstream.
 #
 # Regenerate: diff -u <pristine 8.0.0>/src/map.rs third_party/sequential-storage/src/map.rs
 
 --- a/src/map.rs
 +++ b/src/map.rs
+@@ -636,14 +636,46 @@ impl<S: NorFlash, C: CacheImpl<K>, K: Key> MapStorage<K, S, C> {
+             self.inner.cache.invalidate_cache_state();
+         }
+
+-        // Search for the last used page. We're gonna erase from the one after this first.
+-        // If we get an early shutoff or cancellation, this will make it so that we don't return
+-        // an old version of the key on the next fetch.
+-        let last_used_page = self
++        // Search for the last used page. We're gonna erase from the one after this first,
++        // so the newest copy is erased LAST — that is what stops a torn remove from
++        // returning an old version of the key on the next fetch.
++        //
++        // RS-Key fix: upstream `find_first_page(PartialOpen).unwrap_or_default()` fell back
++        // to page 0 whenever there is no partial-open page (the normal steady state: a closed
++        // frontier page + an open buffer page). That inverted the erase order — page 0 (oldest)
++        // was scheduled LAST instead of the true newest page — so a power cut mid-remove erased
++        // the newest copy first and left an OLDER copy live, which `fetch_item` then returned
++        // (a rollback past the committed value). Compute the last used page exactly the way
++        // `fetch_item_with_location` does, so remove and fetch agree on which page is newest.
++        let mut last_used_page = self
+             .inner
+             .find_first_page(0, PageState::PartialOpen)
+-            .await?
+-            .unwrap_or_default();
++            .await?;
++        if last_used_page.is_none() {
++            if let Some(first_open_page) = self.inner.find_first_page(0, PageState::Open).await? {
++                let previous_page = self.inner.previous_page(first_open_page);
++                if self
++                    .inner
++                    .get_page_state_cached(previous_page)
++                    .await?
++                    .is_closed()
++                {
++                    last_used_page = Some(previous_page);
++                } else {
++                    // All pages are open: there are no items at all, so nothing to remove.
++                    self.inner.cache.unmark_dirty();
++                    return Ok(());
++                }
++            } else {
++                // No open pages — everything is closed. Should never happen; report corruption
++                // (the caller recovers by erasing the flash), the same as `fetch`.
++                return Err(Error::Corrupted {
++                    #[cfg(feature = "_test")]
++                    backtrace: std::backtrace::Backtrace::capture(),
++                });
++            }
++        }
++        let last_used_page = last_used_page.unwrap();
+
+         // Go through all the pages
+         for page_index in self.inner.get_pages(self.inner.next_page(last_used_page)) {
 @@ -1053,14 +1053,16 @@
          data_buffer: &'a mut [u8],
      ) -> Result<Option<(K, V)>, Error<S::Error>> {

--- a/third_party/sequential-storage/src/map.rs
+++ b/third_party/sequential-storage/src/map.rs
@@ -636,14 +636,46 @@ impl<S: NorFlash, C: CacheImpl<K>, K: Key> MapStorage<K, S, C> {
             self.inner.cache.invalidate_cache_state();
         }
 
-        // Search for the last used page. We're gonna erase from the one after this first.
-        // If we get an early shutoff or cancellation, this will make it so that we don't return
-        // an old version of the key on the next fetch.
-        let last_used_page = self
+        // Search for the last used page. We're gonna erase from the one after this first,
+        // so the newest copy is erased LAST — that is what stops a torn remove from
+        // returning an old version of the key on the next fetch.
+        //
+        // RS-Key fix: upstream `find_first_page(PartialOpen).unwrap_or_default()` fell back
+        // to page 0 whenever there is no partial-open page (the normal steady state: a closed
+        // frontier page + an open buffer page). That inverted the erase order — page 0 (oldest)
+        // was scheduled LAST instead of the true newest page — so a power cut mid-remove erased
+        // the newest copy first and left an OLDER copy live, which `fetch_item` then returned
+        // (a rollback past the committed value). Compute the last used page exactly the way
+        // `fetch_item_with_location` does, so remove and fetch agree on which page is newest.
+        let mut last_used_page = self
             .inner
             .find_first_page(0, PageState::PartialOpen)
-            .await?
-            .unwrap_or_default();
+            .await?;
+        if last_used_page.is_none() {
+            if let Some(first_open_page) = self.inner.find_first_page(0, PageState::Open).await? {
+                let previous_page = self.inner.previous_page(first_open_page);
+                if self
+                    .inner
+                    .get_page_state_cached(previous_page)
+                    .await?
+                    .is_closed()
+                {
+                    last_used_page = Some(previous_page);
+                } else {
+                    // All pages are open: there are no items at all, so nothing to remove.
+                    self.inner.cache.unmark_dirty();
+                    return Ok(());
+                }
+            } else {
+                // No open pages — everything is closed. Should never happen; report corruption
+                // (the caller recovers by erasing the flash), the same as `fetch`.
+                return Err(Error::Corrupted {
+                    #[cfg(feature = "_test")]
+                    backtrace: std::backtrace::Backtrace::capture(),
+                });
+            }
+        }
+        let last_used_page = last_used_page.unwrap();
 
         // Go through all the pages
         for page_index in self.inner.get_pages(self.inner.next_page(last_used_page)) {


### PR DESCRIPTION
Release **v0.3.9** — one durability fix since v0.3.8 (bcdDevice 0x082D).

### Fixed
- **fix(fs):** correct the vendored `sequential-storage` torn-remove page-erase order.
  `remove_item_inner` picked its erase start via `find_first_page(PartialOpen).unwrap_or_default()`,
  falling back to page 0 when there is no partial-open page (a normal steady state), which
  inverted the oldest-first erase order. A power-cut mid-delete could then erase the newest
  copy first and leave an older copy live, which the next `fetch_item` returned (a rollback
  past the committed value). The remove path now derives the newest page the same way the
  read path does. On RS-Key this was fail-closed (values are AEAD-sealed and read past a
  length/tag gate), but it is a real durability defect in the store that holds all sealed
  secrets. Upstream `sequential-storage` bug, found by the `kv_durability` fuzz target; fix
  confined to the vendored fork. Greens the `deep-checks` fuzz job.

Gate green locally (`check.sh` ALL CHECKS PASSED); crash artifact + 62686 fresh `kv_durability`
+ 27825 `power_cut` runs clean. Merge-commit (keeps signed commits + develop↔main in sync).