### PR TITLE
Release v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **`authenticatorReset` could hang the device on a heavily-provisioned key.** The
+  FIDO factory reset wiped its files with `Fs::delete`, which skips the backend
+  removal when its in-RAM present-cache reads the key as absent. A torn-migration
+  false-absent key (live in flash, present bit clear) was therefore never removed,
+  yet the reset's `for_each_key` pass — which reads the backend directly — kept
+  re-finding it, so the wipe looped forever and the authenticator wedged until a
+  power cycle (the on-device LED froze). Reset now removes each FIDO file
+  unconditionally (`Fs::force_delete`, as the trusted-display factory wipe already
+  did) and aborts on a backend error rather than retrying it, so the wipe always
+  terminates. Surfaced on a well-worn test key; a fresh key was unaffected.
+  **bcdDevice → 0x0830.**
+
 ### Security
 
 - **A `getAssertion` that matches no credential now asks for a touch before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.3.10] - 2026-07-20
+
 ### Fixed
 
 - **`authenticatorReset` could hang the device on a heavily-provisioned key.** The
@@ -1904,7 +1906,8 @@ family that keeps the "enterprise" features in the open tree.
   signature of it, and a CycloneDX SBOM. See
   [docs/releases.md](docs/releases.md) to verify a download.
 
-[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.9...HEAD
+[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.10...HEAD
+[0.3.10]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.6...v0.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Security
 
+- **A `getAssertion` that matches no credential now asks for a touch before
+  reporting "no credentials".** Previously the authenticator returned
+  `CTAP2_ERR_NO_CREDENTIALS` immediately — the CTAP 2.1 §6.2.2 reference order,
+  which lists the disclosure before the user-presence step — so anyone holding the
+  plugged-in (PIN-locked) device could probe whether a credential exists for a
+  given RP, or for a specific credential id, without any user gesture: a fast
+  `0x2e` meant "absent", a touch prompt meant "present". An interactive request
+  (`up` true) now polls the button before disclosing the miss, for both
+  discoverable and allowList lookups, matching a genuine YubiKey (which does the
+  same and passes FIDO conformance). The platform's silent `up:false` pre-flight
+  (WebAuthn / ssh-sk credential discovery) stays touch-free and still fast-fails,
+  so login latency and ssh-sk are unaffected. **bcdDevice → 0x082F.**
 - **The FIDO `pinUvAuthToken` now expires instead of living for the whole power
   cycle.** A minted PIN/UV auth token carried no usage timer (CTAP 2.1 §6.5.5.7
   was unimplemented), so once issued it stayed valid until the next reboot. It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Security
+
+- **The FIDO `pinUvAuthToken` now expires instead of living for the whole power
+  cycle.** A minted PIN/UV auth token carried no usage timer (CTAP 2.1 §6.5.5.7
+  was unimplemented), so once issued it stayed valid until the next reboot. It
+  now runs the spec's usage timer, checked before every CBOR command: a **30 s
+  rolling inactivity window** — each token-authorized command (`makeCredential`,
+  `getAssertion`, `credentialManagement`, `largeBlobs` write, `authenticatorConfig`,
+  the vendor MSE channel) pushes the deadline out — bounded by a **10-minute
+  absolute cap** from issuance that fires even under constant use. Impact was low
+  — the token is RAM-only (a reboot always cleared it), it cannot be minted
+  without the PIN, and `makeCredential`/`getAssertion` still require a fresh
+  physical touch regardless; the practical exposure was a host that had already
+  captured the token driving touch-free `credentialManagement` enumeration or
+  deletion — but a bounded lifetime closes the gap. Found comparing the FIDO
+  clientPIN state machine against the upstream lineage's own token-expiry fix.
+  **bcdDevice → 0x082E.**
+
 ## [0.3.9] - 2026-07-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   deletion — but a bounded lifetime closes the gap. Found comparing the FIDO
   clientPIN state machine against the upstream lineage's own token-expiry fix.
   **bcdDevice → 0x082E.**
+- **`rsk lock enable --key-out` no longer leaves the lock key briefly
+  world-readable.** The key file was `chmod 0600`-ed only *after* the write
+  finished and the descriptor closed, so the 32-byte host lock key (it wraps the
+  FIDO seed) sat at the umask default in between, and the `chmod` followed a
+  symlink swapped in during the window. The file is now created `0600` atomically
+  with `O_EXCL`. Host-only (`rsk` → 0.3.13); `--key-out` is a test-only flag and
+  the normal flow only prints the key to stdout, so exposure was minor.
 
 ## [0.3.9] - 2026-07-19
 

--- a/crates/rsk-fido/src/clientpin.rs
+++ b/crates/rsk-fido/src/clientpin.rs
@@ -360,7 +360,7 @@ fn issue_token<S: Storage, R: Rng>(
         ctx.state.ppaut_token
     } else {
         ctx.state.reset_pin_uv_auth_token(ctx.rng);
-        ctx.state.begin_using_token(false);
+        ctx.state.begin_using_token(false, ctx.now_ms);
         ctx.state.paut.permissions = permissions;
         match rp_id {
             Some(rp) => {

--- a/crates/rsk-fido/src/clientpin_tests.rs
+++ b/crates/rsk-fido/src/clientpin_tests.rs
@@ -1298,3 +1298,81 @@ fn pin_verify_fails_closed_when_the_retry_write_does_not_persist() {
         Err(CtapError::PinBlocked),
     );
 }
+
+// pinUvAuthToken rolling window (CTAP 2.1 §6.5.5.7): an unused token retires
+// once the inactivity window elapses, and not one tick sooner.
+#[test]
+fn pin_uv_auth_token_expires_after_inactivity_window() {
+    use crate::consts::PUAT_INITIAL_USAGE_LIMIT_MS as W;
+    let mut state = FidoState::new();
+    state.paut.permissions = crate::state::PERM_CM;
+    state.begin_using_token(false, 1_000);
+
+    // One millisecond short of the window: still live.
+    state.expire_stale_token(1_000 + W - 1);
+    assert!(state.paut.in_use);
+    assert!(state.user_verified());
+
+    // Window elapsed with no use: retired, flags/permissions cleared closed.
+    state.expire_stale_token(1_000 + W);
+    assert!(!state.paut.in_use);
+    assert_eq!(state.paut.permissions, 0);
+    assert!(!state.user_verified());
+    assert!(!state.user_present());
+}
+
+// Each use rolls the deadline forward; the token then dies one window after its
+// last use, not its issuance.
+#[test]
+fn pin_uv_auth_token_rolls_forward_on_use() {
+    use crate::consts::PUAT_INITIAL_USAGE_LIMIT_MS as W;
+    let mut state = FidoState::new();
+    state.begin_using_token(false, 0);
+
+    // Used near the end of the first window: deadline moves to (W - 5000) + W.
+    state.mark_token_used(W - 5_000);
+    state.expire_stale_token(W + 1_000); // 6000 since use < W -> alive
+    assert!(state.paut.in_use);
+
+    // Used again: deadline moves again, surviving well past 2× the window.
+    state.mark_token_used(W + 1_000);
+    state.expire_stale_token(2 * W); // 29000 since use < W -> alive
+    assert!(state.paut.in_use);
+
+    // Left idle from the last use: dies exactly one window later.
+    state.expire_stale_token(W + 1_000 + W);
+    assert!(!state.paut.in_use);
+}
+
+// The absolute lifetime cap retires the token even when it is still being used
+// inside the rolling window.
+#[test]
+fn pin_uv_auth_token_hard_capped_despite_use() {
+    use crate::consts::PUAT_MAX_USAGE_PERIOD_MS as MAX;
+    let mut state = FidoState::new();
+    state.begin_using_token(false, 0);
+
+    // A fresh use 1 s before the cap — the rolling window alone would keep it
+    // alive (since_use == 1000), but the cap from issuance retires it anyway.
+    state.mark_token_used(MAX - 1_000);
+    state.expire_stale_token(MAX);
+    assert!(!state.paut.in_use);
+}
+
+// The timer never touches an idle token, never expires early on clock wrap, and
+// mark_token_used on a not-in-use token is a no-op.
+#[test]
+fn pin_uv_auth_token_timer_ignores_idle_and_wrap() {
+    let mut state = FidoState::new();
+    state.expire_stale_token(u64::MAX);
+    assert!(!state.paut.in_use);
+
+    // `now` before issuance (clock wrap): saturating_sub -> 0, so no early expiry.
+    state.begin_using_token(false, 10_000);
+    state.expire_stale_token(0);
+    assert!(state.paut.in_use);
+
+    let mut idle = FidoState::new();
+    idle.mark_token_used(12_345);
+    assert_eq!(idle.paut.last_used_ms, 0);
+}

--- a/crates/rsk-fido/src/config.rs
+++ b/crates/rsk-fido/src/config.rs
@@ -171,6 +171,7 @@ pub fn authenticator_config<S: Storage, R: Rng>(
     {
         return Err(CtapError::PinAuthInvalid);
     }
+    ctx.state.mark_token_used(ctx.now_ms);
 
     match req.subcommand {
         CONFIG_ENABLE_EA => {

--- a/crates/rsk-fido/src/config_tests.rs
+++ b/crates/rsk-fido/src/config_tests.rs
@@ -34,7 +34,7 @@ fn armed(perms: u8) -> FidoState {
     let mut s = FidoState::new();
     s.paut.token = TOKEN;
     s.paut.permissions = perms;
-    s.begin_using_token(false);
+    s.begin_using_token(false, 0);
     s
 }
 

--- a/crates/rsk-fido/src/conformance/mod.rs
+++ b/crates/rsk-fido/src/conformance/mod.rs
@@ -149,7 +149,7 @@ impl Authr {
         let token = [0x99u8; 32];
         self.state.paut.token = token;
         self.state.paut.permissions = permissions;
-        self.state.begin_using_token(false);
+        self.state.begin_using_token(false, self.clock);
         token
     }
 

--- a/crates/rsk-fido/src/consts.rs
+++ b/crates/rsk-fido/src/consts.rs
@@ -274,6 +274,15 @@ pub const MIN_PIN_LENGTH: u8 = 4;
 #[cfg(any(feature = "fips-profile", feature = "strong-pin"))]
 pub const MIN_PIN_LENGTH: u8 = 6;
 
+/// pinUvAuthToken rolling inactivity window (CTAP 2.1 §6.5.5.7 initial usage
+/// time limit): each use of the token pushes its deadline out by this much; if
+/// the window elapses with no use, the token is retired. 30 s matches USB.
+pub const PUAT_INITIAL_USAGE_LIMIT_MS: u64 = 30_000;
+/// pinUvAuthToken absolute lifetime (CTAP 2.1 §6.5.5.7 max usage time period):
+/// the token can never outlive this from issuance, even under constant use, so
+/// it cannot linger for the whole power cycle.
+pub const PUAT_MAX_USAGE_PERIOD_MS: u64 = 600_000;
+
 // U2F authenticate control byte (P1) and flags.
 pub const U2F_AUTH_ENFORCE: u8 = 0x03; // enforce user presence and sign
 pub const U2F_AUTH_CHECK_ONLY: u8 = 0x07; // is this key handle ours?

--- a/crates/rsk-fido/src/credmgmt.rs
+++ b/crates/rsk-fido/src/credmgmt.rs
@@ -157,25 +157,28 @@ pub fn cred_mgmt<S: Storage, R: Rng>(
         return Err(CtapError::InvalidParameter);
     }
     let proto = PinProto::from_u64(req.proto).ok_or(CtapError::InvalidParameter)?;
+    let now = ctx.now_ms;
 
     match req.subcommand {
         CM_GET_CREDS_METADATA => {
-            verify_cm(
+            authorize_cm(
                 ctx.state,
                 proto,
                 &[CM_GET_CREDS_METADATA as u8],
                 param,
                 None,
+                now,
             )?;
             creds_metadata(ctx, out)
         }
         CM_ENUMERATE_RPS_BEGIN => {
-            verify_cm(
+            authorize_cm(
                 ctx.state,
                 proto,
                 &[CM_ENUMERATE_RPS_BEGIN as u8],
                 param,
                 None,
+                now,
             )?;
             enumerate_rps(ctx, true, out)
         }
@@ -189,14 +192,14 @@ pub fn cred_mgmt<S: Storage, R: Rng>(
             let mut pbuf = [0u8; 1 + MAX_RAW_SUBPARA];
             let payload =
                 payload_with_subpara(CM_ENUMERATE_CREDS_BEGIN, req.raw_subpara, &mut pbuf)?;
-            verify_cm(ctx.state, proto, payload, param, Some(&rp_id_hash))?;
+            authorize_cm(ctx.state, proto, payload, param, Some(&rp_id_hash), now)?;
             enumerate_creds(ctx, true, &rp_id_hash, out)
         }
         CM_DELETE_CREDENTIAL => {
             let cred_id = req.cred_id.ok_or(CtapError::MissingParameter)?;
             let mut pbuf = [0u8; 1 + MAX_RAW_SUBPARA];
             let payload = payload_with_subpara(CM_DELETE_CREDENTIAL, req.raw_subpara, &mut pbuf)?;
-            verify_cm(ctx.state, proto, payload, param, None)?;
+            authorize_cm(ctx.state, proto, payload, param, None, now)?;
             delete_credential(ctx, cred_id)
         }
         CM_UPDATE_USER_INFO => {
@@ -204,21 +207,23 @@ pub fn cred_mgmt<S: Storage, R: Rng>(
             let user_id = req.user_id.ok_or(CtapError::MissingParameter)?;
             let mut pbuf = [0u8; 1 + MAX_RAW_SUBPARA];
             let payload = payload_with_subpara(CM_UPDATE_USER_INFO, req.raw_subpara, &mut pbuf)?;
-            verify_cm(ctx.state, proto, payload, param, None)?;
+            authorize_cm(ctx.state, proto, payload, param, None, now)?;
             update_user(ctx, cred_id, user_id, req.user_name, req.user_display_name)
         }
         _ => Err(CtapError::InvalidParameter),
     }
 }
 
-/// Verify the pinUvAuthParam over `payload` and check the `cm` permission and
-/// rpId binding.
-fn verify_cm(
-    state: &FidoState,
+/// Verify the pinUvAuthParam over `payload`, check the `cm` permission and rpId
+/// binding, and on success refresh the token's rolling usage window. Named
+/// `authorize` (not `verify`) because that refresh mutates the usage timer.
+fn authorize_cm(
+    state: &mut FidoState,
     proto: PinProto,
     payload: &[u8],
     param: &[u8],
     rp_id_hash: Option<&[u8; 32]>,
+    now_ms: u64,
 ) -> Result<(), CtapError> {
     if !state.verify_token(proto, payload, param) || state.paut.permissions & PERM_CM == 0 {
         return Err(CtapError::PinAuthInvalid);
@@ -231,6 +236,7 @@ fn verify_cm(
             _ => return Err(CtapError::PinAuthInvalid),
         }
     }
+    state.mark_token_used(now_ms);
     Ok(())
 }
 

--- a/crates/rsk-fido/src/credmgmt_tests.rs
+++ b/crates/rsk-fido/src/credmgmt_tests.rs
@@ -37,7 +37,7 @@ fn armed(perms: u8) -> FidoState {
     let mut s = FidoState::new();
     s.paut.token = TOKEN;
     s.paut.permissions = perms;
-    s.begin_using_token(false);
+    s.begin_using_token(false, 0);
     s
 }
 

--- a/crates/rsk-fido/src/getassertion.rs
+++ b/crates/rsk-fido/src/getassertion.rs
@@ -572,6 +572,12 @@ fn get_assertion_inner<S: Storage, R: Rng>(
     resolve_credential(ctx, req, rp_id_hash, seed, uv, &mut best);
 
     if !best.any {
+        // Poll presence BEFORE disclosing no-match so the device isn't a silent
+        // credential-existence oracle (matches YubiKey; §6.2.2 discloses first, but
+        // requiring the gesture is spec-permitted). up:false pre-flight stays silent.
+        if want_up {
+            ctx.require_presence(crate::Confirm::new("Sign in?", req.rp_id.as_bytes(), &[]))?;
+        }
         return Err(CtapError::NoCredentials);
     }
 

--- a/crates/rsk-fido/src/getassertion.rs
+++ b/crates/rsk-fido/src/getassertion.rs
@@ -359,6 +359,7 @@ fn enforce_pin<S: Storage, R: Rng>(
             {
                 return Err(CtapError::PinAuthInvalid);
             }
+            ctx.state.mark_token_used(ctx.now_ms);
             // Bind an unscoped token to this rpId on first use (CTAP 2.1 §6.2.2),
             // as makeCredential does — else it stays reusable across RPs.
             if !ctx.state.paut.has_rp_id {

--- a/crates/rsk-fido/src/getassertion_tests.rs
+++ b/crates/rsk-fido/src/getassertion_tests.rs
@@ -1022,10 +1022,106 @@ fn no_matching_credentials() {
         state: &mut state,
         now_ms: 0,
     };
-    // No credentials registered, no allowList → NoCredentials.
+    // No credentials registered → NoCredentials (a touch is polled first now; the
+    // AlwaysConfirm presence auto-confirms, so the disclosed result is unchanged).
     assert_eq!(
         get_assertion(&mut ctx, &ga_request(None), &mut out),
         Err(CtapError::NoCredentials)
+    );
+}
+
+// A up:true getAssertion that matches no credential polls the button BEFORE
+// returning NoCredentials, so a plugged-in device is not a silent
+// credential-existence oracle (matches a genuine YubiKey). A declined touch
+// surfaces as OperationDenied — proving the poll ran — for both a discoverable
+// walk and an allowList miss; the silent up:false pre-flight stays touch-free and
+// still fast-fails NoCredentials (ssh-sk credential discovery).
+#[cfg(not(feature = "strict-up"))]
+#[test]
+fn no_match_polls_presence_before_disclosing() {
+    let (mut fs, mut rng) = setup();
+    let fake = [0x5Au8; CRED_RESIDENT_LEN]; // a resident-length id that matches nothing
+    let mut out = [0u8; 256];
+
+    // (A) discoverable (no allowList), up:true default → button polled → declined.
+    {
+        let mut state = crate::FidoState::new();
+        let mut presence = Decline;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 10,
+        };
+        assert_eq!(
+            get_assertion(&mut ctx, &ga_request(None), &mut out),
+            Err(CtapError::OperationDenied),
+            "discoverable no-match must poll the button before NoCredentials",
+        );
+    }
+    // (B) allowList carrying an unknown id, up:true default → same.
+    {
+        let mut state = crate::FidoState::new();
+        let mut presence = Decline;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 20,
+        };
+        assert_eq!(
+            get_assertion(&mut ctx, &ga_request(Some(&fake)), &mut out),
+            Err(CtapError::OperationDenied),
+            "allowList miss must poll the button before NoCredentials",
+        );
+    }
+    // up:false silent pre-flight: no touch polled (Decline never fires) and the
+    // fast NoCredentials is preserved.
+    {
+        let mut state = crate::FidoState::new();
+        let mut presence = Decline;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 30,
+        };
+        assert_eq!(
+            get_assertion(&mut ctx, &ga_request_up(&fake, false), &mut out),
+            Err(CtapError::NoCredentials),
+            "up:false pre-flight must stay silent and fast-fail",
+        );
+    }
+}
+
+// strict-up build: even an up:false no-match polls the button (its opt-in
+// touch-on-every-assertion), so a declined touch denies before NoCredentials.
+#[cfg(feature = "strict-up")]
+#[test]
+fn strict_up_no_match_polls_presence_even_on_up_false() {
+    let (mut fs, mut rng) = setup();
+    let fake = [0x5Au8; CRED_RESIDENT_LEN];
+    let mut out = [0u8; 256];
+    let mut state = crate::FidoState::new();
+    let mut presence = Decline;
+    let mut ctx = Ctx {
+        presence: &mut presence,
+        dev: dev(),
+        fs: &mut fs,
+        rng: &mut rng,
+        state: &mut state,
+        now_ms: 10,
+    };
+    assert_eq!(
+        get_assertion(&mut ctx, &ga_request_up(&fake, false), &mut out),
+        Err(CtapError::OperationDenied),
+        "strict-up: even an up:false no-match polls the button",
     );
 }
 

--- a/crates/rsk-fido/src/getassertion_tests.rs
+++ b/crates/rsk-fido/src/getassertion_tests.rs
@@ -144,7 +144,7 @@ fn arm_pin(fs: &mut Fs<RamStorage>, state: &mut crate::FidoState) -> [u8; 32] {
     let token = [0x99u8; 32];
     state.paut.token = token;
     state.paut.permissions = PERM_GA;
-    state.begin_using_token(false);
+    state.begin_using_token(false, 0);
     token
 }
 
@@ -1984,7 +1984,7 @@ fn reseal_credential(
     let mut state = crate::FidoState::new();
     state.paut.token = token;
     state.paut.permissions = crate::state::PERM_CM;
-    state.begin_using_token(false);
+    state.begin_using_token(false, 0);
     let req = cm_update_request(cred_id, uid, name, &token);
     let mut out = [0u8; 512];
     let mut presence = crate::AlwaysConfirm;

--- a/crates/rsk-fido/src/largeblobs.rs
+++ b/crates/rsk-fido/src/largeblobs.rs
@@ -166,6 +166,7 @@ fn write_fragment<S: Storage, R: Rng>(
     if !ctx.state.verify_token(proto, &vd, param) || ctx.state.paut.permissions & PERM_LBW == 0 {
         return Err(CtapError::PinAuthInvalid);
     }
+    ctx.state.mark_token_used(ctx.now_ms);
 
     if offset + set.len() > ctx.state.lba.expected_length {
         return Err(CtapError::InvalidParameter);

--- a/crates/rsk-fido/src/largeblobs_tests.rs
+++ b/crates/rsk-fido/src/largeblobs_tests.rs
@@ -35,7 +35,7 @@ fn armed(perms: u8) -> FidoState {
     let mut s = FidoState::new();
     s.paut.token = TOKEN;
     s.paut.permissions = perms;
-    s.begin_using_token(false);
+    s.begin_using_token(false, 0);
     s
 }
 

--- a/crates/rsk-fido/src/lib.rs
+++ b/crates/rsk-fido/src/lib.rs
@@ -181,6 +181,10 @@ pub fn process_cbor<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, data: &[u8], out: &
         return 1;
     };
 
+    // Retire a pinUvAuthToken whose usage timer has elapsed before it can
+    // authorize this command (CTAP 2.1 §6.5.5.7).
+    ctx.state.expire_stale_token(ctx.now_ms);
+
     let result = match cmd {
         consts::CTAP_GET_INFO => {
             // minPINLength / forceChangePin come from EF_MINPINLEN ([len, force]).

--- a/crates/rsk-fido/src/makecredential.rs
+++ b/crates/rsk-fido/src/makecredential.rs
@@ -448,6 +448,7 @@ fn enforce_pin<S: Storage, R: Rng>(
             {
                 return Err(CtapError::PinAuthInvalid);
             }
+            ctx.state.mark_token_used(ctx.now_ms);
             if !ctx.state.paut.has_rp_id {
                 ctx.state.paut.rp_id_hash = *rp_id_hash;
                 ctx.state.paut.has_rp_id = true;

--- a/crates/rsk-fido/src/makecredential_tests.rs
+++ b/crates/rsk-fido/src/makecredential_tests.rs
@@ -669,7 +669,7 @@ fn arm_pin(fs: &mut Fs<RamStorage>, state: &mut crate::FidoState) -> [u8; 32] {
     let token = [0x99u8; 32];
     state.paut.token = token;
     state.paut.permissions = PERM_MC | crate::state::PERM_GA;
-    state.begin_using_token(false);
+    state.begin_using_token(false, 0);
     token
 }
 

--- a/crates/rsk-fido/src/reset.rs
+++ b/crates/rsk-fido/src/reset.rs
@@ -44,7 +44,10 @@ pub fn reset<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>) -> CtapResult {
             break;
         }
         for &fid in &keys[..n] {
-            let _ = ctx.fs.delete(fid);
+            // force_delete (unconditional), not delete: a false-absent key would be
+            // skipped yet re-yielded by for_each_key every pass — an infinite loop.
+            // Propagate a backend error rather than retry it, so the wipe progresses.
+            ctx.fs.force_delete(fid).map_err(|_| CtapError::Other)?;
         }
     }
     ctx.state.reset();

--- a/crates/rsk-fido/src/reset_tests.rs
+++ b/crates/rsk-fido/src/reset_tests.rs
@@ -128,3 +128,43 @@ fn reset_aborts_without_touch() {
     // A declined touch wipes nothing.
     assert!(fs.has_data(EF_PIN));
 }
+
+#[test]
+fn reset_wipes_false_absent_credential_without_looping() {
+    // A torn-migration false-absent resident credential: live in the backend but
+    // with a clear present bit (build the store, then wrap it WITHOUT a scan). The
+    // pre-fix reset removed FIDO files with the present-cache-gated `delete`, which
+    // skipped such a key while `for_each_key` (reading the backend directly) kept
+    // re-yielding it — an infinite wipe loop that hung the device. `force_delete`
+    // removes unconditionally, so the wipe terminates. Reaching the asserts below
+    // (rather than hanging) IS the regression check.
+    let cred = EF_CRED + 3;
+    let ram = {
+        let mut seed_fs = Fs::new(RamStorage::new());
+        let mut rng = SeqRng(1);
+        ensure_seed(&dev(), &mut seed_fs, &mut rng).unwrap();
+        seed_fs.put(cred, &[0u8; 100]).unwrap();
+        seed_fs.into_storage()
+    };
+    let mut fs = Fs::new(ram); // no scan → every file, incl. the cred, is false-absent
+    let mut rng = SeqRng(2);
+    let mut state = FidoState::new();
+    {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 0,
+        };
+        reset(&mut ctx).unwrap();
+    }
+    assert!(
+        !fs.has_data(cred),
+        "reset must wipe even a false-absent credential"
+    );
+    // And it still fully re-provisions afterwards.
+    assert!(load_keydev(&dev(), &mut fs).is_some());
+}

--- a/crates/rsk-fido/src/state.rs
+++ b/crates/rsk-fido/src/state.rs
@@ -11,7 +11,10 @@ use zeroize::Zeroize;
 use rsk_crypto::pinproto::{self, PinProto, public_xy};
 
 use crate::Rng;
-use crate::consts::{MAX_CREDENTIAL_COUNT_IN_LIST, MAX_LARGE_BLOB_SIZE, MAX_RESIDENT_CREDENTIALS};
+use crate::consts::{
+    MAX_CREDENTIAL_COUNT_IN_LIST, MAX_LARGE_BLOB_SIZE, MAX_RESIDENT_CREDENTIALS,
+    PUAT_INITIAL_USAGE_LIMIT_MS, PUAT_MAX_USAGE_PERIOD_MS,
+};
 use crate::hmacsecret::{SALT_AUTH_MAX, SALT_ENC_MAX};
 
 // pinUvAuthToken permission bits.
@@ -171,6 +174,12 @@ pub struct PinUvAuthToken {
     pub has_rp_id: bool,
     pub user_present: bool,
     pub user_verified: bool,
+    /// `now_ms` when the token was issued; the absolute-lifetime cap measures
+    /// from here and never moves.
+    pub issued_at_ms: u64,
+    /// `now_ms` of the token's most recent use; the rolling inactivity window
+    /// measures from here and is pushed out by [`FidoState::mark_token_used`].
+    pub last_used_ms: u64,
 }
 
 impl PinUvAuthToken {
@@ -183,6 +192,8 @@ impl PinUvAuthToken {
             has_rp_id: false,
             user_present: false,
             user_verified: false,
+            issued_at_ms: 0,
+            last_used_ms: 0,
         }
     }
 }
@@ -311,6 +322,8 @@ impl FidoState {
         self.paut.rp_id_hash = [0; 32];
         self.paut.user_present = false;
         self.paut.user_verified = false;
+        self.paut.issued_at_ms = 0;
+        self.paut.last_used_ms = 0;
     }
 
     /// `resetPersistentPinUvAuthToken`.
@@ -319,11 +332,49 @@ impl FidoState {
         self.ppaut_permissions = 0;
     }
 
-    /// `beginUsingPinUvAuthToken`.
-    pub fn begin_using_token(&mut self, user_is_present: bool) {
+    /// `beginUsingPinUvAuthToken` — marks the token in use and starts its usage
+    /// timer at `now_ms` (CTAP 2.1 §6.5.5.7).
+    pub fn begin_using_token(&mut self, user_is_present: bool, now_ms: u64) {
         self.paut.user_present = user_is_present;
         self.paut.user_verified = true;
         self.paut.in_use = true;
+        self.paut.issued_at_ms = now_ms;
+        self.paut.last_used_ms = now_ms;
+    }
+
+    /// Refresh the rolling inactivity window after a successful token use
+    /// (CTAP 2.1 §6.5.5.7): each use defers the inactivity deadline, bounded by
+    /// the absolute [`PUAT_MAX_USAGE_PERIOD_MS`] which `issued_at_ms` still caps.
+    pub fn mark_token_used(&mut self, now_ms: u64) {
+        if self.paut.in_use {
+            self.paut.last_used_ms = now_ms;
+        }
+    }
+
+    /// `stopUsingPinUvAuthToken` — drop the in-use state, permissions, and
+    /// presence/rpId binding. The token bytes stay put; `in_use == false` and
+    /// zero permissions make every downstream check fail closed.
+    pub fn stop_using_token(&mut self) {
+        self.paut.in_use = false;
+        self.paut.permissions = 0;
+        self.paut.has_rp_id = false;
+        self.paut.rp_id_hash = [0; 32];
+        self.paut.user_present = false;
+        self.paut.user_verified = false;
+    }
+
+    /// Expire an in-use token once its usage timer has run out (CTAP 2.1
+    /// §6.5.5.7), checked before every CBOR command. Retires on either the
+    /// rolling inactivity window or the absolute lifetime cap, whichever first.
+    pub fn expire_stale_token(&mut self, now_ms: u64) {
+        if !self.paut.in_use {
+            return;
+        }
+        let since_issue = now_ms.saturating_sub(self.paut.issued_at_ms);
+        let since_use = now_ms.saturating_sub(self.paut.last_used_ms);
+        if since_issue >= PUAT_MAX_USAGE_PERIOD_MS || since_use >= PUAT_INITIAL_USAGE_LIMIT_MS {
+            self.stop_using_token();
+        }
     }
 
     /// `getUserVerifiedFlagValue` — false unless a token is in use.

--- a/crates/rsk-fido/src/vendor.rs
+++ b/crates/rsk-fido/src/vendor.rs
@@ -543,6 +543,7 @@ fn pin_gate<S: Storage, R: Rng>(ctx: &mut Ctx<S, R>, req: &Req) -> Result<(), Ct
         {
             return Err(CtapError::PinAuthInvalid);
         }
+        ctx.state.mark_token_used(ctx.now_ms);
     }
     Ok(())
 }

--- a/crates/rsk-fido/src/vendor_tests.rs
+++ b/crates/rsk-fido/src/vendor_tests.rs
@@ -743,7 +743,7 @@ const ACFG_TOKEN: [u8; 32] = [0x77; 32];
 fn arm_acfg(st: &mut FidoState) {
     st.paut.token = ACFG_TOKEN;
     st.paut.permissions = PERM_ACFG;
-    st.begin_using_token(false);
+    st.begin_using_token(false, 0);
 }
 
 /// Build a MAC'd `authenticatorConfig` vendor request

--- a/crates/rsk-fs/src/fs.rs
+++ b/crates/rsk-fs/src/fs.rs
@@ -328,6 +328,20 @@ impl<S: Storage> Fs<S> {
         Ok(())
     }
 
+    /// Delete `fid`, removing it from the backend UNCONDITIONALLY (unlike
+    /// [`delete`](Self::delete), which skips the backend when the present-cache reads
+    /// absent). A torn-migration false-absent key — live in the backend, present bit
+    /// clear — is still removed; otherwise `authenticatorReset`'s re-enumerating wipe
+    /// (it reads the backend directly) keeps re-finding it and loops forever.
+    pub fn force_delete(&mut self, fid: u16) -> Result<()> {
+        let _ = self.meta_delete(fid);
+        self.storage.remove(fid)?;
+        self.mark_absent(fid);
+        self.dynamic.retain(|&f| f != fid);
+        self.write_gen = self.write_gen.wrapping_add(1);
+        Ok(())
+    }
+
     // ---- typed key-slot API ----
     // Secret key material reaches flash only through these. They delegate to the
     // plaintext primitives, but because a [`KeyFid`] is not a `u16` and

--- a/crates/rsk-fs/src/fs_tests.rs
+++ b/crates/rsk-fs/src/fs_tests.rs
@@ -66,6 +66,30 @@ fn put_read_size() {
 }
 
 #[test]
+fn force_delete_removes_a_false_absent_key() {
+    const CRED: u16 = 0xCF05;
+    // A torn-migration false-absent key: live in the backend, present bit clear.
+    // Model it by writing through one Fs, extracting the backend, and re-wrapping
+    // WITHOUT a scan — the new Fs never learned the key is present.
+    let backend = || {
+        let mut seed = fs();
+        seed.put(CRED, &[0u8; 8]).unwrap();
+        seed.into_storage()
+    };
+
+    // delete() is gated on the (clear) present bit, so it skips the backend removal:
+    // the key survives (has_data probes the backend and finds it still there).
+    let mut a = Fs::new(backend());
+    a.delete(CRED).unwrap();
+    assert!(a.has_data(CRED), "delete skips a false-absent key");
+
+    // force_delete() removes it unconditionally.
+    let mut b = Fs::new(backend());
+    b.force_delete(CRED).unwrap();
+    assert!(!b.has_data(CRED), "force_delete removes a false-absent key");
+}
+
+#[test]
 fn factory_wipe_erases_all_but_preserved() {
     let mut fs = fs();
     fs.put(0x1080, b"pin").unwrap();

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -88,17 +88,21 @@ Most RP2350A boards work with at most a one-line change. Everything else
 
 ## Enclosures
 
-A bare board works fine, but a printed case makes it pocketable. Two community
+A bare board works fine, but a printed case makes it pocketable. Three community
 designs fit the boards above:
 
 - **[Waveshare RP2040-One / RP2350-One case](https://www.printables.com/model/1129764-waveshare-rp2040-one-and-rp2350-one-case)**
   by Patrick van der Leer. Sized for the reference board.
 - **[RP2350 USB case](https://www.printables.com/model/1248338-rp2350-usb-case)**
   by Vladimir Varzaru (a remix of Patrick's design). A slimmer USB-stick form.
+- **[Pico 2 Zero FIDO2 case (RP2350)](https://makerworld.com/en/models/2655625-pico-2-zero-fido2-case-rp2350)**
+  on MakerWorld. Fits the RP2350-Zero.
 
-Both are licensed **CC BY-SA 4.0**: print, sell, and remix them freely, as long
-as you credit the authors and keep any derivative under the same license. They
-are third-party designs, linked for convenience, not part of this project.
+The two Printables designs are licensed **CC BY-SA 4.0**: print, sell, and remix
+them freely, as long as you credit the authors and keep any derivative under the
+same license. Check the MakerWorld design's own license on its page before
+reusing it. All are third-party designs, linked for convenience, not part of
+this project.
 
 ## What the hardware does not give you
 

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -440,7 +440,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x082F;
+    let device_release: u16 = 0x0830;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -440,7 +440,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x082D;
+    let device_release: u16 = 0x082E;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -440,7 +440,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x082E;
+    let device_release: u16 = 0x082F;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/fuzz/fuzz_targets/fido_credmgmt.rs
+++ b/fuzz/fuzz_targets/fido_credmgmt.rs
@@ -81,7 +81,7 @@ fuzz_target!(|data: &[u8]| {
     let mut state = FidoState::new();
     state.paut.token = [0x99; 32];
     state.paut.permissions = PERM_CM;
-    state.begin_using_token(false);
+    state.begin_using_token(false, 0);
 
     let mut out = [0u8; 2048];
     let mut presence = rsk_fido::AlwaysConfirm;

--- a/fuzz/fuzz_targets/fido_largeblobs.rs
+++ b/fuzz/fuzz_targets/fido_largeblobs.rs
@@ -42,7 +42,7 @@ fuzz_target!(|data: &[u8]| {
     let mut state = FidoState::new();
     state.paut.token = [0x99; 32];
     state.paut.permissions = PERM_LBW;
-    state.begin_using_token(false);
+    state.begin_using_token(false, 0);
 
     let mut out = [0u8; 2048];
     let mut presence = rsk_fido::AlwaysConfirm;

--- a/fuzz/fuzz_targets/fido_session.rs
+++ b/fuzz/fuzz_targets/fido_session.rs
@@ -110,7 +110,7 @@ fuzz_target!(|data: &[u8]| {
     let mut state = FidoState::new();
     state.paut.token = [0x99; 32];
     state.paut.permissions = PERM_MC | PERM_GA | PERM_CM | PERM_LBW | PERM_ACFG | PERM_PCMR;
-    state.begin_using_token(false);
+    state.begin_using_token(false, 0);
 
     let mut presence = rsk_fido::AlwaysConfirm;
     let mut out = [0u8; 2048];

--- a/fuzz/tests/miri.rs
+++ b/fuzz/tests/miri.rs
@@ -543,7 +543,7 @@ fn miri_fido_credmgmt() {
         let mut state = FidoState::new();
         state.paut.token = [0x99; 32];
         state.paut.permissions = PERM_CM;
-        state.begin_using_token(false);
+        state.begin_using_token(false, 0);
         let mut out = [0u8; 2048];
         let mut presence = rsk_fido::AlwaysConfirm;
         let mut ctx = Ctx {
@@ -610,7 +610,7 @@ fn miri_fido_largeblobs() {
         let mut state = FidoState::new();
         state.paut.token = [0x99; 32];
         state.paut.permissions = PERM_LBW;
-        state.begin_using_token(false);
+        state.begin_using_token(false, 0);
         let mut out = [0u8; 2048];
         let mut presence = rsk_fido::AlwaysConfirm;
         let mut ctx = Ctx {
@@ -1512,7 +1512,7 @@ fn miri_fido_session() {
     let mut state = FidoState::new();
     state.paut.token = [0x99; 32];
     state.paut.permissions = PERM_MC | PERM_GA | PERM_CM | PERM_LBW | PERM_ACFG | PERM_PCMR;
-    state.begin_using_token(false);
+    state.begin_using_token(false, 0);
 
     // One session: token-armed queries, a reset mid-way, then getInfo must
     // still succeed against the wiped store.

--- a/tools/rsk/__init__.py
+++ b/tools/rsk/__init__.py
@@ -8,4 +8,4 @@ backup, secure-boot provisioning, OTP-MKEK burn/lock, FIDO management, LED confi
 OpenPGP reset, and hands-free reboot. Run from `nix develop` (the flake provides
 `rsk` on PATH and all Python deps) or as `python -m rsk`.
 """
-__version__ = "0.3.12"
+__version__ = "0.3.13"

--- a/tools/rsk/lock.py
+++ b/tools/rsk/lock.py
@@ -157,9 +157,15 @@ def cmd_enable(args):
     if args.scheme == "slip39":
         print(f"\n(any {args.threshold} of {args.shares} shares reconstruct the key)")
     if args.key_out:
-        with open(args.key_out, "w") as f:
+        # Create the file 0600 up front: chmod-after-close left a window where the
+        # lock key sat at the umask default (world-readable), and os.chmod follows
+        # a swapped-in symlink. O_EXCL refuses a pre-existing file or symlink.
+        try:
+            fd = os.open(args.key_out, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except OSError as e:
+            die(f"cannot write --key-out {args.key_out}: {e}")
+        with os.fdopen(fd, "w") as f:
             f.write(key.hex() + "\n")
-        os.chmod(args.key_out, 0o600)
         print(f"\n(key hex also written to {args.key_out})")
 
     print("""


### PR DESCRIPTION
Release v0.3.10 — four changes since v0.3.9.

**FIDO**
- `authenticatorReset` no longer wedges on a torn-migration false-absent file (bcdDevice 0x0830)
- a `getAssertion` that matches no credential now asks for a touch before disclosing the miss, matching a YubiKey (0x082F)
- the `pinUvAuthToken` now expires on the CTAP 2.1 §6.5.5.7 usage timer instead of living for the whole power cycle (0x082E)

**Host**
- `rsk lock --key-out` writes the lock key atomically at 0600

**Docs**
- MakerWorld Pico 2 Zero FIDO2 case listed under Enclosures

See CHANGELOG.md for details.