### PR TITLE
fix(fuzz): follow the inclusive credBlob bound in the cred-ext oracle

### DIFF
--- a/crates/rsk-fido/src/credential.rs
+++ b/crates/rsk-fido/src/credential.rs
@@ -36,8 +36,8 @@ use crate::consts::{
     RP_NICK_MAX_LEN,
 };
 
-// `MAX_CREDBLOB_LENGTH` (128) over-bounds the sealable credBlob (`< 128`), a
-// harmless 1-byte slack in `CRED_BOX_MAX`.
+// `MAX_CREDBLOB_LENGTH` (128) bounds the sealable credBlob inclusively, so the
+// `CRED_BOX_MAX` term below sizes it exactly — no slack left to absorb a raise.
 use crate::keyderiv::{KEY_HANDLE_LEN, verify_key};
 
 const CRED_PROTO: &[u8; 4] = b"\xf1\xd0\x02\x02";

--- a/fuzz/fuzz_targets/fido_cred_ext.rs
+++ b/fuzz/fuzz_targets/fido_cred_ext.rs
@@ -6,7 +6,7 @@
 //! Fuzz the credential-box extension round-trip: sealing arbitrary credProtect /
 //! credBlob / flag inputs into a box (`credential_create`) and loading it back
 //! (`credential_load`) must never panic and must reproduce the extensions (a
-//! credBlob is sealed only when shorter than `MAX_CREDBLOB_LENGTH`).
+//! credBlob is sealed only when no longer than `MAX_CREDBLOB_LENGTH`).
 
 use libfuzzer_sys::fuzz_target;
 use rsk_crypto::{Device, sha256};
@@ -55,7 +55,7 @@ fuzz_target!(|data: &[u8]| {
         assert_eq!(c.ext.hmac_secret, flags & 0x10 != 0);
         assert_eq!(c.ext.large_blob_key, flags & 0x20 != 0);
         assert_eq!(c.ext.third_party_payment, flags & 0x40 != 0);
-        if !blob.is_empty() && blob.len() < MAX_CREDBLOB_LENGTH {
+        if !blob.is_empty() && blob.len() <= MAX_CREDBLOB_LENGTH {
             assert_eq!(c.ext.cred_blob, blob);
         } else {
             assert!(c.ext.cred_blob.is_empty());

--- a/fuzz/tests/miri.rs
+++ b/fuzz/tests/miri.rs
@@ -465,7 +465,7 @@ fn miri_fido_cred_ext() {
             assert_eq!(c.ext.hmac_secret, flags & 0x10 != 0);
             assert_eq!(c.ext.large_blob_key, flags & 0x20 != 0);
             assert_eq!(c.ext.third_party_payment, flags & 0x40 != 0);
-            if !blob.is_empty() && blob.len() < MAX_CREDBLOB_LENGTH {
+            if !blob.is_empty() && blob.len() <= MAX_CREDBLOB_LENGTH {
                 assert_eq!(c.ext.cred_blob, blob);
             } else {
                 assert!(c.ext.cred_blob.is_empty());


### PR DESCRIPTION
The scheduled `deep-checks` → `fuzz` job went red on `main`: the `fido_cred_ext`
target replayed a 129-byte corpus input (`flags=0xFF`, a 128-byte blob) and hit
`assert!(cred_blob.is_empty())`.

`90942d2` (v0.4.3) made the sealable credBlob bound inclusive — §12.2 has the
platform send up to and including `maxCredBlobLength` (128), so a 128-byte blob
now seals. The fuzz oracle and its miri mirror still asserted the old exclusive
`< MAX_CREDBLOB_LENGTH`, so exactly 128 bytes tripped the else-branch. This aligns
both to the shipped `<=`, and drops the now-false "1-byte slack" note on
`CRED_BOX_MAX`.

Host-only (fuzz/miri harness + a comment); no firmware behaviour change, bcdDevice
stays 0x0858.

Verified: reproduced the crash on the pre-fix tree, confirmed the same input passes
after; 60s fuzz run over the local corpus clean; `miri_fido_cred_ext` green; full
`./scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)