### PR TITLE
Release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-07-27
+
 ### Fixed
 
 - **Challenge-response reaches KeePassXC, `ykchalresp` and `pam_yubico` on Linux
@@ -2826,7 +2828,8 @@ family that keeps the "enterprise" features in the open tree.
   signature of it, and a CycloneDX SBOM. See
   [docs/releases.md](docs/releases.md) to verify a download.
 
-[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.4...HEAD
+[0.4.4]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.0...v0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   Verified end-to-end on Linux against `ykchalresp`, `ykinfo` and
   `keepassxc-cli` 2.7.11, with a real YubiKey as the control.
   **bcdDevice → `0x0859`.**
+- **The OTP frame protocol now answers on the FIDO interface as well.** Measuring
+  the fix above showed a 5.7.4 YubiKey serving the OTP status frame on its FIDO
+  interface too, while keeping the CTAP-exact report descriptor that declares no
+  feature report — so a host that pokes interface 0 blind finds OTP whatever the
+  order happens to be. RS-Key stalled there. It now answers on both HID
+  interfaces, marshalling one frame state machine, and the FIDO report descriptor
+  is unchanged. Disabling the keyboard interface in the phy record still removes
+  the protocol from both, so `ykman config usb --disable OTP` keeps its meaning.
+  **bcdDevice → `0x085A`.**
 
 ## [0.4.3] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **Challenge-response reaches KeePassXC, `ykchalresp` and `pam_yubico` on Linux
+  again.** Those tools share the `ykpers`/`ykcore` libusb backend, which claims USB
+  interface 0 and pushes the OTP frame reports at it without reading a descriptor
+  first. RS-Key enumerated the FIDO HID interface there, and that interface serves
+  no HID feature reports, so every transfer stalled: the host reported a USB "Pipe
+  error" and listed no hardware key
+  ([#55](https://github.com/TheMaxMur/RS-Key/issues/55)). The interfaces now
+  enumerate in the stock YubiKey order — keyboard/OTP, FIDO HID, CCID — so the
+  reports land on the OTP interface as they do on a real key. Windows and macOS
+  were never affected: their `ykcore` backends find the interface through the OS
+  HID stack. Nothing changed on the wire, and hosts re-enumerate the device once
+  after the upgrade. KeePassXC also filters on Yubico's vendor id, so it still
+  needs a `VIDPID=Yubikey5` build and Yubico's udev rules — see
+  [guides/otp.md](guides/otp.md#challenge-response-from-software).
+  Verified end-to-end on Linux against `ykchalresp`, `ykinfo` and
+  `keepassxc-cli` 2.7.11, with a real YubiKey as the control.
+  **bcdDevice → `0x0859`.**
+
 ## [0.4.3] - 2026-07-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   is unchanged. Disabling the keyboard interface in the phy record still removes
   the protocol from both, so `ykman config usb --disable OTP` keeps its meaning.
   **bcdDevice → `0x085A`.**
+- **A touch-gated challenge-response slot no longer wedges the OTP transport.**
+  Field report: challenge-response worked without `--touch` and failed with it,
+  while a YubiKey was fine. A host that meets a slot waiting for its button press
+  ends that wait one of two ways, and RS-Key honoured neither: it sends the dummy
+  write `0x8f` (ykpers `yk_force_key_update`, also its way of resetting the read
+  mode after collecting a response), which the frame decoder dropped as an
+  out-of-range sequence; or it simply sends the next command, which a YubiKey lets
+  supersede the challenge. So the key stayed in the touch wait and answered
+  "would block" to *everything* for the next 30 seconds — measured against a real
+  YubiKey, which recovers instantly. Since KeePassXC probes every slot before
+  unlocking, one touch slot was enough to make the whole key look broken. Both
+  paths now end the wait, scoped to the OTP transport so an abort there cannot
+  abandon a FIDO ceremony on the same button. The press itself was never the
+  problem — traced on hardware, a press has always produced its HMAC.
+  **bcdDevice → `0x085B`.**
 
 ## [0.4.3] - 2026-07-26
 

--- a/crates/rsk-otp/src/hid.rs
+++ b/crates/rsk-otp/src/hid.rs
@@ -77,7 +77,11 @@ impl FrameRx {
         }
         let seq = (flag & SEQ_MASK) as usize;
         if seq > 9 {
-            return RxOutcome::None;
+            // A write with an out-of-range sequence is the host's dummy write
+            // (`0x8f`, ykpers `yk_force_key_update`): abort what is in flight and
+            // reset the read mode. Dropping it strands the host mid-transfer.
+            self.buf = [0; FRAME_SIZE];
+            return RxOutcome::Reset;
         }
         if seq == 0 {
             self.buf = [0; FRAME_SIZE];

--- a/crates/rsk-otp/src/hid_tests.rs
+++ b/crates/rsk-otp/src/hid_tests.rs
@@ -44,11 +44,38 @@ fn reset_byte_clears_state() {
 }
 
 #[test]
-fn out_of_range_sequence_ignored() {
+fn dummy_write_aborts_like_a_reset() {
+    // `0x8f` — a write whose sequence is out of range — is the host's documented
+    // "force update or abort" (ykpers sends it to cancel a challenge waiting for a
+    // touch, and again to reset the read mode after collecting a response).
     let mut rx = FrameRx::new();
-    let mut bad = [0u8; REPORT_SIZE];
-    bad[REPORT_DATA] = FLAG_WRITE | 0x0A; // seq 10
-    assert_eq!(rx.feed(&bad), RxOutcome::None);
+    let mut dummy = [0u8; REPORT_SIZE];
+    dummy[REPORT_DATA] = FLAG_WRITE | 0x0F;
+    assert_eq!(rx.feed(&dummy), RxOutcome::Reset);
+}
+
+#[test]
+fn a_frame_interrupted_by_a_dummy_write_is_abandoned() {
+    // The abort must not leave half a frame behind for the next transfer to
+    // inherit: what follows it parses on its own or not at all.
+    let payload = [0x5Au8; PAYLOAD_SIZE];
+    let reports = split_frame(&payload, 0x30);
+    let mut rx = FrameRx::new();
+    for r in &reports[..5] {
+        rx.feed(r);
+    }
+    let mut dummy = [0u8; REPORT_SIZE];
+    dummy[REPORT_DATA] = FLAG_WRITE | 0x0F;
+    assert_eq!(rx.feed(&dummy), RxOutcome::Reset);
+    // Resuming mid-frame yields nothing; a frame sent from its start still lands.
+    assert_eq!(rx.feed(&reports[9]), RxOutcome::BadCrc);
+    for r in &reports[..9] {
+        assert_eq!(rx.feed(r), RxOutcome::None);
+    }
+    assert!(matches!(
+        rx.feed(&reports[9]),
+        RxOutcome::Frame { slot: 0x30, .. }
+    ));
 }
 
 #[test]

--- a/docs/guides/otp.md
+++ b/docs/guides/otp.md
@@ -232,6 +232,11 @@ stops the presses.
   the OTP interface as interface 0 unconditionally. Update the firmware. If the
   key isn't listed at all, check the VID and udev requirements
   [above](#challenge-response-from-software).
+- **A `--touch` slot works from `ykman` but not from KeePassXC, and afterwards
+  even `ykinfo` fails for half a minute** → firmware older than bcdDevice
+  `0x085B` stayed in the touch wait once a host had probed the slot and moved on,
+  and answered "would block" to every command until it timed out. Update the
+  firmware. A non-touch slot never hit this.
 
 ## Notes and limits
 

--- a/docs/guides/otp.md
+++ b/docs/guides/otp.md
@@ -130,6 +130,11 @@ requirements a stock YubiKey satisfies implicitly:
 
 `ykman otp calculate` is not affected by either — it goes through hidraw.
 
+Since bcdDevice `0x085A` the frame protocol also answers on the FIDO interface,
+the way a YubiKey does, so a tool that addresses OTP by interface index finds it
+whatever the enabled interface set looks like. Turning the keyboard interface off
+in the phy record still takes it away from both.
+
 Two challenge-response modes exist:
 
 - **HMAC-SHA1** is the common one. Variable-length challenges (`HMAC_LT64`) are

--- a/docs/guides/otp.md
+++ b/docs/guides/otp.md
@@ -117,6 +117,19 @@ The keyboard interface answers the same protocol, so tools written for YubiKeys
 ("YubiKey challenge-response" in KeePassXC, `ykchalresp`, the `pam_yubico`
 HMAC mode) work unchanged.
 
+Those tools are the `ykpers`/`ykcore` family, and on Linux they talk to the key
+over raw libusb rather than through the kernel HID stack. That path has two
+requirements a stock YubiKey satisfies implicitly:
+
+- **A Yubico VID.** KeePassXC filters on Yubico's (and OnlyKey's) vendor id and
+  a fixed PID list, so a default `0x1209` build is invisible to it — build the
+  firmware with `VIDPID=Yubikey5` (see [build.md](../build.md)).
+- **libusb access to the device.** Install Yubico's udev rules
+  (`69-yubikey.rules` / `70-yubikey.rules`, packaged as `yubikey-personalization`
+  on most distributions); without them libusb cannot open the device at all.
+
+`ykman otp calculate` is not affected by either — it goes through hidraw.
+
 Two challenge-response modes exist:
 
 - **HMAC-SHA1** is the common one. Variable-length challenges (`HMAC_LT64`) are
@@ -208,6 +221,12 @@ stops the presses.
   the OTP applet.
 - **Slots 3/4 don't show in `ykman otp info`** → expected. `ykman otp` only
   enumerates 1 and 2.
+- **KeePassXC on Linux says `Hardware key USB error: Pipe error`, or
+  `ykchalresp` fails while `ykman otp calculate` works** → firmware older than
+  bcdDevice `0x0859` enumerated the FIDO interface first, and these tools address
+  the OTP interface as interface 0 unconditionally. Update the firmware. If the
+  key isn't listed at all, check the VID and udev requirements
+  [above](#challenge-response-from-software).
 
 ## Notes and limits
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -57,6 +57,17 @@ there whatever the descriptors say. An interface switched off in
 host that assumes a fixed index only holds where the same interface set is
 enabled.
 
+For the same reason the OTP frame protocol answers a HID feature GET/SET_REPORT
+on **both** HID interfaces — the keyboard one and the FIDO one — which is what a
+5.7.4 YubiKey does. The FIDO report descriptor stays the CTAP-exact one and
+declares no feature report (again as on a YubiKey), so a host reading descriptors
+sees no change; the interrupt endpoints carry CTAPHID and nothing else. Reaching
+the frames there needs a deliberate feature transfer — measured working both from
+raw libusb and through macOS IOKit. Both interfaces marshal one frame state
+machine, so the two are alternative doors to the same OTP application, not
+independent sessions. Disabling the keyboard interface in `ENABLED_USB_ITF`
+removes the protocol from both.
+
 ### 1.1 CCID APDU framing
 
 Standard ISO-7816 short APDUs. SELECT is always `00 A4 04 00 Lc <AID> 00`; the

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -68,6 +68,14 @@ machine, so the two are alternative doors to the same OTP application, not
 independent sessions. Disabling the keyboard interface in `ENABLED_USB_ITF`
 removes the protocol from both.
 
+A slot programmed to require a touch answers its challenge only after a button
+press, and reports the wait in the status byte (`0x20`) meanwhile. Two things end
+that wait early, both matching a YubiKey: the host's **dummy write** — a report
+whose sequence byte is out of range, `0x8f`, which also resets the read mode after
+a response — and **any new frame**, which supersedes the pending challenge. A host
+that does neither waits out the touch timeout (§7 `PRESENCE_TIMEOUT`), during
+which the transport reports only that it is waiting.
+
 ### 1.1 CCID APDU framing
 
 Standard ISO-7816 short APDUs. SELECT is always `00 A4 04 00 Lc <AID> 00`; the

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -48,6 +48,15 @@ how ykman/yubikit confirm it (a write that left the sequence unchanged reports
 `CommandRejectedError: No data`, which is what blocked `ykman config usb` over
 this transport before). The frame codec itself is otherwise out of scope here.
 
+The interfaces are presented in the stock YubiKey order — **keyboard/OTP, FIDO
+HID, CCID** — because some hosts address the OTP interface by index instead of
+by descriptor: the libusb backend `ykpers`/`ykcore` ships (KeePassXC,
+`ykchalresp`, `pam_yubico`) claims interface 0 and sends the OTP frame reports
+there whatever the descriptors say. An interface switched off in
+`ENABLED_USB_ITF` (§7) is omitted and the rest keep that relative order, so a
+host that assumes a fixed index only holds where the same interface set is
+enabled.
+
 ### 1.1 CCID APDU framing
 
 Standard ISO-7816 short APDUs. SELECT is always `00 A4 04 00 Lc <AID> 00`; the

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -509,7 +509,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0858;
+    let device_release: u16 = 0x0859;
     config.device_release = device_release;
 
     let mut builder = Builder::new(
@@ -520,6 +520,24 @@ async fn main(spawner: Spawner) {
         MSOS_DESC.init([0; 64]),
         CONTROL_BUF.init([0; 64]),
     );
+
+    // The keyboard (OTP) interface is built FIRST so it lands on interface 0 like a
+    // stock YubiKey: the libusb backend ykpers/ykcore ships — KeePassXC, ykchalresp,
+    // pam_yubico — claims interface 0 and sends the OTP frame reports there blind.
+    let kbd = (usb_itf & rsk_rescue::phy::USB_ITF_KB != 0).then(|| {
+        HidWriter::<_, 8>::new(
+            &mut builder,
+            KBD_STATE.init(HidState::new()),
+            HidConfig {
+                report_descriptor: otp_kbd::KEYBOARD_REPORT_DESCRIPTOR,
+                request_handler: Some(OTP_HID_HANDLER.init(otp_kbd::OtpHidHandler)),
+                poll_ms: 10,
+                max_packet_size: 8,
+                hid_subclass: HidSubclass::No,
+                hid_boot_protocol: HidBootProtocol::None,
+            },
+        )
+    });
 
     let hid = (usb_itf & rsk_rescue::phy::USB_ITF_HID != 0).then(|| {
         HidReaderWriter::<_, 64, 64>::new(
@@ -558,21 +576,6 @@ async fn main(spawner: Spawner) {
     };
     let ccid = (usb_itf & rsk_rescue::phy::USB_ITF_CCID != 0)
         .then(|| Ccid::new(&mut builder, ClientCcid, card_atr, ccid_pin_support));
-
-    let kbd = (usb_itf & rsk_rescue::phy::USB_ITF_KB != 0).then(|| {
-        HidWriter::<_, 8>::new(
-            &mut builder,
-            KBD_STATE.init(HidState::new()),
-            HidConfig {
-                report_descriptor: otp_kbd::KEYBOARD_REPORT_DESCRIPTOR,
-                request_handler: Some(OTP_HID_HANDLER.init(otp_kbd::OtpHidHandler)),
-                poll_ms: 10,
-                max_packet_size: 8,
-                hid_subclass: HidSubclass::No,
-                hid_boot_protocol: HidBootProtocol::None,
-            },
-        )
-    });
 
     // Go green (idle) the moment the host configures us, not on the first applet
     // command — a healthy, enumerated key with no PC/SC client talking to it would

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -512,7 +512,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x085A;
+    let device_release: u16 = 0x085B;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -34,7 +34,7 @@ use embassy_rp::usb::{Driver as UsbDriver, InterruptHandler as UsbIrq};
 use embassy_time::Timer;
 use embassy_usb::class::hid::{
     Config as HidConfig, HidBootProtocol, HidReaderWriter, HidSubclass, HidWriter,
-    State as HidState,
+    RequestHandler as HidRequestHandler, State as HidState,
 };
 use embassy_usb::{Builder, Config as UsbConfig, UsbDevice};
 use static_cell::StaticCell;
@@ -271,7 +271,10 @@ static MSOS_DESC: StaticCell<[u8; 64]> = StaticCell::new();
 static CONTROL_BUF: StaticCell<[u8; 64]> = StaticCell::new();
 static HID_STATE: StaticCell<HidState> = StaticCell::new();
 static KBD_STATE: StaticCell<HidState> = StaticCell::new();
-static OTP_HID_HANDLER: StaticCell<otp_kbd::OtpHidHandler> = StaticCell::new();
+// One handler instance per HID interface serving the OTP frame protocol; both
+// marshal the same `otp_kbd` frame state, as a YubiKey's one OTP application does.
+static OTP_HID_HANDLER_KBD: StaticCell<otp_kbd::OtpHidHandler> = StaticCell::new();
+static OTP_HID_HANDLER_FIDO: StaticCell<otp_kbd::OtpHidHandler> = StaticCell::new();
 static USB_HANDLER: StaticCell<led::StatusHandler> = StaticCell::new();
 // Holds the LED power-enable `Output` for the device's lifetime; dropping it would
 // release the pad and let the gated LED rail fall (see the LED block below).
@@ -509,7 +512,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0859;
+    let device_release: u16 = 0x085A;
     config.device_release = device_release;
 
     let mut builder = Builder::new(
@@ -524,13 +527,14 @@ async fn main(spawner: Spawner) {
     // The keyboard (OTP) interface is built FIRST so it lands on interface 0 like a
     // stock YubiKey: the libusb backend ykpers/ykcore ships — KeePassXC, ykchalresp,
     // pam_yubico — claims interface 0 and sends the OTP frame reports there blind.
-    let kbd = (usb_itf & rsk_rescue::phy::USB_ITF_KB != 0).then(|| {
+    let otp_enabled = usb_itf & rsk_rescue::phy::USB_ITF_KB != 0;
+    let kbd = otp_enabled.then(|| {
         HidWriter::<_, 8>::new(
             &mut builder,
             KBD_STATE.init(HidState::new()),
             HidConfig {
                 report_descriptor: otp_kbd::KEYBOARD_REPORT_DESCRIPTOR,
-                request_handler: Some(OTP_HID_HANDLER.init(otp_kbd::OtpHidHandler)),
+                request_handler: Some(OTP_HID_HANDLER_KBD.init(otp_kbd::OtpHidHandler)),
                 poll_ms: 10,
                 max_packet_size: 8,
                 hid_subclass: HidSubclass::No,
@@ -539,13 +543,18 @@ async fn main(spawner: Spawner) {
         )
     });
 
+    // A 5.7.4 YubiKey answers the OTP frame protocol on its FIDO interface too —
+    // measured, and its FIDO report descriptor stays the CTAP-exact one that declares
+    // no feature report. Match that: it is what saves a host addressing OTP by index.
+    let fido_otp: Option<&'static mut dyn HidRequestHandler> = otp_enabled
+        .then(|| OTP_HID_HANDLER_FIDO.init(otp_kbd::OtpHidHandler) as &mut dyn HidRequestHandler);
     let hid = (usb_itf & rsk_rescue::phy::USB_ITF_HID != 0).then(|| {
         HidReaderWriter::<_, 64, 64>::new(
             &mut builder,
             HID_STATE.init(HidState::new()),
             HidConfig {
                 report_descriptor: FIDO_REPORT_DESCRIPTOR,
-                request_handler: None,
+                request_handler: fido_otp,
                 // 1 ms HID interval: a credMgmt/getAssertion response is several
                 // 64-byte IN frames; at 5 ms/frame that framing dominated once the
                 // per-call flash scan was removed. Full-speed floor is 1 ms.

--- a/firmware/src/otp_kbd.rs
+++ b/firmware/src/otp_kbd.rs
@@ -133,6 +133,9 @@ impl RequestHandler for OtpHidHandler {
             let mut h = c.borrow_mut();
             match h.rx.feed(&report) {
                 RxOutcome::Frame { slot, payload } => {
+                    // The host moved on to another command: a YubiKey lets that
+                    // supersede a challenge still waiting for its touch.
+                    crate::presence::cancel_otp_wait();
                     h.req_slot = slot;
                     h.req_payload = payload;
                     h.req_ready = true;
@@ -140,6 +143,7 @@ impl RequestHandler for OtpHidHandler {
                     OTP_REQ.signal(());
                 }
                 RxOutcome::Reset => {
+                    crate::presence::cancel_otp_wait();
                     h.tx = FrameTx::new();
                     h.state = State::Idle;
                 }
@@ -198,7 +202,11 @@ pub fn finish_response(status: [u8; REPORT_SIZE], body: &[u8]) {
         h.status = status;
         if body.is_empty() {
             h.tx = FrameTx::new();
-            h.state = State::Idle;
+            // A frame that arrived while this command ran is already queued — stay
+            // in `Processing` for it rather than flashing idle at the host.
+            if !h.req_ready {
+                h.state = State::Idle;
+            }
         } else {
             h.tx.load(body);
             h.state = State::Responding;

--- a/firmware/src/presence.rs
+++ b/firmware/src/presence.rs
@@ -52,6 +52,28 @@ pub fn request_cancel() {
     CANCEL_REQUESTED.store(true, Ordering::Relaxed);
 }
 
+/// Set while the worker runs an OTP frame command, so [`cancel_otp_wait`] can only
+/// end that transport's ceremony — never a FIDO or OpenPGP one waiting on the same
+/// button.
+static OTP_WAIT_SCOPE: AtomicBool = AtomicBool::new(false);
+
+/// Mark (or unmark) the OTP frame command the worker is running.
+pub fn set_otp_scope(active: bool) {
+    OTP_WAIT_SCOPE.store(active, Ordering::Relaxed);
+}
+
+/// End an OTP touch wait because the host moved on: it sent the dummy write that
+/// aborts (`0x8f`), or a new frame — a YubiKey lets either supersede the wait, and
+/// without that every later command reads "would block" until the wait times out.
+pub fn cancel_otp_wait() {
+    if OTP_WAIT_SCOPE.load(Ordering::Relaxed) {
+        CANCEL_REQUESTED.store(true, Ordering::Relaxed);
+        // The wait is over as of this decision; stop advertising it right away so
+        // the host's next status poll cannot read a stale "waiting for touch".
+        UP_PENDING.store(false, Ordering::Relaxed);
+    }
+}
+
 /// Built-in touch-wait timeout (ms) used when the phy record carries none.
 const DEFAULT_TIMEOUT_MS: u32 = 30_000;
 /// Touch-wait timeout in ms, seeded at boot from the phy record's

--- a/firmware/src/worker.rs
+++ b/firmware/src/worker.rs
@@ -557,7 +557,11 @@ impl<'a> Worker<'a> {
         };
         self.refresh_caps_if_dirty();
         crate::led::set_status(crate::led::STATUS_PROCESSING);
+        // Scope any touch wait this command starts to the OTP transport, so a host
+        // that aborts it cannot also abandon a FIDO ceremony on the same button.
+        crate::presence::set_otp_scope(true);
         let (body, n, status) = self.ccid.handle_otp_hid(slot, &payload);
+        crate::presence::set_otp_scope(false);
         otp_kbd::finish_response(status, &body[..n]);
         self.ccid.scrub();
         // This path runs the CFG_CHAL_BTN_TRIG touch wait too, and `ButtonPresence`

--- a/tests/02_usb_interfaces.py
+++ b/tests/02_usb_interfaces.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+"""USB layout test — the interface order and the OTP frame protocol's reach.
+
+Two properties a host tool written for YubiKeys depends on, neither of which any
+host test can see (they live in the USB descriptors and on the control pipe):
+
+  * the interfaces enumerate in the stock YubiKey order — keyboard/OTP, FIDO,
+    CCID. `ykpers`/`ykcore` (KeePassXC, ykchalresp, pam_yubico) claims interface
+    0 and puts the OTP frame reports there without reading a descriptor first,
+    so whichever interface sits at index 0 decides whether those tools work;
+  * the OTP frame protocol answers a HID feature GET_REPORT on *both* HID
+    interfaces, as a 5.7.4 YubiKey does, which keeps such a host working even if
+    the order ever shifts (e.g. an interface disabled in the phy record).
+
+    pip install pyusb        # plus libusb
+    python tests/02_usb_interfaces.py
+
+**Linux only in practice**: libusb cannot claim a HID interface on macOS (IOKit
+holds it) or Windows. Run it on a Linux host with the Yubico udev rules
+installed — the same environment the tools under test need.
+
+The device is picked by its product string ("RS-Key" / "RSK"); pass --index to
+choose among several, which is also how to point it at a real YubiKey as a
+reference. A key with the OTP interface disabled
+(`ykman config usb --disable OTP`) will fail here by design: the frame protocol
+is gone from both interfaces then.
+"""
+import argparse
+import contextlib
+import sys
+
+try:
+    import usb.core
+    import usb.util
+except ImportError:
+    sys.exit("missing dependency: pip install pyusb")
+
+RSKEY_VIDS = (0x1050, 0x1209)  # Yubico-interop build, then the RS-Key default
+HID_CLASS, CCID_CLASS = 0x03, 0x0B
+HID_GET_REPORT, FEATURE_REPORT = 0x01, 0x03 << 8
+REPORT_DESC_TYPE = 0x22
+# Usage Page (Generic Desktop) + Usage (Keyboard), and Usage Page (0xF1D0).
+KEYBOARD_DESC_PREFIX = bytes([0x05, 0x01, 0x09, 0x06])
+FIDO_DESC_PREFIX = bytes([0x06, 0xD0, 0xF1])
+STATUS_FRAME_LEN = 8
+
+
+def candidates():
+    found = []
+    for vid in RSKEY_VIDS:
+        found += list(usb.core.find(find_all=True, idVendor=vid))
+    return found
+
+
+def pick(index):
+    devs = candidates()
+    if not devs:
+        sys.exit("no RS-Key found (VID 0x1050 / 0x1209)")
+    if index is not None:
+        return devs[index]
+    ours = [d for d in devs if "RS" in (usb.util.get_string(d, d.iProduct) or "").upper()]
+    if len(ours) == 1:
+        return ours[0]
+    if len(devs) == 1:
+        return devs[0]
+    for i, d in enumerate(devs):
+        print(f"  --index {i}: {usb.util.get_string(d, d.iProduct)} bcdDevice=0x{d.bcdDevice:04x}")
+    sys.exit("several candidates — pass --index")
+
+
+@contextlib.contextmanager
+def claimed(dev, itf):
+    """Take the interface off the kernel, as ykpers does, and hand it back after."""
+    if dev.is_kernel_driver_active(itf):
+        dev.detach_kernel_driver(itf)
+    usb.util.claim_interface(dev, itf)
+    try:
+        yield
+    finally:
+        usb.util.release_interface(dev, itf)
+        with contextlib.suppress(usb.core.USBError):
+            dev.attach_kernel_driver(itf)
+
+
+def probe(dev, itf):
+    """(report descriptor, OTP status frame) — the frame is None if the device stalls."""
+    with claimed(dev, itf):
+        descriptor = bytes(
+            dev.ctrl_transfer(0x81, 0x06, REPORT_DESC_TYPE << 8, itf, 256, 1000)
+        )
+        try:
+            frame = bytes(
+                dev.ctrl_transfer(
+                    0xA1, HID_GET_REPORT, FEATURE_REPORT, itf, STATUS_FRAME_LEN, 1000
+                )
+            )
+        except usb.core.USBError as e:
+            frame = None
+            print(f"  itf {itf}: feature GET_REPORT refused — {e}")
+    return descriptor, frame
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--index", type=int, help="pick the nth candidate device")
+    args = ap.parse_args()
+
+    dev = pick(args.index)
+    print(f"{usb.util.get_string(dev, dev.iProduct)}  bcdDevice=0x{dev.bcdDevice:04x}")
+
+    interfaces = sorted(
+        (i.bInterfaceNumber, i.bInterfaceClass) for i in dev.get_active_configuration()
+    )
+    print(f"  interfaces: {interfaces}")
+    hid_itfs = [n for n, cls in interfaces if cls == HID_CLASS]
+    ccid_itfs = [n for n, cls in interfaces if cls == CCID_CLASS]
+    if len(hid_itfs) != 2:
+        sys.exit(f"FAIL: expected two HID interfaces, got {hid_itfs}")
+
+    kbd_itf, fido_itf = hid_itfs
+    probes = {itf: probe(dev, itf) for itf in hid_itfs}
+
+    if not probes[kbd_itf][0].startswith(KEYBOARD_DESC_PREFIX):
+        sys.exit(f"FAIL: interface {kbd_itf} is not the keyboard/OTP interface")
+    if not probes[fido_itf][0].startswith(FIDO_DESC_PREFIX):
+        sys.exit(f"FAIL: interface {fido_itf} is not the FIDO interface")
+    if kbd_itf != 0:
+        sys.exit(f"FAIL: keyboard/OTP must be interface 0, found it at {kbd_itf} — ykpers breaks")
+    if ccid_itfs and ccid_itfs[0] < fido_itf:
+        sys.exit(f"FAIL: CCID at {ccid_itfs[0]} precedes FIDO at {fido_itf}")
+    print(f"  OK  order: keyboard/OTP {kbd_itf}, FIDO {fido_itf}, CCID {ccid_itfs}")
+
+    for itf, (_, frame) in probes.items():
+        if frame is None or len(frame) != STATUS_FRAME_LEN:
+            sys.exit(f"FAIL: interface {itf} served no OTP status frame")
+        if not 1 <= frame[1] <= 9:
+            sys.exit(f"FAIL: interface {itf} status frame looks wrong: {frame.hex(' ')}")
+        print(
+            f"  OK  itf {itf} status frame {frame.hex(' ')} "
+            f"(version {frame[1]}.{frame[2]}.{frame[3]})"
+        )
+
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/77_otp_touch_wait.py
+++ b/tests/77_otp_touch_wait.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+"""A touch-gated challenge must not wedge the OTP transport.
+
+A slot programmed with `--touch` answers only after a button press, and reports
+the wait in the status byte (`0x20`). A host that meets that wait and moves on
+ends it one of two ways, both of which a YubiKey honours:
+
+  * the dummy write `0x8f` — an out-of-range sequence, ykpers `yk_force_key_update`;
+  * simply sending the next command, which supersedes the pending challenge.
+
+RS-Key honoured neither before bcdDevice `0x085B`: it sat in the wait and answered
+"would block" to everything for the whole touch timeout, which was enough to make
+KeePassXC treat the key as broken. This test needs no press — it checks that the
+device lets go, not that it computes the right HMAC (`73_otp_keyboard.py` covers
+that).
+
+    pip install pyusb
+    python tests/77_otp_touch_wait.py [--slot 1|2]
+
+**Linux only in practice**: libusb cannot claim a HID interface on macOS or
+Windows. The slot must be programmed as a `--touch` challenge-response slot —
+the test says so and skips if it sees no touch wait.
+"""
+import argparse
+import contextlib
+import sys
+import time
+
+try:
+    import usb.core
+    import usb.util
+except ImportError:
+    sys.exit("missing dependency: pip install pyusb")
+
+SLOT_CHAL_HMAC = {1: 0x30, 2: 0x38}
+SLOT_DEVICE_SERIAL = 0x10
+DUMMY_WRITE = 0x8F
+WRITE_FLAG = 0x80
+WAIT_FLAG, RESP_PENDING = 0x20, 0x40
+RELEASE_BUDGET = 3.0  # seconds; the touch timeout it must NOT wait out is 15-30
+
+
+def crc16(data):
+    crc = 0xFFFF
+    for b in data:
+        crc ^= b
+        for _ in range(8):
+            lsb = crc & 1
+            crc >>= 1
+            if lsb:
+                crc ^= 0x8408
+    return crc
+
+
+class Otp:
+    def __init__(self, dev, itf=0):
+        self.dev, self.itf = dev, itf
+
+    def status(self):
+        return bytes(self.dev.ctrl_transfer(0xA1, 0x01, 0x0300, self.itf, 8, 1000))
+
+    def put(self, report):
+        self.dev.ctrl_transfer(0x21, 0x09, 0x0300, self.itf, report, 1000)
+
+    def send_frame(self, slot_id):
+        frame = bytearray(70)
+        frame[64] = slot_id
+        frame[65:67] = crc16(bytes(64)).to_bytes(2, "little")
+        for seq in range(10):
+            self.put(bytes(frame[seq * 7 : seq * 7 + 7]) + bytes([WRITE_FLAG | seq]))
+
+    def wait_until(self, done, budget):
+        t0 = time.monotonic()
+        while time.monotonic() - t0 < budget:
+            st = self.status()
+            if done(st):
+                return time.monotonic() - t0, st
+            time.sleep(0.05)
+        return None, self.status()
+
+    def drain(self, budget=8.0):
+        """Read until the plain status frame settles (no response mid-stream)."""
+        t0, stable = time.monotonic(), 0
+        while time.monotonic() - t0 < budget:
+            stable = stable + 1 if self.status()[7] == 0 else 0
+            if stable >= 4:
+                return True
+            time.sleep(0.05)
+        return False
+
+
+def arm_and_confirm_wait(otp, slot_id):
+    otp.send_frame(slot_id)
+    took, st = otp.wait_until(lambda s: s[7] & WAIT_FLAG, 2.0)
+    if took is None:
+        sys.exit(
+            f"SKIP: no touch wait after arming (status {st.hex(' ')}) — program the "
+            "slot with `ykman otp chalresp --touch <slot>` and rerun"
+        )
+    return took
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--slot", type=int, choices=(1, 2), default=1)
+    args = ap.parse_args()
+
+    dev = None
+    for vid in (0x1050, 0x1209):
+        for d in usb.core.find(find_all=True, idVendor=vid):
+            if "RS" in (usb.util.get_string(d, d.iProduct) or "").upper():
+                dev = d
+    if dev is None:
+        sys.exit("no RS-Key found")
+    print(f"{usb.util.get_string(dev, dev.iProduct)}  bcdDevice=0x{dev.bcdDevice:04x}")
+
+    otp = Otp(dev)
+    if dev.is_kernel_driver_active(otp.itf):
+        dev.detach_kernel_driver(otp.itf)
+    usb.util.claim_interface(dev, otp.itf)
+    try:
+        if not otp.drain():
+            sys.exit("FAIL: the transport never settled to an idle status frame")
+
+        arm_and_confirm_wait(otp, SLOT_CHAL_HMAC[args.slot])
+        print("  armed: the device reports a touch wait")
+        otp.send_frame(SLOT_DEVICE_SERIAL)
+        took, st = otp.wait_until(lambda s: s[7] & RESP_PENDING, RELEASE_BUDGET)
+        if took is None:
+            sys.exit(f"FAIL: a new frame did not supersede the wait ({st.hex(' ')})")
+        print(f"  OK  a new frame superseded the wait in {took:.1f}s ({st[:4].hex()})")
+        otp.drain()
+
+        arm_and_confirm_wait(otp, SLOT_CHAL_HMAC[args.slot])
+        otp.put(bytes(7) + bytes([DUMMY_WRITE]))
+        took, st = otp.wait_until(lambda s: not s[7] & WAIT_FLAG, RELEASE_BUDGET)
+        if took is None:
+            sys.exit(f"FAIL: the 0x8f dummy write did not end the wait ({st.hex(' ')})")
+        print(f"  OK  the 0x8f dummy write ended the wait in {took:.1f}s")
+        otp.drain()
+    finally:
+        usb.util.release_interface(dev, otp.itf)
+        with contextlib.suppress(usb.core.USBError):
+            dev.attach_kernel_driver(otp.itf)
+
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Issue [#55](https://github.com/TheMaxMur/RS-Key/issues/55): challenge-response was unreachable from KeePassXC on Linux, and a `--touch` slot made things worse. Two independent defects, both found by measuring against a real YubiKey side by side.

### What was wrong

- **The interface order.** KeePassXC vendors `ykcore`, whose libusb backend claims USB interface 0 and sends the OTP frame reports there without reading a descriptor first. RS-Key enumerated the FIDO HID interface at 0, which serves no HID feature reports, so every transfer stalled — "Hardware key USB error: Pipe error". Windows and macOS were never affected: their `ykcore` backends go through the OS HID stack and land on the right interface whatever its index. The same backend carries `ykchalresp`, `ykinfo` and `pam_yubico`'s HMAC mode.
- **A touch-gated slot wedged the transport.** A host that meets a slot waiting for its button press ends that wait either with the dummy write `0x8f` or by simply sending the next command. RS-Key honoured neither, so it sat in the touch wait and answered "would block" to everything for the next 30 seconds. KeePassXC probes every slot before unlocking, so one touch slot made the whole key look broken.

### What changed

Interfaces now enumerate in the stock YubiKey order — keyboard/OTP, FIDO, CCID — and the OTP frame protocol answers on both HID interfaces, which is what a 5.7.4 YubiKey does while keeping the CTAP-exact FIDO report descriptor. Both paths that end a touch wait are honoured, scoped to the OTP transport so an abort there cannot abandon a FIDO ceremony on the same button.

bcdDevice `0x0858` → `0x085B`. Nothing else on the wire changed; hosts re-enumerate the device once after the upgrade.

### Verification

Flashed and measured on hardware with a real YubiKey 5C NFC as the control:

| | before | after |
|---|---|---|
| `ykchalresp` / `ykinfo` on Linux | `Pipe error` | same HMAC as the YubiKey |
| `keepassxc-cli` with a non-touch slot | no key found | key found, challenge completes |
| `keepassxc-cli` with a touch slot | wedged | asks for the touch, takes it, completes |
| abort a challenge → `ykinfo -s` | dead ~30 s | instant, like a YubiKey |

Two new device tests (`tests/02_usb_interfaces.py`, `tests/77_otp_touch_wait.py`) cover both regressions; a real YubiKey passes the first one unchanged. The frame-decoder half is covered by host tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)