### PR TITLE
Tui build fix

### DIFF
--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -45,7 +45,8 @@ let
   rskTuiPkg = rustPlatform.buildRustPackage {
     pname = "rsk-tui";
     version = "0.1.0";
-    src = lib.cleanSource ../tools/tui;
+    src = self;
+    sourceRoot = "source/tools/tui";
     cargoLock.lockFile = ../tools/tui/Cargo.lock;
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = lib.optionals pkgs.stdenv.isLinux [


### PR DESCRIPTION
## Tui fails to build with the following error

```
       Last 21 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/bjqjsxls01w978ssgvkbba66by3h0vy3-source
       > source root is source
       > Executing cargoSetupPostUnpackHook
       > Finished cargoSetupPostUnpackHook
       > Running phase: patchPhase
       > Executing cargoSetupPostPatchHook
       > Validating consistency between /build/source/Cargo.lock and /build/cargo-vendor-dir/Cargo.lock
       > Finished cargoSetupPostPatchHook
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Running phase: buildPhase
       > Executing cargoBuildHook
       > cargoBuildHook flags: -j 4 --target x86_64-unknown-linux-gnu --offline --profile release
       > error: failed to load manifest for dependency `rsk-slip39`
       >
       > Caused by:
       >   failed to read `/crates/rsk-slip39/Cargo.toml`
       >
       > Caused by:
       >   No such file or directory (os error 2)
       For full logs, run:
```

## How it was tested

- [x] Host-only change (CLI / docs / CI) — no device behavior touched

Builds and executes locally.

I don't yet have any compatible hardware, it sees an original Yubikey though :)