### PR TITLE
Release v0.4.1

### DIFF
--- a/.github/workflows/deep-checks.yml
+++ b/.github/workflows/deep-checks.yml
@@ -64,7 +64,7 @@ concurrency:
 jobs:
   miri:
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Changed
+
+- **`ykman config usb --disable`/`--enable` now actually disables applications.**
+  The enabled-applications mask (`USB_ENABLED` in the Management DeviceConfig) used
+  to be reporting-only — a "disabled" app kept working. It is now **enforced**: a
+  disabled application's applet stops answering — PIV/OpenPGP/OATH/OTP return `6A82`
+  on CCID SELECT, FIDO2 (CBOR) and U2F (MSG) are refused over CTAPHID, and the OTP
+  keyboard goes inert (no typed tickets, no challenge-response). It takes effect
+  live (next command, no replug) and is **reversible**: the Management applet, the
+  FIDO vendor `CONFIG_WRITE`, and the OTP-HID identify/config slots are never gated,
+  so any one transport can re-enable. On the default build the admin write stays
+  ungated for ykman parity, so a hostile host can toggle applications — a reversible
+  DoS, documented in docs/threat-model.md; `--features strict-config` gates the
+  write on operator presence. **bcdDevice → 0x084A.**
+
+### Fixed
+
+- **`ykman config usb` no longer fails with `CommandRejectedError: No data` over the
+  OTP keyboard transport.** ykman/yubikit confirm an OTP-HID config write by the
+  status frame's program-sequence byte advancing; `SET_DEVICE_INFO` (and the other
+  OTP-HID admin writes) persisted the config but never bumped that counter — so on a
+  host without PC/SC, where ykman falls back from CCID to the OTP-HID transport, the
+  write was reported rejected even though it took. They now advance the sequence like
+  a slot configure. **bcdDevice → 0x084A.**
+
 ## [0.4.0] - 2026-07-22
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **FIDO: a pinUvAuthToken no longer keeps its permissions across a touch.**
+  After a user-presence-gated `makeCredential` or `getAssertion`, CTAP 2.1 §6.5.5.7
+  requires clearing the token's user-present / user-verified flags and every
+  permission except `largeBlobWrite`. RS-Key only refreshed the token's inactivity
+  timer, so a token minted with `mc|ga|acfg` could register or authenticate with one
+  touch and then run `authenticatorConfig` (`toggleAlwaysUv`,
+  `enableEnterpriseAttestation`) with **no second touch**. RS-Key now runs the full
+  §6.5.5.7 triad at every place a `makeCredential` / `getAssertion` tests presence —
+  including the `getAssertion` no-match (`NO_CREDENTIALS`) branch, which takes a real
+  anti-oracle touch. (`makeCredential`'s `up` is implicit; `getAssertion` keys on the
+  raw `up`, so a silent `up:false` pre-flight still does not consume the token.)
+  Authenticated (needs a valid PIN/UV token); reported by @cresseelia
+  (GHSA-wqjm-653g-hgw3). **bcdDevice → 0x084C.**
+
 - **`ykman otp swap` now works.** The OTP applet's SWAP (slot `0x06`) accepted only
   an empty body or RS-Key's `[a,b]` 4-slot-offset extension, but ykman/yubikit send
   the standard swap as a bare 6-byte access code (no offset bytes). RS-Key rejected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,15 +41,24 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
-- **Smart card: `SELECT` of the ISO master file (`3F00`) now answers `6D00`, the way
+- **OATH `CALCULATE ALL` no longer breaks the Yubico Authenticator (regression of the
+  unreleased issue-#44 SELECT fix).** YKOATH `CALCULATE ALL` reuses instruction byte
+  `0xA4` — the same as `SELECT` — as `00 A4 00 01 …`. The first cut of the
+  master-file-`SELECT`→`6D00` rule matched on `INS 0xA4` + `P1=0x00` and so shadowed
+  `CALCULATE ALL`, returning `6D00`; the Yubico Authenticator (which refreshes codes
+  with `CALCULATE ALL`) then failed and spun, re-connecting in a loop (the LED blinked
+  hard). The rule now keys on `P2=0x0C` (`SELECT`, no response data), which
+  `CALCULATE ALL` (`P2=0x01`) does not use. **bcdDevice → 0x0850.**
+
+- **Smart card: the master-file `SELECT` (`00 A4 00 0C …`) now answers `6D00`, the way
   a YubiKey does.** GnuPG's `scdaemon` probes a card with `SELECT 3F00` and only when
   that fails with a card error does it recognise a YubiKey and read the real serial
   from the management applet. RS-Key answered `6A88`, so `scdaemon` skipped that step:
   Kleopatra / `gpg --card-status` showed a raw serial (`0006 47537774`) instead of the
   device serial and did not surface the PIV application alongside OpenPGP. The applet
-  dispatcher now returns `6D00` for any `SELECT`-by-FID (`P1=0x00`) — RS-Key is
-  applet-only and has no master file — so the whole YubiKey code path in `scdaemon`
-  runs. Found via a live differential against a real YubiKey (issue #44).
+  dispatcher now returns `6D00` for the master-file `SELECT` (`A4 P1=0x00 P2=0x0C`) —
+  RS-Key is applet-only and has no master file — so the whole YubiKey code path in
+  `scdaemon` runs. Found via a live differential against a real YubiKey (issue #44).
   **bcdDevice → 0x084E.**
 
 - **FIDO: `makeCredential` no longer answers `excludeList` without a touch.** An

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **Smart card: `SELECT` of the ISO master file (`3F00`) now answers `6D00`, the way
+  a YubiKey does.** GnuPG's `scdaemon` probes a card with `SELECT 3F00` and only when
+  that fails with a card error does it recognise a YubiKey and read the real serial
+  from the management applet. RS-Key answered `6A88`, so `scdaemon` skipped that step:
+  Kleopatra / `gpg --card-status` showed a raw serial (`0006 47537774`) instead of the
+  device serial and did not surface the PIV application alongside OpenPGP. The applet
+  dispatcher now returns `6D00` for any `SELECT`-by-FID (`P1=0x00`) — RS-Key is
+  applet-only and has no master file — so the whole YubiKey code path in `scdaemon`
+  runs. Found via a live differential against a real YubiKey (issue #44).
+  **bcdDevice → 0x084E.**
+
 - **FIDO: `makeCredential` no longer answers `excludeList` without a touch.** An
   `excludeList` hit returned `CTAP2_ERR_CREDENTIAL_EXCLUDED` instantly, before any
   user-presence gesture, so a host holding a candidate credential id could silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-24
+
 ### Changed
 
 - **The default build's CCID ATR no longer impersonates a YubiKey.** The card's
@@ -2264,7 +2266,8 @@ family that keeps the "enterprise" features in the open tree.
   signature of it, and a CycloneDX SBOM. See
   [docs/releases.md](docs/releases.md) to verify a download.
 
-[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.10...v0.4.0
 [0.3.10]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/TheMaxMur/RS-Key/compare/v0.3.8...v0.3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **FIDO: `makeCredential` no longer answers `excludeList` without a touch.** An
+  `excludeList` hit returned `CTAP2_ERR_CREDENTIAL_EXCLUDED` instantly, before any
+  user-presence gesture, so a host holding a candidate credential id could silently
+  probe whether it is registered on the inserted key (an rpId-bound existence
+  oracle). CTAP 2.1 §6.1.2 requires the presence gesture before disclosing the
+  match; RS-Key already did this on the `getAssertion` no-match path and now does it
+  here too, spending the pinUvAuthToken on that touch. **bcdDevice → 0x084D.**
+
 - **FIDO: a pinUvAuthToken no longer keeps its permissions across a touch.**
   After a user-presence-gated `makeCredential` or `getAssertion`, CTAP 2.1 §6.5.5.7
   requires clearing the token's user-present / user-verified flags and every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Fixed
 
+- **`ykman otp swap` now works.** The OTP applet's SWAP (slot `0x06`) accepted only
+  an empty body or RS-Key's `[a,b]` 4-slot-offset extension, but ykman/yubikit send
+  the standard swap as a bare 6-byte access code (no offset bytes). RS-Key rejected
+  that frame as `WRONG_LENGTH`, so the host saw `Failed to write` / `No data`; it now
+  swaps slots 1↔2 and honours the code. Found by a full OTP-HID differential against
+  a real YubiKey — every other OTP-HID command already matched. **bcdDevice → 0x084B.**
 - **`ykman config usb` no longer fails with `CommandRejectedError: No data` over the
   OTP keyboard transport.** ykman/yubikit confirm an OTP-HID config write by the
   status frame's program-sequence byte advancing; `SET_DEVICE_INFO` (and the other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ### Changed
 
+- **The default build's CCID ATR no longer impersonates a YubiKey.** The card's
+  answer-to-reset was the YubiKey 5's ATR on every build; it is now gated on the
+  effective USB VID, exactly like the iManufacturer and OpenPGP AID. A Yubico
+  identity build (`VIDPID=Yubikey5`, or a PicoForge-repointed VID) keeps the
+  YubiKey ATR for `ykman` / `ykmd` compatibility; the default RS-Key build
+  presents an ATR with the same T=1 card capabilities but a `RS-Key`
+  historical-byte label. On Windows a default build is therefore no longer bound
+  to Yubico's `ykmd` minidriver by the "YubiKey Smart Card" ATR entry — PIV falls
+  to the inbox `msclmd` (which recognises the card by its PIV AID). **bcdDevice →
+  0x084F.**
+
 - **`ykman config usb --disable`/`--enable` now actually disables applications.**
   The enabled-applications mask (`USB_ENABLED` in the Management DeviceConfig) used
   to be reporting-only — a "disabled" app kept working. It is now **enforced**: a

--- a/crates/rsk-fido/src/getassertion.rs
+++ b/crates/rsk-fido/src/getassertion.rs
@@ -578,6 +578,12 @@ fn get_assertion_inner<S: Storage, R: Rng>(
         if want_up {
             ctx.require_presence(crate::Confirm::new("Sign in?", req.rp_id.as_bytes(), &[]))?;
         }
+        // That poll is a real presence gesture, so spend the token like the success
+        // path — a no-match ceremony must not leave an acfg token usable without a
+        // fresh touch (GHSA-wqjm-653g-hgw3). Same raw-`up` key as above.
+        if req.up {
+            ctx.state.consume_after_user_presence();
+        }
         return Err(CtapError::NoCredentials);
     }
 
@@ -668,6 +674,14 @@ fn get_assertion_inner<S: Storage, R: Rng>(
             req.rp_id.as_bytes(),
             account,
         ))?;
+    }
+
+    // Spend the pinUvAuthToken now presence was asserted (CTAP 2.1 §6.2.2 / §6.5.5.7
+    // triad; GHSA-wqjm-653g-hgw3). Keyed on the raw `up`, NOT want_up: a strict-up
+    // pre-flight (up:false) stays inert and must not consume the token, else the real
+    // assertion loses its permission.
+    if req.up {
+        ctx.state.consume_after_user_presence();
     }
 
     // authData = rpIdHash | flags([UP][,UV][,ED]) | counter [| ext] — no attestedCredentialData.

--- a/crates/rsk-fido/src/getassertion_tests.rs
+++ b/crates/rsk-fido/src/getassertion_tests.rs
@@ -215,6 +215,142 @@ fn assertion_with_pin_sets_uv_flag() {
     assert_eq!(ad[32] & FLAG_UV, FLAG_UV, "UV flag must be set");
 }
 
+// GHSA-wqjm-653g-hgw3: a getAssertion that asserts user presence must run
+// clearPinUvAuthTokenPermissionsExceptLbw (CTAP 2.1 §6.2.2 / §6.5.5.7). A token
+// armed with ga|acfg|lbw keeps only lbw after the touch, so acfg can't ride the
+// assertion into a no-touch authenticatorConfig.
+#[test]
+fn assertion_up_true_spends_token_permissions_except_lbw() {
+    let (mut fs, mut rng) = setup();
+    let mut state = crate::FidoState::new();
+    let mut out = [0u8; 1024];
+    let cred_id = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 10,
+        };
+        let n = make_credential(&mut ctx, &mc_request(false), &mut out).unwrap();
+        parse_mc(&out[..n]).0
+    };
+    let token = arm_pin(&mut fs, &mut state);
+    state.paut.permissions = PERM_GA | crate::state::PERM_ACFG | crate::state::PERM_LBW;
+    let mut param = [0u8; 32];
+    let plen = rsk_crypto::pinproto::authenticate(PinProto::Two, &token, &CDH, &mut param).unwrap();
+    let req = ga_request_pin(&cred_id, &param[..plen], 2); // `up` defaults to true
+    let mut o = [0u8; 1024];
+    {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 20,
+        };
+        get_assertion(&mut ctx, &req, &mut o).unwrap();
+    }
+    assert_eq!(
+        state.paut.permissions,
+        crate::state::PERM_LBW,
+        "only largeBlobWrite survives a UP-gated getAssertion"
+    );
+    assert!(
+        !state.user_verified(),
+        "the §6.5.5.7 triad also clears the token's user-verified flag"
+    );
+}
+
+// The nuance the fix must preserve: an up:false pre-flight (silent credential
+// discovery) tests no presence, so it must NOT spend the token — else the real
+// up:true assertion that follows on the same token loses its permission. Keyed on
+// the raw `up`, so an unconditional clear would fail here even on the default build.
+#[test]
+fn assertion_up_false_preflight_keeps_token_permissions() {
+    let (mut fs, mut rng) = setup();
+    let mut state = crate::FidoState::new();
+    let mut out = [0u8; 1024];
+    let cred_id = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 10,
+        };
+        let n = make_credential(&mut ctx, &mc_request(false), &mut out).unwrap();
+        parse_mc(&out[..n]).0
+    };
+    let _token = arm_pin(&mut fs, &mut state);
+    state.paut.permissions = PERM_GA | crate::state::PERM_ACFG;
+    let req = ga_request_up(&cred_id, false); // up:false, no pinUvAuthParam
+    let mut o = [0u8; 1024];
+    {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 20,
+        };
+        get_assertion(&mut ctx, &req, &mut o).unwrap();
+    }
+    assert_eq!(
+        state.paut.permissions,
+        PERM_GA | crate::state::PERM_ACFG,
+        "an up:false pre-flight must not spend the token"
+    );
+}
+
+// GHSA-wqjm follow-up: the getAssertion NO_CREDENTIALS branch also takes a real
+// "Sign in?" anti-oracle touch, so it must spend the token like the success path —
+// a no-match ceremony must not leave an acfg token usable without a fresh touch.
+#[test]
+fn assertion_no_match_spends_token_permissions_except_lbw() {
+    let (mut fs, mut rng) = setup();
+    let mut state = crate::FidoState::new();
+    let token = arm_pin(&mut fs, &mut state);
+    state.paut.permissions = PERM_GA | crate::state::PERM_ACFG | crate::state::PERM_LBW;
+    let mut param = [0u8; 32];
+    let plen = rsk_crypto::pinproto::authenticate(PinProto::Two, &token, &CDH, &mut param).unwrap();
+    // up:true (default) with an allowList entry that resolves to no credential → the
+    // no-match branch polls presence, then returns NoCredentials.
+    let bogus = [0x77u8; 42];
+    let req = ga_request_pin(&bogus, &param[..plen], 2);
+    let mut o = [0u8; 1024];
+    let err = {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 20,
+        };
+        get_assertion(&mut ctx, &req, &mut o).unwrap_err()
+    };
+    assert_eq!(err, CtapError::NoCredentials);
+    assert_eq!(
+        state.paut.permissions,
+        crate::state::PERM_LBW,
+        "the no-match branch spends the token too"
+    );
+    assert!(
+        !state.user_verified(),
+        "no-match branch also clears the UV flag"
+    );
+}
+
 #[test]
 fn unscoped_pin_token_binds_rpid_on_first_getassertion() {
     // A GA-capable token minted without an rpId (legacy getPinToken) must bind

--- a/crates/rsk-fido/src/makecredential.rs
+++ b/crates/rsk-fido/src/makecredential.rs
@@ -474,6 +474,12 @@ fn make_credential_inner<S: Storage, R: Rng>(
     // (a UV-required credProtect credential is invisible without UV — §12.1).
     for &id in &req.exclude[..req.exclude_len] {
         if exclude_hit(ctx.fs, seed, rp_id_hash, id, uv) {
+            // §6.1.2 requires a user-presence gesture BEFORE disclosing the match, so
+            // the device isn't a silent credential-existence oracle (matches the
+            // getAssertion no-match poll and a real YubiKey). `up` is implicit; spend
+            // the token on that touch too, so acfg can't ride it (GHSA-wqjm class).
+            ctx.require_presence(crate::Confirm::titled("Use this key?"))?;
+            ctx.state.consume_after_user_presence();
             return Err(CtapError::CredentialExcluded);
         }
     }

--- a/crates/rsk-fido/src/makecredential.rs
+++ b/crates/rsk-fido/src/makecredential.rs
@@ -561,6 +561,11 @@ fn make_credential_inner<S: Storage, R: Rng>(
         req.user_name.as_bytes(),
     ))?;
 
+    // Spend the pinUvAuthToken now the presence test passed (CTAP 2.1 §6.5.5.7
+    // triad; GHSA-wqjm-653g-hgw3). makeCredential's `up` is implicitly true; on the
+    // no-PIN path no token is in use so this is a no-op.
+    ctx.state.consume_after_user_presence();
+
     // authData = rpIdHash | flags | counter | aaguid | credIdLen | credId | COSEpubkey | ext.
     // Worst case (ML-DSA-65): AUTH_DATA_HEADER(55) + CRED_BOX_MAX(748) +
     // COSE_AKP_MLDSA65_MAX(1962) + MC_EXT_MAX(192) + clientDataHash(32) = 2989,

--- a/crates/rsk-fido/src/makecredential_tests.rs
+++ b/crates/rsk-fido/src/makecredential_tests.rs
@@ -1093,6 +1093,106 @@ fn make_credential_spends_token_permissions_except_lbw() {
     );
 }
 
+// Register a non-resident credential and return its credential id (from authData:
+// rpIdHash(32) flags(1) ctr(4) aaguid(16) credLen(2) credId …).
+fn register_and_get_cred_id(
+    fs: &mut Fs<RamStorage>,
+    rng: &mut SeqRng,
+    state: &mut crate::FidoState,
+) -> std::vec::Vec<u8> {
+    let mut out = [0u8; 1024];
+    let mut presence = crate::AlwaysConfirm;
+    let mut ctx = Ctx {
+        presence: &mut presence,
+        dev: dev(),
+        fs,
+        rng,
+        state,
+        now_ms: 1000,
+    };
+    let n = make_credential(&mut ctx, &build_request(false), &mut out).unwrap();
+    let ad = verify_response(&out[..n], &[0xCD; 32]);
+    let clen = u16::from_be_bytes([ad[53], ad[54]]) as usize;
+    ad[55..55 + clen].to_vec()
+}
+
+// §6.1.2: an excludeList hit must poll user presence BEFORE disclosing
+// CTAP2_ERR_CREDENTIAL_EXCLUDED, so the device isn't a silent credential-existence
+// oracle. A declining button therefore fails the touch (OperationDenied) instead of
+// instantly confirming the credential exists.
+#[test]
+fn excluded_makecredential_requires_touch_before_disclosing() {
+    let mut fs = Fs::new(RamStorage::new());
+    let mut rng = SeqRng(1);
+    ensure_seed(&dev(), &mut fs, &mut rng).unwrap();
+    let mut state = crate::FidoState::new();
+    let cred_id = register_and_get_cred_id(&mut fs, &mut rng, &mut state);
+    let req = mc_build(5, |e| {
+        good_params(e);
+        e.u8(5).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&cred_id).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+    });
+    let mut out = [0u8; 1024];
+    let mut presence = Decline;
+    let mut ctx = Ctx {
+        presence: &mut presence,
+        dev: dev(),
+        fs: &mut fs,
+        rng: &mut rng,
+        state: &mut state,
+        now_ms: 1000,
+    };
+    assert_eq!(
+        make_credential(&mut ctx, &req, &mut out),
+        Err(CtapError::OperationDenied),
+        "excluded makeCredential must poll presence before disclosing the match"
+    );
+}
+
+// The confirmed path still returns CREDENTIAL_EXCLUDED, and the touch spends the
+// pinUvAuthToken so a mc|acfg token can't ride an excluded registration into config.
+#[test]
+fn excluded_makecredential_confirms_then_spends_token() {
+    let mut fs = Fs::new(RamStorage::new());
+    let mut rng = SeqRng(1);
+    ensure_seed(&dev(), &mut fs, &mut rng).unwrap();
+    let mut state = crate::FidoState::new();
+    let cred_id = register_and_get_cred_id(&mut fs, &mut rng, &mut state);
+    let token = arm_pin(&mut fs, &mut state);
+    state.paut.permissions = PERM_MC | crate::state::PERM_ACFG | crate::state::PERM_LBW;
+    let cdh = [0xCDu8; 32];
+    let mut param = [0u8; 32];
+    let plen = rsk_crypto::pinproto::authenticate(PinProto::Two, &token, &cdh, &mut param).unwrap();
+    let req = mc_build(7, |e| {
+        good_params(e);
+        e.u8(5).unwrap().array(1).unwrap().map(2).unwrap();
+        e.str("id").unwrap().bytes(&cred_id).unwrap();
+        e.str("type").unwrap().str("public-key").unwrap();
+        e.u8(8).unwrap().bytes(&param[..plen]).unwrap();
+        e.u8(9).unwrap().u64(2).unwrap();
+    });
+    let mut out = [0u8; 1024];
+    let mut presence = crate::AlwaysConfirm;
+    let mut ctx = Ctx {
+        presence: &mut presence,
+        dev: dev(),
+        fs: &mut fs,
+        rng: &mut rng,
+        state: &mut state,
+        now_ms: 1000,
+    };
+    assert_eq!(
+        make_credential(&mut ctx, &req, &mut out),
+        Err(CtapError::CredentialExcluded)
+    );
+    assert_eq!(
+        state.paut.permissions,
+        crate::state::PERM_LBW,
+        "the excluded-registration touch spends the token too"
+    );
+}
+
 #[test]
 fn make_credential_requires_pin_when_set() {
     let mut fs = Fs::new(RamStorage::new());

--- a/crates/rsk-fido/src/makecredential_tests.rs
+++ b/crates/rsk-fido/src/makecredential_tests.rs
@@ -1013,6 +1013,86 @@ fn make_credential_with_pin_sets_uv_flag() {
     assert_eq!(auth_data[32] & FLAG_UV, FLAG_UV, "UV flag must be set");
 }
 
+// An authenticatorConfig/toggleAlwaysUv request MAC'd under `token` (protocol two,
+// no subCommandParams): `{1: subCommand, 3: proto, 4: pinUvAuthParam}`.
+fn config_toggle_always_uv_req(token: &[u8; 32]) -> std::vec::Vec<u8> {
+    let sub = crate::consts::CONFIG_TOGGLE_ALWAYS_UV as u8;
+    let mut vp = std::vec![0xffu8; 32];
+    vp.push(crate::consts::CTAP_CONFIG);
+    vp.push(sub);
+    let mut mac = [0u8; 32];
+    let mlen = rsk_crypto::pinproto::authenticate(PinProto::Two, token, &vp, &mut mac).unwrap();
+    let mut req = std::vec::Vec::new();
+    req.push(0xA3); // map(3)
+    req.extend_from_slice(&[0x01, sub]); // 1: subCommand
+    req.extend_from_slice(&[0x03, 0x02]); // 3: pinUvAuthProtocol = 2
+    req.push(0x04); // 4: pinUvAuthParam
+    req.push(0x58);
+    req.push(mlen as u8);
+    req.extend_from_slice(&mac[..mlen]);
+    req
+}
+
+// GHSA-wqjm-653g-hgw3: a UP-gated makeCredential must run
+// clearPinUvAuthTokenPermissionsExceptLbw (CTAP 2.1 §6.5.5.7). A token armed with
+// mc|acfg|lbw keeps only lbw after the touch, so the acfg permission can't ride the
+// registration into a no-touch authenticatorConfig.
+#[test]
+fn make_credential_spends_token_permissions_except_lbw() {
+    let mut fs = Fs::new(RamStorage::new());
+    let mut rng = SeqRng(1);
+    ensure_seed(&dev(), &mut fs, &mut rng).unwrap();
+    let mut state = crate::FidoState::new();
+    let token = arm_pin(&mut fs, &mut state);
+    state.paut.permissions = PERM_MC | crate::state::PERM_ACFG | crate::state::PERM_LBW;
+
+    let cdh = [0xCDu8; 32];
+    let mut param = [0u8; 32];
+    let plen = rsk_crypto::pinproto::authenticate(PinProto::Two, &token, &cdh, &mut param).unwrap();
+    let req = build_request_pin(&param[..plen], 2);
+    let mut out = [0u8; 1024];
+    {
+        let mut presence = crate::AlwaysConfirm;
+        let mut ctx = Ctx {
+            presence: &mut presence,
+            dev: dev(),
+            fs: &mut fs,
+            rng: &mut rng,
+            state: &mut state,
+            now_ms: 1000,
+        };
+        make_credential(&mut ctx, &req, &mut out).unwrap();
+    }
+    assert_eq!(
+        state.paut.permissions,
+        crate::state::PERM_LBW,
+        "only largeBlobWrite survives a UP-gated makeCredential"
+    );
+    assert!(
+        !state.user_verified(),
+        "the §6.5.5.7 triad also clears the token's user-verified flag"
+    );
+
+    // The behavioural consequence: authenticatorConfig over the same token is now
+    // rejected — the touch spent the acfg permission (the PoC's step 4).
+    let cfg = config_toggle_always_uv_req(&token);
+    let mut cfg_out = [0u8; 64];
+    let mut presence = crate::AlwaysConfirm;
+    let mut ctx = Ctx {
+        presence: &mut presence,
+        dev: dev(),
+        fs: &mut fs,
+        rng: &mut rng,
+        state: &mut state,
+        now_ms: 1000,
+    };
+    assert_eq!(
+        crate::config::authenticator_config(&mut ctx, &cfg, &mut cfg_out),
+        Err(CtapError::PinAuthInvalid),
+        "acfg must not ride the makeCredential touch (GHSA-wqjm-653g-hgw3)"
+    );
+}
+
 #[test]
 fn make_credential_requires_pin_when_set() {
     let mut fs = Fs::new(RamStorage::new());

--- a/crates/rsk-fido/src/state.rs
+++ b/crates/rsk-fido/src/state.rs
@@ -362,6 +362,20 @@ impl FidoState {
         }
     }
 
+    /// The CTAP 2.1 §6.5.5.7 post-user-presence triad — `clearUserPresentFlag()`,
+    /// `clearUserVerifiedFlag()`, `clearPinUvAuthTokenPermissionsExceptLbw()` — run
+    /// once a makeCredential / getAssertion user-presence test succeeds. Spends the
+    /// in-use token down to largeBlobWrite and drops its UP/UV flags so a follow-on
+    /// authenticatorConfig can't ride the touch (GHSA-wqjm-653g-hgw3). The token
+    /// stays `in_use` (lbw is deliberately retained); it retires on its usage timer.
+    pub fn consume_after_user_presence(&mut self) {
+        if self.paut.in_use {
+            self.paut.permissions &= PERM_LBW;
+            self.paut.user_present = false;
+            self.paut.user_verified = false;
+        }
+    }
+
     /// `stopUsingPinUvAuthToken` — drop the in-use state, permissions, and
     /// presence/rpId binding. The token bytes stay put; `in_use == false` and
     /// zero permissions make every downstream check fail closed.

--- a/crates/rsk-mgmt/src/lib.rs
+++ b/crates/rsk-mgmt/src/lib.rs
@@ -19,17 +19,20 @@ pub const MANAGEMENT_AID: &[u8] = &[0xA0, 0x00, 0x00, 0x05, 0x27, 0x47, 0x11, 0x
 /// all agree.
 pub const VERSION: (u8, u8, u8) = rsk_sdk::FIRMWARE_VERSION;
 
-// Capability bits.
-const CAP_OTP: u16 = 0x01;
-const CAP_U2F: u16 = 0x02;
-const CAP_OPENPGP: u16 = 0x08;
-const CAP_OATH: u16 = 0x20;
-const CAP_FIDO2: u16 = 0x200;
-const CAP_PIV: u16 = 0x10;
+// Capability bits (YubiKey `CAPABILITY.*`) — the USB_ENABLED bitmask vocabulary,
+// also the applet-gate keys the firmware maps each applet to.
+pub const CAP_OTP: u16 = 0x01;
+pub const CAP_U2F: u16 = 0x02;
+pub const CAP_OPENPGP: u16 = 0x08;
+pub const CAP_OATH: u16 = 0x20;
+pub const CAP_FIDO2: u16 = 0x200;
+pub const CAP_PIV: u16 = 0x10;
 
 /// Capabilities this firmware actually implements. Reporting only what exists
-/// keeps Yubico Authenticator from showing tabs that would error on SELECT.
-const SUPPORTED_CAPS: u16 = CAP_FIDO2 | CAP_U2F | CAP_OPENPGP | CAP_OATH | CAP_OTP | CAP_PIV;
+/// keeps Yubico Authenticator from showing tabs that would error on SELECT; it is
+/// also the ceiling a host-written USB_ENABLED is clamped to and the factory
+/// default enabled set.
+pub const SUPPORTED_CAPS: u16 = CAP_FIDO2 | CAP_U2F | CAP_OPENPGP | CAP_OATH | CAP_OTP | CAP_PIV;
 
 // DeviceInfo TLV tags.
 const TAG_USB_SUPPORTED: u8 = 0x01;
@@ -191,7 +194,59 @@ pub fn persist_dev_conf<S: Storage>(fs: &mut Fs<S>, blob: &[u8]) -> Result<(), D
     if blob.len() > EF_DEV_CONF_MAX {
         return Err(DevConfError::TooLong);
     }
-    fs.put(EF_DEV_CONF, blob).map_err(|_| DevConfError::Store)
+    fs.put(EF_DEV_CONF, blob).map_err(|_| DevConfError::Store)?;
+    // The enabled-applications set changed; the firmware reloads its cached mask
+    // (which gates applet dispatch) before the next command it guards.
+    DEV_CONF_DIRTY.store(true, core::sync::atomic::Ordering::Relaxed);
+    Ok(())
+}
+
+/// Set by [`persist_dev_conf`] on any successful write, drained by the firmware to
+/// know when to reload its cached enabled-capability mask. Same swap-to-consume
+/// latch as the device-reset request; enforcement is build-agnostic (a
+/// `strict-config` build still honours a persisted config), so this is ungated.
+static DEV_CONF_DIRTY: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+/// Take (and clear) the "enabled-applications config changed" latch.
+pub fn take_dev_conf_dirty() -> bool {
+    DEV_CONF_DIRTY.swap(false, core::sync::atomic::Ordering::Relaxed)
+}
+
+/// The enabled-applications mask from a persisted `EF_DEV_CONF` TLV blob — the
+/// `USB_ENABLED` (`0x03`) tag, clamped to [`SUPPORTED_CAPS`]. A blob without that
+/// tag, or none persisted at all, is the factory default: everything supported is
+/// enabled. Walks short-form TLVs like [`clamp_usb_enabled`]; a malformed length
+/// stops the walk (→ default), never slicing out of bounds.
+pub fn enabled_from_conf(conf: &[u8]) -> u16 {
+    let mut i = 0;
+    while i + 2 <= conf.len() {
+        let len = conf[i + 1] as usize;
+        if i + 2 + len > conf.len() {
+            break;
+        }
+        if conf[i] == TAG_USB_ENABLED && len == 2 {
+            return u16::from_be_bytes([conf[i + 2], conf[i + 3]]) & SUPPORTED_CAPS;
+        }
+        i += 2 + len;
+    }
+    SUPPORTED_CAPS
+}
+
+/// Read `EF_DEV_CONF` and return its enabled-applications mask ([`enabled_from_conf`]).
+/// The firmware caches this and re-reads it when [`take_dev_conf_dirty`] fires.
+pub fn read_enabled_caps<S: Storage>(fs: &mut Fs<S>) -> u16 {
+    let mut conf = [0u8; EF_DEV_CONF_MAX];
+    match fs.read(EF_DEV_CONF, &mut conf) {
+        Some(full) if full > 0 => enabled_from_conf(&conf[..full.min(conf.len())]),
+        _ => SUPPORTED_CAPS,
+    }
+}
+
+/// Whether an applet guarded by capability bit `cap` is enabled under `mask`.
+/// `cap == 0` marks an always-available applet (management, vendor, rescue) — the
+/// re-enable path must never be gated off, or a disable becomes irreversible.
+pub fn cap_enabled(mask: u16, cap: u16) -> bool {
+    cap == 0 || mask & cap != 0
 }
 
 impl<'a> ManagementApplet<'a> {

--- a/crates/rsk-mgmt/src/tests.rs
+++ b/crates/rsk-mgmt/src/tests.rs
@@ -351,6 +351,71 @@ fn device_reset_denied_without_presence() {
     }
 }
 
+#[test]
+fn enabled_from_conf_reads_usb_enabled_tag() {
+    // ykman `config usb --disable PIV` persists USB_ENABLED = 0x022B (everything
+    // supported minus PIV, 0x10). The parsed mask must have PIV cleared, the rest set.
+    let conf = [TAG_USB_ENABLED, 0x02, 0x02, 0x2B];
+    let mask = enabled_from_conf(&conf);
+    assert_eq!(mask, 0x022B);
+    assert!(!cap_enabled(mask, CAP_PIV));
+    assert!(cap_enabled(mask, CAP_FIDO2));
+    assert!(cap_enabled(mask, CAP_OPENPGP));
+}
+
+#[test]
+fn enabled_from_conf_defaults_to_all_supported() {
+    // No blob, or one without a USB_ENABLED tag → everything supported is enabled.
+    assert_eq!(enabled_from_conf(&[]), SUPPORTED_CAPS);
+    assert_eq!(enabled_from_conf(&[0x0C, 0x00]), SUPPORTED_CAPS);
+}
+
+#[test]
+fn enabled_from_conf_clamps_to_supported() {
+    // A mask wider than the firmware implements is clamped, mirroring READ CONFIG,
+    // so a disabled applet can never be re-enabled into an unimplemented capability.
+    let conf = [TAG_USB_ENABLED, 0x02, 0x3A, 0x3B];
+    assert_eq!(enabled_from_conf(&conf), 0x3A3B & SUPPORTED_CAPS);
+}
+
+#[test]
+fn enabled_from_conf_stops_on_malformed_length() {
+    // A length running past the blob stops the walk (→ default), never slicing OOB.
+    let conf = [TAG_USB_ENABLED, 0x05, 0x02];
+    assert_eq!(enabled_from_conf(&conf), SUPPORTED_CAPS);
+}
+
+#[test]
+fn cap_enabled_treats_zero_as_always_on() {
+    // Management/vendor/rescue map to cap 0 — the re-enable path is never gated off.
+    assert!(cap_enabled(0, 0));
+    assert!(cap_enabled(CAP_FIDO2, 0));
+    assert!(!cap_enabled(0, CAP_PIV));
+    assert!(cap_enabled(CAP_PIV, CAP_PIV));
+}
+
+#[test]
+fn read_enabled_caps_roundtrips_via_flash() {
+    let mut fs = fs();
+    assert_eq!(read_enabled_caps(&mut fs), SUPPORTED_CAPS); // absent → default
+    persist_dev_conf(&mut fs, &[TAG_USB_ENABLED, 0x02, 0x02, 0x2B]).unwrap();
+    assert_eq!(read_enabled_caps(&mut fs), 0x022B); // "disable PIV" round-trips
+}
+
+#[test]
+fn persist_dev_conf_sets_dirty_latch() {
+    // The firmware reloads its cached enabled mask when this fires. Only this test
+    // reads the latch, so a concurrent sibling's persist (also a set) can't flip the
+    // assert; the negative "take clears it" is left out to stay race-free.
+    let mut fs = fs();
+    let _ = take_dev_conf_dirty();
+    persist_dev_conf(&mut fs, &[TAG_USB_ENABLED, 0x02, 0x02, 0x2B]).unwrap();
+    assert!(
+        take_dev_conf_dirty(),
+        "a successful config write sets the latch"
+    );
+}
+
 #[cfg(not(feature = "strict-config"))]
 #[test]
 fn device_reset_signals_the_firmware_on_presence() {

--- a/crates/rsk-otp/src/lib.rs
+++ b/crates/rsk-otp/src/lib.rs
@@ -174,6 +174,27 @@ const YUBICO_CHARSET: &[u8; 45] = b"cbdefghijklnrtuvCBDEFGHIJKLNRTUV0123456789!\
 #[cfg(not(feature = "strict-config"))]
 const SCANMAP_LEN: usize = 45;
 
+/// Whether a keyboard-HID slot P1 is an OTP *function* — programming a slot
+/// (configure/update/swap) or a challenge-response — as opposed to an
+/// identify/config slot (GET SERIAL, READ/WRITE CONFIG, status, admin). When the
+/// OTP application is disabled via `ykman config usb`, the firmware takes the
+/// former inert while keeping the latter live, so the host can still read the
+/// DeviceInfo and re-enable OTP.
+pub fn is_function_slot(slot_id: u8) -> bool {
+    matches!(
+        slot_id,
+        P1_CONFIG_SLOT1
+            | P1_CONFIG_SLOT2
+            | P1_UPDATE_SLOT1
+            | P1_UPDATE_SLOT2
+            | P1_SWAP
+            | P1_CHAL_OTP_SLOT1
+            | P1_CHAL_OTP_SLOT2
+            | P1_CHAL_HMAC_SLOT1
+            | P1_CHAL_HMAC_SLOT2
+    )
+}
+
 /// "Wrong data" in this protocol is reported as `0x6700` (wrong length).
 const SW_WRONG_DATA: Sw = Sw::WRONG_LENGTH;
 
@@ -688,7 +709,14 @@ impl<'a> OtpApplet<'a> {
             return Sw::INCORRECT_PARAMS;
         }
         match rsk_mgmt::persist_dev_conf(fs, &data[1..1 + len]) {
-            Ok(()) => Sw::OK,
+            Ok(()) => {
+                // ykman/yubikit confirm an OTP-transport write by the program-
+                // sequence byte in the status frame advancing (`_is_sequence_updated`),
+                // not by any response body. Bump it like a slot configure/update/swap
+                // or `ykman config usb` fails with `CommandRejectedError: No data`.
+                self.config_seq = self.config_seq.wrapping_add(1);
+                Sw::OK
+            }
             Err(rsk_mgmt::DevConfError::TooLong) => Sw::INCORRECT_PARAMS,
             Err(rsk_mgmt::DevConfError::Store) => Sw::MEMORY_FAILURE,
         }
@@ -702,6 +730,7 @@ impl<'a> OtpApplet<'a> {
         let n = apdu.data.len().min(EF_OTP_DEVCFG_MAX);
         if n != 0 {
             let _ = fs.put(EF_OTP_DEVCFG, &apdu.data[..n]);
+            self.config_seq = self.config_seq.wrapping_add(1); // pgmSeq bump (see cmd_set_device_info)
         }
         Sw::OK
     }
@@ -715,6 +744,7 @@ impl<'a> OtpApplet<'a> {
         if n != 0 {
             let fid = if slot2 { EF_OTP_NDEF2 } else { EF_OTP_NDEF1 };
             let _ = fs.put(fid, &apdu.data[..n]);
+            self.config_seq = self.config_seq.wrapping_add(1); // pgmSeq bump (see cmd_set_device_info)
         }
         Sw::OK
     }
@@ -729,6 +759,7 @@ impl<'a> OtpApplet<'a> {
             return Sw::OK;
         }
         let _ = fs.put(EF_OTP_SCANMAP, &apdu.data[..SCANMAP_LEN]);
+        self.config_seq = self.config_seq.wrapping_add(1); // pgmSeq bump (see cmd_set_device_info)
         Sw::OK
     }
 

--- a/crates/rsk-otp/src/lib.rs
+++ b/crates/rsk-otp/src/lib.rs
@@ -495,25 +495,32 @@ impl<'a> OtpApplet<'a> {
     }
 
     /// P1 = 0x06: swap the two slots. Body layouts: empty = slots 1↔2, no code;
-    /// `[a,b]` = slots (1+a)↔(2+b); `[a,b,code0..code5]` = the same pair with a
-    /// 6-byte access code. Swapping moves/deletes stored configs, so — like
-    /// cmd_configure/cmd_update/delete (docs/guides/otp.md) — a programmed slot is
-    /// only touched when the presented code matches its stored access code; an
-    /// unprotected slot's all-zero code is satisfied by the default, so a plain
-    /// `ykman otp swap` of unprotected slots is unchanged. Out-of-range offsets
-    /// are rejected so a swap can never orphan a slot outside the 4-slot range.
+    /// `[code0..code5]` (6 bytes) = slots 1↔2 with an access code — the frame
+    /// `ykman`/yubikit actually send for `otp swap`; `[a,b]` = slots (1+a)↔(2+b);
+    /// `[a,b,code0..code5]` = that pair with a 6-byte access code. Swapping
+    /// moves/deletes stored configs, so — like cmd_configure/cmd_update/delete
+    /// (docs/guides/otp.md) — a programmed slot is only touched when the presented
+    /// code matches its stored access code; an unprotected slot's all-zero code is
+    /// satisfied by the default, so a plain `ykman otp swap` of unprotected slots
+    /// is unchanged. Out-of-range offsets are rejected so a swap can never orphan a
+    /// slot outside the 4-slot range.
     fn cmd_swap<S: Storage>(&mut self, apdu: &Apdu, fs: &mut Fs<S>, res: &mut ResBuf) -> Sw {
         let (mut fid1, mut fid2) = (EF_OTP_SLOT1, EF_OTP_SLOT2);
         let mut code = [0u8; ACC_CODE_SIZE];
-        if apdu.nc > 0 {
-            if apdu.nc != 2 && apdu.nc != 2 + ACC_CODE_SIZE {
-                return Sw::WRONG_LENGTH;
-            }
+        if apdu.nc == ACC_CODE_SIZE {
+            // The standard `ykman otp swap` frame: a bare 6-byte access code, no
+            // slot-offset bytes → swap the default slots 1↔2 with it. Missing this
+            // arm rejected the real swap as WRONG_LENGTH (ykman: "Failed to write").
+            code.copy_from_slice(&apdu.data[..ACC_CODE_SIZE]);
+        } else if apdu.nc == 2 || apdu.nc == 2 + ACC_CODE_SIZE {
+            // RS-Key's 4-slot extension: [a,b] offsets, optionally + a 6-byte code.
             fid1 += apdu.data[0] as u16;
             fid2 += apdu.data[1] as u16;
             if apdu.nc == 2 + ACC_CODE_SIZE {
                 code.copy_from_slice(&apdu.data[2..2 + ACC_CODE_SIZE]);
             }
+        } else if apdu.nc != 0 {
+            return Sw::WRONG_LENGTH;
         }
         if fid1 > EF_OTP_SLOT_LAST || fid2 > EF_OTP_SLOT_LAST {
             return Sw::INCORRECT_P1P2;

--- a/crates/rsk-otp/src/tests.rs
+++ b/crates/rsk-otp/src/tests.rs
@@ -638,6 +638,47 @@ fn hid_frame_set_device_info_round_trips_to_config() {
     );
 }
 
+#[cfg(not(feature = "strict-config"))]
+#[test]
+fn hid_frame_set_device_info_bumps_program_sequence() {
+    // ykman/yubikit confirm an OTP-transport config write by the program-sequence
+    // byte in the status frame advancing (`_is_sequence_updated`), not by a response
+    // body. Before the fix `ykman config usb` failed with CommandRejectedError("No
+    // data") because SET_DEVICE_INFO left the sequence unchanged. A real (non-empty)
+    // write must advance it exactly like a slot configure.
+    let mut fs = new_fs();
+    let presence = RefCell::new(AlwaysConfirm);
+    let rng = RefCell::new(CountRng(7));
+    let mut app = OtpApplet::new(SERIAL, SERIAL_HASH, None, &rng, &presence);
+    let seq_before = app.hid_status_frame(&mut fs)[4];
+
+    // DeviceConfig.get_bytes() for `config usb --disable PIV`: [len=4][03 02 02 2B].
+    let mut payload = [0u8; hid::PAYLOAD_SIZE];
+    payload[..5].copy_from_slice(&[0x04, 0x03, 0x02, 0x02, 0x2B]);
+    let mut out = [0u8; 64];
+    let mut res = ResBuf::new(&mut out);
+    assert_eq!(app.process_hid(0x15, &payload, &mut fs, &mut res), Sw::OK);
+    assert_eq!(
+        app.hid_status_frame(&mut fs)[4],
+        seq_before.wrapping_add(1),
+        "SET_DEVICE_INFO must advance pgmSeq so ykman sees the write"
+    );
+
+    // An empty (no-op) write must NOT bump — yubikit's benign "No data" is correct
+    // there, and a spurious bump would report a phantom config change.
+    let seq_after = app.hid_status_frame(&mut fs)[4];
+    let mut r2 = ResBuf::new(&mut out);
+    assert_eq!(
+        app.process_hid(0x15, &[0u8; hid::PAYLOAD_SIZE], &mut fs, &mut r2),
+        Sw::OK
+    );
+    assert_eq!(
+        app.hid_status_frame(&mut fs)[4],
+        seq_after,
+        "empty write is a no-op"
+    );
+}
+
 #[cfg(feature = "strict-config")]
 #[test]
 fn hid_frame_set_device_info_ignored_under_strict() {

--- a/crates/rsk-otp/src/tests.rs
+++ b/crates/rsk-otp/src/tests.rs
@@ -466,6 +466,58 @@ fn swap_moves_configs_between_slots() {
 }
 
 #[test]
+fn swap_accepts_bare_ykman_access_code_frame() {
+    // ykman/yubikit send `otp swap` as a BARE 6-byte access code (no slot-offset
+    // bytes). RS-Key rejected that nc=6 frame as WRONG_LENGTH, so the host saw
+    // "Failed to write". It must now swap slots 1<->2 and honour the code.
+    let mut fs = new_fs();
+    let presence = RefCell::new(AlwaysConfirm);
+    let rng = RefCell::new(CountRng(7));
+    let mut app = OtpApplet::new(SERIAL, SERIAL_HASH, None, &rng, &presence);
+    let key20 = [0x44; 20];
+    configure(
+        &mut app,
+        &mut fs,
+        0x01,
+        0,
+        &chalresp_config(&key20, &[0; 6], 0),
+        &[0; 6],
+    );
+
+    // The exact yubikit frame: a bare all-zero 6-byte code, no offsets.
+    let (sw, body) = run(&mut app, &mut fs, &otp_apdu(0x06, 0, &[0u8; 6]));
+    assert_eq!(sw, Sw::OK);
+    assert_eq!(body[4], CONFIG2_VALID); // moved slot 1 -> slot 2
+    let chal = [0x11; 64];
+    let (_, resp) = run(&mut app, &mut fs, &otp_apdu(0x38, 0, &chal));
+    assert_eq!(resp, hmac_sha1(&key20, &chal)); // the config genuinely moved
+}
+
+#[test]
+fn swap_bare_code_is_matched_not_ignored() {
+    // The bare-6-byte path still gates a protected slot (not a blanket accept):
+    // a wrong code is refused, the exact code allows the swap.
+    let mut fs = new_fs();
+    let presence = RefCell::new(AlwaysConfirm);
+    let rng = RefCell::new(CountRng(7));
+    let mut app = OtpApplet::new(SERIAL, SERIAL_HASH, None, &rng, &presence);
+    let acc = [9, 8, 7, 6, 5, 4];
+    configure(
+        &mut app,
+        &mut fs,
+        0x01,
+        0,
+        &chalresp_config(&[0x55; 20], &acc, 0),
+        &[0; 6],
+    );
+    assert_eq!(
+        run(&mut app, &mut fs, &otp_apdu(0x06, 0, &[1u8; 6])).0,
+        Sw::SECURITY_STATUS_NOT_SATISFIED
+    );
+    assert_eq!(run(&mut app, &mut fs, &otp_apdu(0x06, 0, &acc)).0, Sw::OK);
+}
+
+#[test]
 fn swap_refuses_protected_slot_without_access_code() {
     // run-5 (HIGH): SLOT_SWAP used to move/delete an access-code-protected slot
     // with no code — unlike configure/update — so an unauthenticated host could

--- a/crates/rsk-rescue/src/phy_kani.rs
+++ b/crates/rsk-rescue/src/phy_kani.rs
@@ -18,22 +18,41 @@ fn parse_any_input() {
     assert!(phy.enabled_usb_itf.is_some());
 }
 
-/// `serialize` then `parse` is the identity on EVERY `PhyData` — every
-/// field-presence combination, every field value, product strings up to 4
-/// bytes (the cap gates only the string copy; the TLV structure is fully
-/// covered) — modulo the one documented normalization: a missing
-/// ENABLED_USB_ITF parses as ALL. The `unwrap` doubles as proof that
-/// `PHY_MAX_SIZE` always fits the record.
-///
-/// Fields are compared one by one, the product by content: whole-struct
-/// `==` would memcmp `Product`'s full 32-byte buffer and force the unwind
-/// bound (hence every loop's unrolling) from the parser's depth to the
-/// buffer's — ~5× the solve time for a property that is an artifact of
-/// construction, not part of the wire spec.
-#[kani::proof]
-#[kani::unwind(14)]
-fn serialize_parse_roundtrip() {
+/// A symbolic present-or-absent ≤4-byte, NUL-free string. The wire format is
+/// NUL-terminated, so a stored string cannot contain NUL — parse truncates at
+/// the first one, so the harness excludes it. The cap gates only the string
+/// copy; the TLV structure (tag, length, content, terminator) is fully covered.
+fn any_product() -> Option<Product> {
     const W: usize = 4;
+    if kani::any() {
+        let raw: [u8; W] = kani::any();
+        let len: usize = kani::any();
+        kani::assume(1 <= len && len <= W);
+        for i in 0..len {
+            kani::assume(raw[i] != 0);
+        }
+        let p = Product::new(&raw[..len]);
+        assert!(p.is_some());
+        p
+    } else {
+        None
+    }
+}
+
+/// `serialize` then `parse` is the identity on every scalar-field-presence
+/// combination plus the product string. Manufacturer stays absent here — it
+/// serializes as an independent tag, so its own path is proved cheaply by
+/// [`serialize_parse_manufacturer_roundtrip`] and the both-present buffer fit
+/// by [`serialize_max_fits`], sparing this query a second symbolic string.
+///
+/// Fields are compared one by one, the product by content: whole-struct `==`
+/// would memcmp `Product`'s full 32-byte buffer and force the unwind bound
+/// from the parser's depth to the buffer's — ~5× the solve time for a property
+/// that is an artifact of construction, not the wire spec. The `unwrap`
+/// doubles as proof that `PHY_MAX_SIZE` always fits the record.
+#[kani::proof]
+#[kani::unwind(13)]
+fn serialize_parse_roundtrip() {
     let mut phy = PhyData::default();
     if kani::any() {
         phy.vid_pid = Some((kani::any(), kani::any()));
@@ -48,28 +67,7 @@ fn serialize_parse_roundtrip() {
     if kani::any() {
         phy.presence_timeout = Some(kani::any());
     }
-    if kani::any() {
-        let raw: [u8; W] = kani::any();
-        let len: usize = kani::any();
-        kani::assume(1 <= len && len <= W);
-        // The wire format is NUL-terminated, so a product string cannot
-        // contain NUL — parse truncates at the first one.
-        for i in 0..len {
-            kani::assume(raw[i] != 0);
-        }
-        phy.usb_product = Product::new(&raw[..len]);
-        assert!(phy.usb_product.is_some());
-    }
-    if kani::any() {
-        let raw: [u8; W] = kani::any();
-        let len: usize = kani::any();
-        kani::assume(1 <= len && len <= W);
-        for i in 0..len {
-            kani::assume(raw[i] != 0);
-        }
-        phy.usb_manufacturer = Product::new(&raw[..len]);
-        assert!(phy.usb_manufacturer.is_some());
-    }
+    phy.usb_product = any_product();
     if kani::any() {
         phy.enabled_curves = Some(kani::any());
     }
@@ -100,11 +98,6 @@ fn serialize_parse_roundtrip() {
         (None, None) => {}
         _ => panic!("usb_product presence changed across the roundtrip"),
     }
-    match (&got.usb_manufacturer, &phy.usb_manufacturer) {
-        (Some(g), Some(p)) => assert_eq!(g.as_bytes(), p.as_bytes()),
-        (None, None) => {}
-        _ => panic!("usb_manufacturer presence changed across the roundtrip"),
-    }
     assert_eq!(got.enabled_curves, phy.enabled_curves);
     assert_eq!(
         got.enabled_usb_itf,
@@ -113,6 +106,63 @@ fn serialize_parse_roundtrip() {
     assert_eq!(got.led_driver, phy.led_driver);
     assert_eq!(got.led_order, phy.led_order);
     assert_eq!(got.led_num, phy.led_num);
+    assert!(got.usb_manufacturer.is_none());
+}
+
+/// The manufacturer TLV — the field added this cycle — roundtrips on its own.
+/// It serializes as an independent tag, so it needs no scalar-presence base
+/// (that combinatorial cost lives once, in [`serialize_parse_roundtrip`],
+/// whose multi-TLV adjacency already exercises the walker); this harness only
+/// proves the new tag's own serialize/parse path, so it stays cheap.
+#[kani::proof]
+#[kani::unwind(13)]
+fn serialize_parse_manufacturer_roundtrip() {
+    let mut phy = PhyData::default();
+    phy.usb_manufacturer = any_product();
+
+    let mut buf = [0u8; PHY_MAX_SIZE];
+    let n = phy.serialize(&mut buf).unwrap();
+
+    let got = PhyData::parse(&buf[..n]);
+    match (&got.usb_manufacturer, &phy.usb_manufacturer) {
+        (Some(g), Some(p)) => assert_eq!(g.as_bytes(), p.as_bytes()),
+        (None, None) => {}
+        _ => panic!("usb_manufacturer presence changed across the roundtrip"),
+    }
+    assert!(got.usb_product.is_none());
+}
+
+/// The worst case for buffer sizing — every field present, BOTH strings at
+/// the 4-byte cap — still serializes within `PHY_MAX_SIZE`. String lengths are
+/// fixed (only content is symbolic) so this stays a cheap serialize-only query;
+/// the roundtrip proofs carry at most one symbolic string each, so this is
+/// where the both-present fit bound is checked.
+#[kani::proof]
+#[kani::unwind(14)]
+fn serialize_max_fits() {
+    const W: usize = 4;
+    let a: [u8; W] = kani::any();
+    let b: [u8; W] = kani::any();
+    for i in 0..W {
+        kani::assume(a[i] != 0);
+        kani::assume(b[i] != 0);
+    }
+    let mut phy = PhyData::default();
+    phy.vid_pid = Some((kani::any(), kani::any()));
+    phy.led_gpio = Some(kani::any());
+    phy.led_brightness = Some(kani::any());
+    phy.opts = kani::any();
+    phy.presence_timeout = Some(kani::any());
+    phy.enabled_curves = Some(kani::any());
+    phy.enabled_usb_itf = Some(kani::any());
+    phy.led_driver = Some(kani::any());
+    phy.led_order = Some(kani::any());
+    phy.led_num = Some(kani::any());
+    phy.usb_product = Product::new(&a);
+    phy.usb_manufacturer = Product::new(&b);
+
+    let mut buf = [0u8; PHY_MAX_SIZE];
+    assert!(phy.serialize(&mut buf).is_some());
 }
 
 /// `overlay` over any base record and any ≤12-byte host blob never panics or

--- a/crates/rsk-sdk/src/applet.rs
+++ b/crates/rsk-sdk/src/applet.rs
@@ -270,6 +270,15 @@ impl Dispatcher {
             };
         }
 
+        // A YubiKey-class card is applet-only — no ISO master file — so a SELECT
+        // by FID/path (P1=0x00, e.g. GnuPG scdaemon's `SELECT 3F00` probe) is
+        // unsupported. Answering 6D00 like a real YubiKey lets scdaemon recognise
+        // the device and read its serial from the management applet; on any other
+        // status word it skips that and shows a raw serial (issue #44).
+        if apdu.ins == 0xA4 && apdu.p1 == 0x00 {
+            return Sw::INS_NOT_SUPPORTED;
+        }
+
         // Dispatch to the selected applet (unless it was disabled since SELECT).
         match self.current {
             Some(i) if self.selectable(i) => {

--- a/crates/rsk-sdk/src/applet.rs
+++ b/crates/rsk-sdk/src/applet.rs
@@ -115,6 +115,10 @@ pub struct Dispatcher {
     pending_len: usize,
     pending_off: usize,
     pending_sw: Sw,
+    /// Bit `i` set → applet index `i` is selectable; cleared → invisible. Set by
+    /// [`Self::set_enabled`] from the persisted enabled-applications config;
+    /// defaults to all-active so callers that never restrict are unaffected.
+    enabled: u32,
 }
 
 impl Default for Dispatcher {
@@ -134,12 +138,28 @@ impl Dispatcher {
             pending_len: 0,
             pending_off: 0,
             pending_sw: Sw::OK,
+            enabled: u32::MAX,
         }
     }
 
     /// Index of the currently selected applet, if any.
     pub fn current(&self) -> Option<usize> {
         self.current
+    }
+
+    /// Restrict which registered applets are selectable: bit `i` set → applet
+    /// index `i` is active; cleared → invisible (SELECT and any command to it
+    /// return `FILE_NOT_FOUND`, exactly as if it were not registered). Indices
+    /// `≥ 32` are always active. The firmware sets this from the persisted
+    /// enabled-applications config, so `ykman config usb --disable X` really
+    /// removes X's applet rather than only hiding it from the DeviceInfo report.
+    pub fn set_enabled(&mut self, mask: u32) {
+        self.enabled = mask;
+    }
+
+    /// Whether applet index `i` is currently active (see [`Self::set_enabled`]).
+    fn selectable(&self, i: usize) -> bool {
+        i >= 32 || self.enabled & (1 << i) != 0
     }
 
     /// Drop any selected applet. Used when a fresh logical session begins (a
@@ -214,11 +234,10 @@ impl Dispatcher {
                 ne: apdu.ne,
                 data: &self.chain[..total],
             };
-            let chain_ok = self
-                .current
-                .map(|i| applets[i].response_chaining())
-                .unwrap_or(false);
-            let sw = match self.current {
+            // A disabled current applet is unreachable, like a dropped selection.
+            let cur = self.current.filter(|&i| self.selectable(i));
+            let chain_ok = cur.map(|i| applets[i].response_chaining()).unwrap_or(false);
+            let sw = match cur {
                 Some(i) => applets[i].process(&combined, ctx, res),
                 None => Sw::FILE_NOT_FOUND,
             };
@@ -227,11 +246,12 @@ impl Dispatcher {
             return self.maybe_chain(sw, apdu.ne, chain_ok, res);
         }
 
-        // SELECT by AID.
+        // SELECT by AID. A disabled applet is skipped, so its AID matches nothing
+        // (→ FILE_NOT_FOUND) just as if it were never registered.
         if apdu.ins == 0xA4 && apdu.p1 == 0x04 && (apdu.p2 == 0x00 || apdu.p2 == 0x04) {
-            let found = applets.iter().position(|app| {
+            let found = applets.iter().enumerate().position(|(i, app)| {
                 let aid = app.aid();
-                apdu.data.len() >= aid.len() && &apdu.data[..aid.len()] == aid
+                self.selectable(i) && apdu.data.len() >= aid.len() && &apdu.data[..aid.len()] == aid
             });
             return match found {
                 Some(i) => {
@@ -250,14 +270,14 @@ impl Dispatcher {
             };
         }
 
-        // Dispatch to the selected applet.
+        // Dispatch to the selected applet (unless it was disabled since SELECT).
         match self.current {
-            Some(i) => {
+            Some(i) if self.selectable(i) => {
                 let chain_ok = applets[i].response_chaining();
                 let sw = applets[i].process(&apdu, ctx, res);
                 self.maybe_chain(sw, apdu.ne, chain_ok, res)
             }
-            None => Sw::FILE_NOT_FOUND,
+            _ => Sw::FILE_NOT_FOUND,
         }
     }
 

--- a/crates/rsk-sdk/src/applet.rs
+++ b/crates/rsk-sdk/src/applet.rs
@@ -270,12 +270,12 @@ impl Dispatcher {
             };
         }
 
-        // A YubiKey-class card is applet-only — no ISO master file — so a SELECT
-        // by FID/path (P1=0x00, e.g. GnuPG scdaemon's `SELECT 3F00` probe) is
-        // unsupported. Answering 6D00 like a real YubiKey lets scdaemon recognise
-        // the device and read its serial from the management applet; on any other
-        // status word it skips that and shows a raw serial (issue #44).
-        if apdu.ins == 0xA4 && apdu.p1 == 0x00 {
+        // The master-file SELECT (`00 A4 00 0C …`, GnuPG scdaemon's `3F00` probe)
+        // must answer 6D00 like a YubiKey, or scdaemon skips its YubiKey detection
+        // and shows a raw serial (issue #44). Key on P2=0x0C (SELECT, no response
+        // data): INS 0xA4 is overloaded — OATH reuses it for CALCULATE ALL
+        // (`A4 p1=00 p2=01`), which must still reach the applet, not be shadowed.
+        if apdu.ins == 0xA4 && apdu.p1 == 0x00 && apdu.p2 == 0x0C {
             return Sw::INS_NOT_SUPPORTED;
         }
 

--- a/crates/rsk-sdk/src/applet_tests.rs
+++ b/crates/rsk-sdk/src/applet_tests.rs
@@ -239,6 +239,59 @@ fn select_by_fid_is_unsupported_like_a_yubikey() {
     assert_eq!(disp.current(), Some(0));
 }
 
+// Models the OATH applet: INS 0xA4 is CALCULATE ALL (its own command, `p1=0 p2=1`),
+// NOT a SELECT. The first cut of the issue-#44 fix blanket-shadowed `A4 p1=0` and
+// wrongly returned 6D00 here, breaking OATH calculate-all (Yubico Authenticator).
+struct Oathish;
+impl Applet<()> for Oathish {
+    fn aid(&self) -> &'static [u8] {
+        &[0xA0, 0x00, 0x00, 0x05, 0x27, 0x21, 0x01]
+    }
+    fn select(&mut self, _reselect: bool, _ctx: &mut (), _res: &mut ResBuf) -> Sw {
+        Sw::OK
+    }
+    fn process(&mut self, apdu: &Apdu, _ctx: &mut (), res: &mut ResBuf) -> Sw {
+        if apdu.ins == 0xA4 && apdu.p1 == 0x00 && apdu.p2 == 0x01 {
+            res.push(0x99); // a CALCULATE ALL response body
+            Sw::OK
+        } else {
+            Sw::INS_NOT_SUPPORTED
+        }
+    }
+}
+
+#[test]
+fn oath_calculate_all_is_not_shadowed_by_the_select_mf_rule() {
+    // INS 0xA4 is overloaded: OATH CALCULATE ALL is `00 A4 00 01 …`. The SELECT-MF
+    // 6D00 rule (issue #44) keys on P2=0x0C, so CALCULATE ALL (P2=0x01) still
+    // reaches the applet — a regression guard for the Yubico Authenticator.
+    let mut app = Oathish;
+    let mut applets: [&mut dyn Applet<()>; 1] = [&mut app];
+    let mut disp = Dispatcher::new();
+    let mut out = [0u8; 16];
+    let mut res = ResBuf::new(&mut out);
+
+    let sel = [
+        0x00, 0xA4, 0x04, 0x00, 0x07, 0xA0, 0x00, 0x00, 0x05, 0x27, 0x21, 0x01,
+    ];
+    assert_eq!(disp.process(&sel, &mut applets, &mut (), &mut res), Sw::OK);
+
+    // CALCULATE ALL (A4 p1=00 p2=01) routes to the applet.
+    let calc_all = [0x00, 0xA4, 0x00, 0x01, 0x02, 0x74, 0x00];
+    assert_eq!(
+        disp.process(&calc_all, &mut applets, &mut (), &mut res),
+        Sw::OK
+    );
+    assert_eq!(res.as_slice(), &[0x99]);
+
+    // But the master-file SELECT (P2=0x0C) is still shadowed with 6D00.
+    let sel_mf = [0x00, 0xA4, 0x00, 0x0C, 0x02, 0x3F, 0x00];
+    assert_eq!(
+        disp.process(&sel_mf, &mut applets, &mut (), &mut res),
+        Sw::INS_NOT_SUPPORTED
+    );
+}
+
 // Returns `body_len` bytes (value = index & 0xFF) for GET DATA (INS 0xCA);
 // `chain` toggles opt-in to dispatcher response chaining.
 struct Chunky {

--- a/crates/rsk-sdk/src/applet_tests.rs
+++ b/crates/rsk-sdk/src/applet_tests.rs
@@ -179,6 +179,66 @@ fn select_unknown_aid() {
     );
 }
 
+// Mimics OpenPGP/PIV: a current applet whose own SELECT handler answers a
+// non-6D00 status (6A88, exactly as OpenPGP's `cmd_select` does) for a SELECT it
+// does not recognise. Used to prove the dispatcher shadows it on a by-FID SELECT.
+struct PickySelect;
+impl Applet<()> for PickySelect {
+    fn aid(&self) -> &'static [u8] {
+        &[0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x03]
+    }
+    fn select(&mut self, _reselect: bool, _ctx: &mut (), _res: &mut ResBuf) -> Sw {
+        Sw::OK
+    }
+    fn process(&mut self, apdu: &Apdu, _ctx: &mut (), _res: &mut ResBuf) -> Sw {
+        if apdu.ins == 0xA4 {
+            Sw::REFERENCE_NOT_FOUND // 6A88 — what OpenPGP returns for a foreign SELECT
+        } else {
+            Sw::INS_NOT_SUPPORTED
+        }
+    }
+}
+
+#[test]
+fn select_by_fid_is_unsupported_like_a_yubikey() {
+    // GnuPG scdaemon probes a card with `SELECT 3F00` (P1=0x00, select the ISO
+    // master file). A real YubiKey answers 6D00, which is the trigger for scdaemon
+    // to recognise it and read its serial from the management applet. RS-Key is
+    // applet-only (no MF), so the dispatcher must answer 6D00 *before* dispatch —
+    // otherwise the current applet (OpenPGP) returns 6A88 and scdaemon shows a raw
+    // serial and drops PIV (issue #44).
+    let mut app = PickySelect;
+    let mut applets: [&mut dyn Applet<()>; 1] = [&mut app];
+    let mut disp = Dispatcher::new();
+    let mut out = [0u8; 16];
+    let mut res = ResBuf::new(&mut out);
+
+    // 00 A4 00 0C 02 3F 00 — SELECT the master file by FID.
+    let sel_mf = [0x00, 0xA4, 0x00, 0x0C, 0x02, 0x3F, 0x00];
+
+    // Answered 6D00 even with no applet selected.
+    assert_eq!(
+        disp.process(&sel_mf, &mut applets, &mut (), &mut res),
+        Sw::INS_NOT_SUPPORTED
+    );
+
+    // Select the applet by AID (P1=0x04 still works), then probe by FID: the
+    // dispatcher shadows the applet's 6A88 with 6D00.
+    let sel_aid = [
+        0x00, 0xA4, 0x04, 0x00, 0x08, 0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x03,
+    ];
+    assert_eq!(
+        disp.process(&sel_aid, &mut applets, &mut (), &mut res),
+        Sw::OK
+    );
+    assert_eq!(
+        disp.process(&sel_mf, &mut applets, &mut (), &mut res),
+        Sw::INS_NOT_SUPPORTED
+    );
+    // The by-AID selection survives — the FID probe did not deselect it.
+    assert_eq!(disp.current(), Some(0));
+}
+
 // Returns `body_len` bytes (value = index & 0xFF) for GET DATA (INS 0xCA);
 // `chain` toggles opt-in to dispatcher response chaining.
 struct Chunky {

--- a/crates/rsk-sdk/src/applet_tests.rs
+++ b/crates/rsk-sdk/src/applet_tests.rs
@@ -385,6 +385,67 @@ fn extended_le_response_is_not_chained() {
 }
 
 #[test]
+fn set_enabled_hides_a_disabled_applet() {
+    // A cleared enable bit makes an applet invisible: its AID matches nothing on
+    // SELECT (FILE_NOT_FOUND), exactly as `ykman config usb --disable X` intends,
+    // while its still-enabled neighbour selects and dispatches normally.
+    let mut echo = Echo { selected: false }; // index 0
+    let mut chunk = Chunky {
+        body_len: 3,
+        chain: false,
+    }; // index 1
+    let mut applets: [&mut dyn Applet<()>; 2] = [&mut echo, &mut chunk];
+    let mut disp = Dispatcher::new();
+    let mut out = [0u8; 64];
+    let mut res = ResBuf::new(&mut out);
+
+    disp.set_enabled(0b10); // disable index 0 (Echo), keep index 1 (Chunky)
+
+    let mut sel0 = vec![0x00, 0xA4, 0x04, 0x00, 0x08];
+    sel0.extend_from_slice(&[0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x01]);
+    assert_eq!(
+        disp.process(&sel0, &mut applets, &mut (), &mut res),
+        Sw::FILE_NOT_FOUND
+    );
+    assert_eq!(disp.current(), None);
+
+    let sel1 = [
+        0x00, 0xA4, 0x04, 0x00, 0x08, 0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x02,
+    ];
+    assert_eq!(disp.process(&sel1, &mut applets, &mut (), &mut res), Sw::OK);
+    assert_eq!(disp.current(), Some(1));
+
+    // Re-enable Echo and confirm it selects again — a disable is reversible.
+    disp.set_enabled(u32::MAX);
+    assert_eq!(disp.process(&sel0, &mut applets, &mut (), &mut res), Sw::OK);
+    assert_eq!(disp.current(), Some(0));
+}
+
+#[test]
+fn disabling_the_current_applet_makes_it_unreachable() {
+    // The contrived window: an applet is selected, then disabled before its next
+    // command (config changed over another transport). Dispatch-to-current
+    // re-checks the enable bit, so the command finds nothing.
+    let mut echo = Echo { selected: false };
+    let mut applets: [&mut dyn Applet<()>; 1] = [&mut echo];
+    let mut disp = Dispatcher::new();
+    let mut out = [0u8; 64];
+    let mut res = ResBuf::new(&mut out);
+
+    let mut sel = vec![0x00, 0xA4, 0x04, 0x00, 0x08];
+    sel.extend_from_slice(&[0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x01]);
+    assert_eq!(disp.process(&sel, &mut applets, &mut (), &mut res), Sw::OK);
+    assert_eq!(disp.current(), Some(0));
+
+    disp.set_enabled(0); // disabled since SELECT
+    let cmd = [0x00, 0x10, 0x00, 0x00, 0x03, 0xDE, 0xAD, 0xBE];
+    assert_eq!(
+        disp.process(&cmd, &mut applets, &mut (), &mut res),
+        Sw::FILE_NOT_FOUND
+    );
+}
+
+#[test]
 fn opt_out_applet_is_never_chained() {
     let mut c = Chunky {
         body_len: 269,

--- a/crates/rsk-usb/src/ccid.rs
+++ b/crates/rsk-usb/src/ccid.rs
@@ -75,10 +75,23 @@ pub const MAX_CCID_MSG: usize = 2048;
 /// the `is_multiple_of` modulus and the endpoint allocations in lockstep.
 const EP_PACKET_SIZE: usize = 64;
 
-/// ATR for the FIDO card.
-pub const ATR_FIDO: &[u8] = &[
+/// ATR presented on the Yubico-identity build (effective VID == Yubico): a real
+/// YubiKey 5's answer-to-reset, byte-for-byte, so `ykman`/`ykmd` and the Windows
+/// "YubiKey Smart Card" minidriver treat the card exactly like a YubiKey. The
+/// historical bytes carry a card-capabilities compact-TLV + the "YubiKey" label.
+pub const ATR_YUBIKEY: &[u8] = &[
     0x3b, 0xfd, 0x13, 0x00, 0x00, 0x81, 0x31, 0xfe, 0x15, 0x80, 0x73, 0xc0, 0x21, 0xc0, 0x57, 0x59,
     0x75, 0x62, 0x69, 0x4b, 0x65, 0x79, 0x40,
+];
+
+/// ATR presented on the default RS-Key build (non-Yubico VID): identical T=1 card
+/// capabilities to [`ATR_YUBIKEY`], but the historical-byte label is "RS-Key", not
+/// "YubiKey" — the card does not impersonate a YubiKey when it is not carrying the
+/// Yubico USB identity (mirrors the VID-gated iManufacturer / OpenPGP AID). The
+/// last byte is the recomputed TCK (XOR checksum over T0..historical bytes).
+pub const ATR_RSKEY: &[u8] = &[
+    0x3b, 0xfc, 0x13, 0x00, 0x00, 0x81, 0x31, 0xfe, 0x15, 0x80, 0x73, 0xc0, 0x21, 0xc0, 0x56, 0x52,
+    0x53, 0x2d, 0x4b, 0x65, 0x79, 0x4b,
 ];
 
 /// T=1 parameters returned for Get/Set/Reset Parameters (`bmFindexDindex,
@@ -246,7 +259,7 @@ pub struct Ccid<'d, D: Driver<'d>, H: ApduHandler> {
 impl<'d, D: Driver<'d>, H: ApduHandler> Ccid<'d, D, H> {
     /// Allocate the CCID interface (class 0x0B, 3 endpoints: bulk OUT, bulk IN,
     /// interrupt IN) on `builder` and build the transport. `atr` is the card's
-    /// answer-to-reset (e.g. [`ATR_FIDO`]). `pin_support` sets the descriptor's
+    /// answer-to-reset (e.g. [`ATR_YUBIKEY`]). `pin_support` sets the descriptor's
     /// `bPINSupport` byte: `0x00` (no pinpad) on a standard build, `0x01` (VERIFY)
     /// on a display build so a host driver drives on-device PIN entry. Every host
     /// CCID stack reads this byte straight from the descriptor; it is the single

--- a/crates/rsk-usb/src/ccid_tests.rs
+++ b/crates/rsk-usb/src/ccid_tests.rs
@@ -17,11 +17,28 @@ fn msg(msg_type: u8, seq: u8, payload: &[u8]) -> Vec<u8> {
 }
 
 #[test]
+fn atr_identities_are_well_formed() {
+    // A T=1 ATR ends with a TCK: the XOR of every byte after TS (T0..TCK) is 0.
+    // Guard it for both — ATR_RSKEY is hand-derived from ATR_YUBIKEY (relabelled
+    // "RS-Key", checksum recomputed), so a typo would ship a malformed ATR.
+    for atr in [ATR_YUBIKEY, ATR_RSKEY] {
+        assert_eq!(atr[1..].iter().fold(0u8, |a, &b| a ^ b), 0, "bad TCK");
+    }
+    // Identical protocol / card-capability bytes (only the historical label plus
+    // the K length and TCK differ), so a host negotiates T=1 the same on either.
+    assert_eq!(&ATR_YUBIKEY[2..14], &ATR_RSKEY[2..14]);
+    // The default build carries the "RS-Key" label and never the "YubiKey" one.
+    assert!(ATR_RSKEY.windows(6).any(|w| w == b"RS-Key"));
+    assert!(ATR_RSKEY.windows(7).all(|w| w != b"YubiKey"));
+    assert!(ATR_YUBIKEY.windows(7).any(|w| w == b"YubiKey"));
+}
+
+#[test]
 fn slot_status_returns_ret_with_status() {
     let mut status = STATUS_INACTIVE;
     let mut out = [0u8; 64];
     let m = msg(CCID_SLOT_STATUS, 7, &[]);
-    let n = process_message(&m, ATR_FIDO, &mut status, &mut out);
+    let n = process_message(&m, ATR_YUBIKEY, &mut status, &mut out);
     assert_eq!(n, 10);
     assert_eq!(out[0], CCID_SLOT_STATUS_RET);
     assert_eq!(&out[1..5], &[0, 0, 0, 0]); // dwLength 0
@@ -34,15 +51,15 @@ fn power_on_returns_atr_and_activates() {
     let mut status = STATUS_INACTIVE;
     let mut out = [0u8; 64];
     let m = msg(CCID_POWER_ON, 1, &[]);
-    let n = process_message(&m, ATR_FIDO, &mut status, &mut out);
-    assert_eq!(n, 10 + ATR_FIDO.len());
+    let n = process_message(&m, ATR_YUBIKEY, &mut status, &mut out);
+    assert_eq!(n, 10 + ATR_YUBIKEY.len());
     assert_eq!(out[0], CCID_DATA_BLOCK_RET);
     assert_eq!(
         u32::from_le_bytes([out[1], out[2], out[3], out[4]]),
-        ATR_FIDO.len() as u32
+        ATR_YUBIKEY.len() as u32
     );
     assert_eq!(out[7], STATUS_ACTIVE);
-    assert_eq!(&out[10..10 + ATR_FIDO.len()], ATR_FIDO);
+    assert_eq!(&out[10..10 + ATR_YUBIKEY.len()], ATR_YUBIKEY);
     assert_eq!(status, STATUS_ACTIVE); // slot now powered
 }
 
@@ -51,7 +68,7 @@ fn power_off_deactivates() {
     let mut status = STATUS_ACTIVE;
     let mut out = [0u8; 64];
     let m = msg(CCID_POWER_OFF, 2, &[]);
-    let n = process_message(&m, ATR_FIDO, &mut status, &mut out);
+    let n = process_message(&m, ATR_YUBIKEY, &mut status, &mut out);
     assert_eq!(n, 10);
     assert_eq!(out[0], CCID_SLOT_STATUS_RET);
     assert_eq!(out[7], STATUS_INACTIVE);
@@ -64,7 +81,7 @@ fn get_params_returns_t1() {
     let mut out = [0u8; 64];
     for ty in [CCID_GET_PARAMS, CCID_SET_PARAMS, CCID_RESET_PARAMS] {
         let m = msg(ty, 3, &[]);
-        let n = process_message(&m, ATR_FIDO, &mut status, &mut out);
+        let n = process_message(&m, ATR_YUBIKEY, &mut status, &mut out);
         assert_eq!(n, 17);
         assert_eq!(out[0], CCID_PARAMS_RET);
         assert_eq!(out[9], 0x01); // T=1
@@ -77,7 +94,7 @@ fn set_rate_returns_eight_zeros() {
     let mut status = STATUS_ACTIVE;
     let mut out = [0u8; 64];
     let m = msg(CCID_SET_RATE, 4, &[]);
-    let n = process_message(&m, ATR_FIDO, &mut status, &mut out);
+    let n = process_message(&m, ATR_YUBIKEY, &mut status, &mut out);
     assert_eq!(n, 18);
     assert_eq!(out[0], CCID_SET_RATE_RET);
     assert_eq!(&out[10..18], &[0u8; 8]);
@@ -92,7 +109,7 @@ fn xfr_block_located_and_framed() {
     let m = msg(CCID_XFR_BLOCK, 5, &apdu);
     let mut status = STATUS_ACTIVE;
     let mut out = [0u8; 64];
-    assert_eq!(process_message(&m, ATR_FIDO, &mut status, &mut out), 0);
+    assert_eq!(process_message(&m, ATR_YUBIKEY, &mut status, &mut out), 0);
 
     let (a, b) = xfr_apdu(&m).expect("xfr apdu range");
     assert_eq!(&m[a..b], &apdu);
@@ -141,7 +158,7 @@ fn unknown_type_no_response() {
     let mut status = STATUS_ACTIVE;
     let mut out = [0u8; 64];
     let m = msg(0x42, 6, &[]);
-    let n = process_message(&m, ATR_FIDO, &mut status, &mut out);
+    let n = process_message(&m, ATR_YUBIKEY, &mut status, &mut out);
     assert_eq!(n, 0);
 }
 
@@ -149,7 +166,7 @@ fn unknown_type_no_response() {
 fn short_message_ignored() {
     let mut status = STATUS_ACTIVE;
     let mut out = [0u8; 64];
-    let n = process_message(&[0x65, 0, 0], ATR_FIDO, &mut status, &mut out);
+    let n = process_message(&[0x65, 0, 0], ATR_YUBIKEY, &mut status, &mut out);
     assert_eq!(n, 0);
 }
 

--- a/docs/guides/otp.md
+++ b/docs/guides/otp.md
@@ -172,26 +172,27 @@ chip-id bytes than the reported 8-digit value, so the two aren't byte-identical.
 ## Disabling the keyboard interface
 
 If the extra keyboard is unwanted (some KVMs or login screens dislike a button
-that types), the obvious move is `ykman config usb --disable otp`. But on this
-firmware that does **not** actually remove the keyboard:
+that types), `ykman config usb --disable otp` now genuinely turns OTP off:
 
 ```sh
-ykman config usb --disable otp        # flips the reported OTP capability bit only
-ykman config usb --list               # what ykman thinks is on
+ykman config usb --disable otp        # disables the OTP application (enforced)
+ykman config usb --list               # confirm what is on
+ykman config usb --enable otp         # reversible — turns it back on
 ```
 
-`ykman config usb` writes the Yubico management capability blob (`EF_DEV_CONF`),
-which is just the set of bits `ykman` reports back. Whether the keyboard HID
-interface actually enumerates is decided at boot by a separate interface mask in
-the rescue `phy` record (`EF_PHY` / `USB_ITF_KB`), and nothing translates a
-capability-bit change into that mask. So after `--disable otp` the keyboard
-keeps enumerating across reboots. `ykman` merely *reports* OTP as disabled.
+The write persists to the Yubico management capability blob (`EF_DEV_CONF`) and
+the firmware **enforces** it live (no replug): a button press then types
+nothing, and Yubico / HMAC challenge-response is refused on both the keyboard
+frame protocol and the CCID OTP applet.
 
-To genuinely drop the keyboard interface you have to clear the `USB_ITF_KB` bit
-in the rescue `phy` mask via the rescue applet. Stock `ykman` can't do it. If
-typing is the problem and you don't need that path, leaving the slots empty (or
-behind an access code) avoids accidental presses without touching the interface
-set.
+One caveat: the keyboard **USB interface still enumerates**. Whether the HID
+interface is present at all is decided at boot by a separate mask in the rescue
+`phy` record (`EF_PHY` / `USB_ITF_KB`), which a capability-bit change does not
+touch — so the OS still sees an (now inert) keyboard. To drop the interface
+itself, clear the `USB_ITF_KB` bit in the rescue `phy` mask via the rescue
+applet (stock `ykman` can't do it). If accidental typing was the only worry,
+`--disable otp` — or leaving the slots empty / behind an access code — already
+stops the presses.
 
 ## Troubleshooting
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -53,7 +53,9 @@ this transport before). The frame codec itself is otherwise out of scope here.
 Standard ISO-7816 short APDUs. SELECT is always `00 A4 04 00 Lc <AID> 00`; the
 selected applet then receives `CLA INS P1 P2 [Lc <data>] [Le]`. There is no ISO
 master file, so a SELECT by FID/path (`P1=00`, e.g. GnuPG's `3F00` probe) answers
-`6D00` like a YubiKey. The reference transport is `tools/rsk/ccid.py`:
+`6D00` like a YubiKey. The power-on ATR is T=1, its historical bytes labelled
+`YubiKey` on a Yubico-identity build and `RS-Key` on the default build (identical
+card capabilities). The reference transport is `tools/rsk/ccid.py`:
 
 ```python
 def select(conn, aid):

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -51,8 +51,9 @@ this transport before). The frame codec itself is otherwise out of scope here.
 ### 1.1 CCID APDU framing
 
 Standard ISO-7816 short APDUs. SELECT is always `00 A4 04 00 Lc <AID> 00`; the
-selected applet then receives `CLA INS P1 P2 [Lc <data>] [Le]`. The reference
-transport is `tools/rsk/ccid.py`:
+selected applet then receives `CLA INS P1 P2 [Lc <data>] [Le]`. There is no ISO
+master file, so a SELECT by FID/path (`P1=00`, e.g. GnuPG's `3F00` probe) answers
+`6D00` like a YubiKey. The reference transport is `tools/rsk/ccid.py`:
 
 ```python
 def select(conn, aid):

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -52,8 +52,8 @@ this transport before). The frame codec itself is otherwise out of scope here.
 
 Standard ISO-7816 short APDUs. SELECT is always `00 A4 04 00 Lc <AID> 00`; the
 selected applet then receives `CLA INS P1 P2 [Lc <data>] [Le]`. There is no ISO
-master file, so a SELECT by FID/path (`P1=00`, e.g. GnuPG's `3F00` probe) answers
-`6D00` like a YubiKey. The power-on ATR is T=1, its historical bytes labelled
+master file, so the master-file SELECT (`00 A4 00 0C …`, GnuPG's `3F00` probe)
+answers `6D00` like a YubiKey. The power-on ATR is T=1, its historical bytes labelled
 `YubiKey` on a Yubico-identity build and `RS-Key` on the default build (identical
 card capabilities). The reference transport is `tools/rsk/ccid.py`:
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -42,8 +42,11 @@ also carries the ykman OTP-HID admin writes (SET_DEVICE_INFO `0x15`,
 DEVICE_CONFIG `0x11`, SCAN_MAP `0x12`, NDEF `0x08`/`0x09`) — ungated, like a stock
 YubiKey; `strict-config` refuses them. SET_DEVICE_INFO shares the same
 `EF_DEV_CONF` DeviceInfo store as the CCID WRITE CONFIG (§6); the rest are inert
-on this USB-only board except SCAN_MAP (it remaps typed OTP output). The frame
-codec itself is otherwise out of scope here.
+on this USB-only board except SCAN_MAP (it remaps typed OTP output). Each admin
+write **advances the status frame's program-sequence byte** — that increment is
+how ykman/yubikit confirm it (a write that left the sequence unchanged reports
+`CommandRejectedError: No data`, which is what blocked `ykman config usb` over
+this transport before). The frame codec itself is otherwise out of scope here.
 
 ### 1.1 CCID APDU framing
 
@@ -326,6 +329,17 @@ fixed `USB_SUPPORTED/SERIAL/FORM_FACTOR/VERSION` prefix.
 WRITE CONFIG a `TAG_USB_ENABLED(03)` TLV with the desired mask, e.g. enable only
 FIDO2+U2F → inner blob `03 02 02 02`, full APDU
 `00 1C 00 00 05 04 03 02 02 02`.
+
+`USB_ENABLED` is **enforced**, not merely reported: a cleared bit makes that
+application's applet stop answering — PIV/OpenPGP/OATH/OTP return `6A82` on
+CCID SELECT, FIDO2 (CBOR) and U2F (MSG) are refused over CTAPHID, and the OTP
+keyboard goes inert. The change is live (next command; no replug). Its ceiling
+is `USB_SUPPORTED`, so a wider host-written mask is clamped. The re-enable path
+is never gated — the Management applet (§6), the FIDO vendor `CONFIG_WRITE`
+(§9) and the OTP-HID identify/config slots stay reachable — so a disable is
+always reversible. Building `--features strict-config` gates the *write* on
+operator presence; the enforcement of a persisted mask is the same on both
+builds.
 
 > WRITE CONFIG refuses an inner blob > 64 bytes (`6A80`) so a malformed config
 > can't wedge later reads. **On the default build the write is ungated** (full
@@ -672,7 +686,8 @@ SET     00 10 40 11        # P1=0x40 brightness, P2 = color 1 | status 1<<4 = 0x
    `0x41` `CONFIG_WRITE/READ` path instead, see §9, which also covers those
    extras.)
 3. **Applet enable/disable** is the Yubico-compatible Management applet (§6),
-   identical to how you'd configure a YubiKey's USB applications.
+   identical to how you'd configure a YubiKey's USB applications — and enforced:
+   a disabled application's applet stops answering (see §6, `USB_ENABLED`).
 4. **Version-gate** on the Rescue SELECT identity (`01 02 08 06 …`, §7) and the
    Management SELECT version string. Treat unknown phy tags / `0x41` subcommands as
    skippable, not errors.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -33,15 +33,21 @@ bulk stream, ISO-7816 APDUs, CTAP2 CBOR. Defenses:
   every byte the host sends. Touch requirements bound the rate.
 - **Device config is UNGATED on the default build.** The shipped default is the
   full-ykman/YubiKey-compatible admin surface: a hostile USB host can silently
-  rewrite the reported DeviceInfo / enabled-applications / USB identity — over
-  CCID Management `WRITE CONFIG`, the FIDO vendor `CONFIG_WRITE`, and the CTAPHID
+  rewrite the DeviceInfo / enabled-applications / USB identity — over CCID
+  Management `WRITE CONFIG`, the FIDO vendor `CONFIG_WRITE`, and the CTAPHID
   (`0x43`) and OTP-HID (`0x15`) transport writes — with **no** touch or PIN, and
-  can trigger a device-wide factory reset (that one keeps a presence gate). This
-  is cosmetic: the config/identity is never proof a device is genuine (attestation
-  is — see §3). If you need config writes gated on the operator, build/flash
-  **`firmware-strict-config`**, which restores the presence/PIN gates and refuses
-  the ungated transport writes ([build.md](build.md)). It is not the runtime flash
-  flag `EF_HARDENED`.
+  can trigger a device-wide factory reset (that one keeps a presence gate). The
+  USB *identity* (serial, strings) is cosmetic — never proof a device is genuine,
+  attestation is (§3). The **enabled-applications mask is enforced**, though: a
+  disabled application's applet stops answering (PIV/OpenPGP/OATH/OTP over CCID,
+  FIDO2/U2F over CTAPHID, the OTP keyboard), so a hostile host can turn one off.
+  That is a **reversible denial-of-service**, not a confidentiality or integrity
+  break — the Management applet, the FIDO vendor command, and the OTP-HID
+  identify/config slots are never gated, so any single transport can re-enable it,
+  and no secret is exposed. If you need config writes gated on the operator,
+  build/flash **`firmware-strict-config`**, which restores the presence/PIN gates
+  and refuses the ungated transport writes ([build.md](build.md)). It is not the
+  runtime flash flag `EF_HARDENED`.
 - **The residual gap is *intent*. The trusted-display flavor closes it.** Because
   a standard key attests presence and possession, a malicious page can silently
   drive an authorized key over WebUSB to phish a real sign-in ([demonstrated

--- a/firmware/src/ccid_handler.rs
+++ b/firmware/src/ccid_handler.rs
@@ -30,6 +30,20 @@ const RESP_CAP: usize = 2038;
 const IDX_OPENPGP: usize = 1;
 const IDX_PIV: usize = 5;
 
+/// The YubiKey capability bit that gates each applet, in registration order
+/// `[vendor, openpgp, management, oath, otp, piv, rescue]`. `0` = always
+/// available: management (the re-enable path), vendor and rescue (recovery) must
+/// never be gated off, or `ykman config usb --disable` would be irreversible.
+const APPLET_CAPS: [u16; 7] = [
+    0,
+    rsk_mgmt::CAP_OPENPGP,
+    0,
+    rsk_mgmt::CAP_OATH,
+    rsk_mgmt::CAP_OTP,
+    rsk_mgmt::CAP_PIV,
+    0,
+];
+
 /// YubiKey Management vendor commands carried over CTAPHID (logical, i.e.
 /// `TYPE_INIT` already stripped by the transport). READ CONFIG (`0x42`) is what
 /// `ykman` / Yubico Authenticator read to identify the key over the FIDO
@@ -53,6 +67,10 @@ pub struct CcidApplets<'a> {
     otp: OtpApplet<'a>,
     piv: PivApplet<'a>,
     rescue: RescueApplet<'a>,
+    /// Cached enabled-applications mask from `EF_DEV_CONF`; reloaded when a config
+    /// write sets the dirty latch. Gates CCID SELECT, the OTP keyboard interface
+    /// and (via the worker) the FIDO2/U2F transports.
+    enabled_caps: u16,
     resp: [u8; RESP_CAP],
 }
 
@@ -109,8 +127,35 @@ impl<'a> CcidApplets<'a> {
                 kv_total,
                 crate::flash_storage::FLASH_SIZE as u32,
             ),
+            enabled_caps: rsk_mgmt::read_enabled_caps(&mut fs.borrow_mut()),
             resp: [0; RESP_CAP],
         }
+    }
+
+    /// Reload the cached enabled-applications mask from flash — called after a
+    /// config write flips [`rsk_mgmt::take_dev_conf_dirty`], so the next gated
+    /// command sees the new set. Returns the reloaded mask.
+    pub fn refresh_enabled(&mut self) -> u16 {
+        self.enabled_caps = rsk_mgmt::read_enabled_caps(&mut self.fs.borrow_mut());
+        self.enabled_caps
+    }
+
+    /// Whether the applet/transport guarded by capability bit `cap` is enabled.
+    /// The worker consults this to gate the FIDO2 (CBOR) and U2F (MSG) transports.
+    pub fn caps_enabled(&self, cap: u16) -> bool {
+        rsk_mgmt::cap_enabled(self.enabled_caps, cap)
+    }
+
+    /// The `Dispatcher::set_enabled` index-mask derived from the current cap mask:
+    /// bit `i` set → applet `i` (in `APPLET_CAPS` order) is selectable.
+    fn applet_enable_mask(&self) -> u32 {
+        let mut mask = 0u32;
+        for (i, &cap) in APPLET_CAPS.iter().enumerate() {
+            if rsk_mgmt::cap_enabled(self.enabled_caps, cap) {
+                mask |= 1 << i;
+            }
+        }
+        mask
     }
 
     /// Serve a YubiKey Management vendor command received over the CTAPHID
@@ -203,6 +248,10 @@ impl<'a> CcidApplets<'a> {
             self.disp.clear_chaining();
             return &self.resp[..n];
         }
+        // A disabled application's applet is invisible: SELECT (and any command to
+        // it) returns FILE_NOT_FOUND, so `ykman config usb --disable X` really
+        // removes X over CCID, not just from the DeviceInfo report.
+        self.disp.set_enabled(self.applet_enable_mask());
         let (sw, n) = {
             let mut res = ResBuf::new(&mut self.resp[..RESP_CAP - 2]);
             let mut applets: [&mut dyn Applet<Store>; 7] = [
@@ -233,6 +282,13 @@ impl<'a> CcidApplets<'a> {
         slot_id: u8,
         payload: &[u8; 64],
     ) -> ([u8; 64], usize, [u8; 8]) {
+        // OTP disabled: the function slots (program/update/swap/challenge-response)
+        // go inert, but the identify/config slots (serial, READ/WRITE CONFIG,
+        // status) stay live so the host can still read DeviceInfo and re-enable OTP.
+        if !self.caps_enabled(rsk_mgmt::CAP_OTP) && rsk_otp::is_function_slot(slot_id) {
+            let status = self.otp.hid_status_frame(&mut self.fs.borrow_mut());
+            return ([0u8; 64], 0, status);
+        }
         let mut body = [0u8; 64];
         let n = {
             let mut res = ResBuf::new(&mut body);
@@ -270,6 +326,9 @@ impl<'a> CcidApplets<'a> {
         slot: u8,
         ts_secs: u32,
     ) -> Option<([u8; rsk_otp::ticket::MAX_TICKET], usize, bool)> {
+        if !self.caps_enabled(rsk_mgmt::CAP_OTP) {
+            return None; // OTP disabled — a button press types nothing.
+        }
         let mut rnd = [0u8; 2];
         {
             let mut r = self.rng.borrow_mut();
@@ -290,7 +349,9 @@ impl<'a> CcidApplets<'a> {
     /// dispatch. The search runs on BOTH cores ([`crate::core1`]) and blocks this
     /// thread-executor task; the CCID transport streams time-extensions meanwhile.
     fn try_rsa_keygen(&mut self, apdu: &[u8]) -> Option<usize> {
-        if self.disp.current() != Some(IDX_OPENPGP) {
+        // The cap check closes the contrived window where OpenPGP was selected and
+        // then disabled — the fast path bypasses the dispatcher's own gate.
+        if self.disp.current() != Some(IDX_OPENPGP) || !self.caps_enabled(rsk_mgmt::CAP_OPENPGP) {
             return None;
         }
         let p = Apdu::parse(apdu).ok()?;
@@ -337,7 +398,7 @@ impl<'a> CcidApplets<'a> {
     /// the CCID transport can stream time-extensions. Validation errors fall
     /// through to normal dispatch for the right status word.
     fn try_piv_rsa_keygen(&mut self, apdu: &[u8]) -> Option<usize> {
-        if self.disp.current() != Some(IDX_PIV) {
+        if self.disp.current() != Some(IDX_PIV) || !self.caps_enabled(rsk_mgmt::CAP_PIV) {
             return None;
         }
         let p = Apdu::parse(apdu).ok()?;

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -497,7 +497,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x084B;
+    let device_release: u16 = 0x084C;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -41,7 +41,7 @@ use static_cell::StaticCell;
 
 use rsk_crypto::Device;
 use rsk_fs::Fs;
-use rsk_usb::ccid::{ATR_FIDO, Ccid};
+use rsk_usb::ccid::{ATR_RSKEY, ATR_YUBIKEY, Ccid};
 use rsk_usb::ctaphid::{CtapHid, FIDO_REPORT_DESCRIPTOR};
 
 mod ccid_handler;
@@ -497,7 +497,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x084E;
+    let device_release: u16 = 0x084F;
     config.device_release = device_release;
 
     let mut builder = Builder::new(
@@ -536,8 +536,16 @@ async fn main(spawner: Spawner) {
     } else {
         0x00
     };
+    // Present the YubiKey ATR only when the effective VID is Yubico's, mirroring
+    // the iManufacturer / OpenPGP AID: a default (non-Yubico) build must not
+    // impersonate a YubiKey on the wire — it carries the "RS-Key" ATR instead.
+    let card_atr: &'static [u8] = if usb_vid == YUBICO_VID {
+        ATR_YUBIKEY
+    } else {
+        ATR_RSKEY
+    };
     let ccid = (usb_itf & rsk_rescue::phy::USB_ITF_CCID != 0)
-        .then(|| Ccid::new(&mut builder, ClientCcid, ATR_FIDO, ccid_pin_support));
+        .then(|| Ccid::new(&mut builder, ClientCcid, card_atr, ccid_pin_support));
 
     let kbd = (usb_itf & rsk_rescue::phy::USB_ITF_KB != 0).then(|| {
         HidWriter::<_, 8>::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -497,7 +497,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x084C;
+    let device_release: u16 = 0x084D;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -497,7 +497,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x084F;
+    let device_release: u16 = 0x0850;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -497,7 +497,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x084D;
+    let device_release: u16 = 0x084E;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -497,7 +497,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x084A;
+    let device_release: u16 = 0x084B;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -497,7 +497,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0849;
+    let device_release: u16 = 0x084A;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/worker.rs
+++ b/firmware/src/worker.rs
@@ -367,6 +367,9 @@ impl<'a> Worker<'a> {
     /// `EXCHANGE` after `DONE`, and the lock's critical section is momentary, so
     /// the high-priority executor is never blocked.
     async fn handle_transport(&mut self) {
+        // A config write since the last request may have changed the enabled set;
+        // reload it before any gate consults it.
+        self.refresh_caps_if_dirty();
         // Show the processing status for the dispatch; the first request also
         // flips the boot status to idle for good.
         crate::led::set_status(crate::led::STATUS_PROCESSING);
@@ -378,6 +381,15 @@ impl<'a> Worker<'a> {
             if ex.kind == Kind::Secure {
                 self.handle_secure_req(&mut ex);
             } else {
+                // FIDO2 (CBOR) / U2F (MSG) disabled via `ykman config usb` answer a
+                // deny; the interface stays enumerated (descriptor fixed at boot) but
+                // does nothing until re-enabled. The re-enable path — CCID management
+                // and the FIDO Management vendor command (`Kind::Vendor`) — is never
+                // gated, so a disable is always reversible.
+                let fido2_on = self.ccid.caps_enabled(rsk_mgmt::CAP_FIDO2);
+                let u2f_on = self.ccid.caps_enabled(rsk_mgmt::CAP_U2F);
+                let cbor_denied = [rsk_fido::CtapError::OperationDenied as u8];
+                let u2f_denied = rsk_sdk::Sw::CONDITIONS_NOT_SATISFIED.to_bytes();
                 let Exchange {
                     kind,
                     vcmd,
@@ -389,7 +401,9 @@ impl<'a> Worker<'a> {
                     ..
                 } = &mut *ex;
                 let r: &[u8] = match *kind {
+                    Kind::Cbor if !fido2_on => &cbor_denied,
                     Kind::Cbor => self.ctap.handle_cbor(&req[..*req_len]),
+                    Kind::Msg if !u2f_on => &u2f_denied,
                     Kind::Msg => {
                         // A CTAPHID_INIT since the last MSG drops the applet
                         // selection so U2F isn't hijacked by a sticky vendor SELECT.
@@ -508,10 +522,21 @@ impl<'a> Worker<'a> {
     /// One keyboard-interface OTP frame command: run it against flash and stash
     /// the response for the GET_REPORT poller. A CHAL_BTN_TRIG slot blocks here in
     /// a touch wait; the high-priority GET_REPORT polls report `0x20` meanwhile.
+    /// Reload the cached enabled-applications mask if a config write flipped the
+    /// dirty latch, so the CCID / FIDO2 / U2F / OTP gates all act on the new set
+    /// before the next request. Cheap (one relaxed atomic) on the common no-change
+    /// path; a flash re-read only right after `ykman config usb` changed it.
+    fn refresh_caps_if_dirty(&mut self) {
+        if rsk_mgmt::take_dev_conf_dirty() {
+            self.ccid.refresh_enabled();
+        }
+    }
+
     fn handle_otp_hid(&mut self) {
         let Some((slot, payload)) = otp_kbd::take_request() else {
             return;
         };
+        self.refresh_caps_if_dirty();
         crate::led::set_status(crate::led::STATUS_PROCESSING);
         let (body, n, status) = self.ccid.handle_otp_hid(slot, &payload);
         otp_kbd::finish_response(status, &body[..n]);

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -96,15 +96,14 @@
       fuzzToolchain
       pkgs.cargo-fuzz
     ];
-    # `-Zmiri-many-seeds` (bare) re-runs the whole 34-target suite once per seed
-    # over a large default range; under the interpreter, with ML-KEM/ML-DSA and
-    # P-521 in the mix, that overran the weekly job's 3 h budget — it was
-    # cancelled before finishing, so the run produced zero coverage. Bound it to
-    # 16 seeds: the test RNGs are deterministically seeded and the code is
-    # single-threaded, so the only thing the seed varies is Miri's address
-    # nondeterminism; 16 samples of that catch what the full range would, in a
-    # fraction of the wall time, and the job actually completes.
-    MIRIFLAGS = "-Zmiri-many-seeds=0..16 -Zdeduplicate-diagnostics -Zmiri-strict-provenance";
+    # `-Zmiri-many-seeds` (bare) re-runs the whole suite once per seed over a
+    # large default range; under the interpreter, with ML-KEM/ML-DSA/EC/RSA in
+    # the mix, one pass is ~1 h. The test RNGs are deterministically seeded and
+    # the code is single-threaded, so the seed varies only Miri's address
+    # nondeterminism, where samples have steep diminishing returns. 16 seeds
+    # (~4 h) began timing out as the crypto suite grew; 8 (~2 h) samples that
+    # nondeterminism just as well and leaves headroom under the job budget.
+    MIRIFLAGS = "-Zmiri-many-seeds=0..8 -Zdeduplicate-diagnostics -Zmiri-strict-provenance";
     # libFuzzer's runtime is C++: on Linux the fuzz binaries need
     # libstdc++.so.6 at run time, and a nix-linked binary's loader does not
     # search the host's /usr/lib (broke the deep-checks CI job, every target


### PR DESCRIPTION
Cut of **v0.4.1** — the post-v0.4.0 develop line (bcdDevice `0x084A` → `0x0850`).

### Security
- Run the full CTAP 2.1 §6.5.5.7 pinUvAuthToken triad after a user-presence-gated
  `makeCredential` / `getAssertion` (GHSA-wqjm-653g-hgw3).
- Require a touch before `makeCredential` discloses an `excludeList` match (an
  rpId-bound credential-existence oracle).

### Interop (found via a live differential against a real YubiKey)
- The master-file `SELECT` answers `6D00`, so GnuPG / Kleopatra reads the real card
  serial and surfaces PIV alongside OpenPGP (#44).
- OATH `CALCULATE ALL` is no longer shadowed by that rule — it reuses `INS 0xA4` and
  had been breaking the Yubico Authenticator.
- `ykman config usb --disable` now actually disables an application; `ykman otp swap`
  works; the default (non-Yubico) build no longer presents the YubiKey ATR.

Full list in [CHANGELOG.md](CHANGELOG.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
