### PR TITLE
Enhance firmware with cross-executor atomic ordering and UI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,10 +76,34 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   `firmware/src/presence.rs`.
 - **Test changed.** `t9_groups_are_printable_and_have_distinct_chars` checked
   for duplicate characters *within* each group (where the old
-  `rename_charset_is_printable_and_cycles` checked the whole charset). A
-  `const _: () = assert!(T9_GROUPS.len() == 10)` now pins the relationship
-  `hit_rename` (`Char(0..=9)`) expects, so a future edit that drops a group fails
-  the build instead of panicking on device at `groups[gi]`.
+  `rename_charset_is_printable_and_cycles` checked the whole charset). The test
+  now also rejects a character appearing in *two* groups — a T9 char must belong
+  to exactly one, else `active_group`/`cycle_at` on the rename screen is
+  ambiguous. (`const _: () = assert!(T9_GROUPS.len() == 10)` pins the
+  relationship `hit_rename` (`Char(0..=9)`) expects, so dropping a group fails
+  the build instead of panicking on device at `groups[gi]`.)
+- The AA fringe in `aa::filled_circle` now blends to a caller-passed `bg`
+  colour instead of the hardcoded `theme::BG` — truthful blending against
+  the surface the circle is drawn over, so a future AA circle on a card or
+  other non-`BG` region won't get a global-background halo. Existing call
+  sites (boot splash, reset warning, PIN-pad dots, success circle) pass
+  `theme::BG`, so the rendered output is byte-equivalent.
+- `firmware/build.rs` strips a trailing `# ...` comment from a TOML value
+  before parsing it (handling the `"`-quoted case, since a quoted value may
+  legitimately contain `#`). Previously `pin = 13 # GPIO for chip-select`
+  read as `13 # …` and panicked `parse_toml`'s `u32` helper; today's four
+  board configs are clean of inline comments, so this is a trap removed
+  for future edits, not a current-data fix.
+- `firmware/build.rs` renames the board-config display slice from `b2` to
+  `disp_cfg` and documents that `display_cs` is the semantic gate pin
+  (a `[display]` section without `cs` is dropped, and the knobs fall back
+  to the Waveshare defaults). It was previously a one-line clever `and_then`
+  with no note explaining why.
+- `masked_entry`'s `total` reverts to the v0.4.4 one-liner
+  `(expected as usize).max(entered).min(ENTRY_MAX_SHOWN)` — the UI redesign
+  rewrote it as an `if/else` with the same result and a cosier comment
+  ("no leftover outlines on delete") describing a change that didn't happen;
+  the original is shorter and says exactly what it does.
 
 ## [0.4.4] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
   so overriding `PK_DISPLAY_CS` etc. without touching `BOARD` reused the cached
   build and shipped a firmware with stale pins.
 
+### Removed
+
+- Dead code from the UI redesign: `aa::filled_rounded_rect` (~64 lines, never
+  called), and the `CARET_BLINK_MS` const left behind with `#[allow(dead_code)]`
+  after the rename pad switched from a caret blink to a T9 pending-char.
+
 ### Security
 
 - `docs/unsafe.md` records the four new `AnyPin::steal` sites (display

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,68 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **The PIN-entry band no longer leaves a stale "+" overflow marker and the right
+  half of the 10th dot behind when the user deletes from a long PIN back to ≤10
+  digits** (`render_pin_dots`). The repaint cleared one small rectangle per dot,
+  centred on each circle, but `masked_entry` draws dots top-left-aligned — so the
+  clear was off by `ENTRY_DIA/2` and missed the "+" at x 184 plus dot 10's right
+  tail (x 176..180). Deleting 11 → 10 left the "+" on screen for the rest of the
+  session, lying that the PIN was still long, and 10 → 9 left a one-pixel stub.
+  The repaint now clears one strip over the whole entry band (every dot position
+  plus the overflow slot to its right) before redrawing. Covered by a host test
+  in `rsk-ui`.
+
+### Changed
+
+- **`bcdDevice` bumped to `0x085C`.** The UI redesign (anti-aliased dots, the T9
+  phone keypad rename, the PIN-pad rewrite, the component system) was merged but a
+  merge-conflict resolution collapsed the `0x0859` bump back to `0x085B`, so
+  firmware behaviour changed while the version stayed flat. Restores the
+  per-behaviour-change bump the project policy requires.
+- **OpenPGP RSA heap restored to 128 KiB.** It was halved to 64 KiB inside the
+  per-board-config commit without a callout; on `embedded_alloc` a failed
+  allocation aborts (`handle_alloc_error` → panic → watchdog reset), so a long
+  PIN-pad-less RSA-4096 keygen/CRT mid-operation could reset the device. Back to
+  the v0.4.4 value until a separate justification for the smaller size is on
+  record.
+- **Display control GPIOs are now checked for collisions at compile time.** The
+  four new `AnyPin::steal` sites for `CS`/`DC`/`RST`/`TP_RST` were added by number
+  with no compile-time guard beyond `WAKE_PIN` vs the `10..=18` range, so a board
+  config could aim `cs` at the same pad as `WAKE_PIN`, `LED_PIN`, the hard-wired
+  SPI1 (`PIN_10/11/12`) / I2C1 (`PIN_6/7`) lines, or another control line, and
+  silently drive one pad from two owners. A `const _: () = assert!(...)` now
+  rejects all of those at build time. The backlight PWM `(pin, slice, channel)`
+  combo likewise had no compile-time guard and panicked at boot on an unsupported
+  board (a runtime panic on fully constant operands); it too is now a `const`
+  assert, and the runtime match arm is `unreachable!`.
+- **`firmware/build.rs` re-rustc's when any of the 11 `PK_DISPLAY_*` env vars
+  change.** They were the only env knobs missing a `cargo:rerun-if-env-changed`,
+  so overriding `PK_DISPLAY_CS` etc. without touching `BOARD` reused the cached
+  build and shipped a firmware with stale pins.
+
+### Security
+
+- `docs/unsafe.md` records the four new `AnyPin::steal` sites (display
+  `CS`/`DC`/`RST`/`TP_RST`) and the `firmware/build.rs` `env::set_var` site,
+  restoring the runtime-site count from 15 to 19 and matching the new
+  collision-assert containment in the prose.
+
+### Internal
+
+- Cross-executor `Ordering` consistency: the `CANCEL_REQUESTED.store(false, …)`
+  false-clears in `display/pin.rs` and `display/presence.rs` are `Relaxed` (no
+  publication occurs from a `false` store — the publication is the subsequent
+  `true`/`Release` store), matching the same false-clears already in
+  `firmware/src/presence.rs`.
+- **Test changed.** `t9_groups_are_printable_and_have_distinct_chars` checked
+  for duplicate characters *within* each group (where the old
+  `rename_charset_is_printable_and_cycles` checked the whole charset). A
+  `const _: () = assert!(T9_GROUPS.len() == 10)` now pins the relationship
+  `hit_rename` (`Char(0..=9)`) expects, so a future edit that drops a group fails
+  the build instead of panicking on device at `groups[gi]`.
+
 ## [0.4.4] - 2026-07-27
 
 ### Fixed

--- a/crates/rsk-ui/src/aa.rs
+++ b/crates/rsk-ui/src/aa.rs
@@ -9,7 +9,6 @@ use embedded_graphics::{
     geometry::Point as EgPoint,
     pixelcolor::Rgb565,
     prelude::{Drawable, RgbColor},
-    primitives::Rectangle,
 };
 
 use crate::theme;
@@ -20,8 +19,8 @@ const FP_HALF: i64 = FP_ONE / 2;
 const AA_BAND: i64 = FP_ONE + FP_HALF;
 
 const ALPHA: [u8; 32] = [
-    255, 247, 239, 231, 223, 215, 207, 199, 191, 183, 175, 167, 159, 151, 143, 135, 128, 120,
-    112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8,
+    255, 247, 239, 231, 223, 215, 207, 199, 191, 183, 175, 167, 159, 151, 143, 135, 128, 120, 112,
+    104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8,
 ];
 
 /// Anti-aliased filled circle. Takes top-left and diameter (same API as
@@ -68,76 +67,13 @@ pub fn filled_circle<D: DrawTarget<Color = Rgb565>>(
     Ok(())
 }
 
-/// Anti-aliased filled rounded rectangle. Same API as
-/// `RoundedRectangle::with_equal_corners(rect, size)`.
-pub fn filled_rounded_rect<D: DrawTarget<Color = Rgb565>>(
-    t: &mut D,
-    bounds: Rectangle,
-    corner_radius: u32,
-    fill: Rgb565,
-) -> Result<(), D::Error> {
-    let bx = bounds.top_left.x;
-    let by = bounds.top_left.y;
-    let bw = bounds.size.width as i32;
-    let bh = bounds.size.height as i32;
-    let cr_u = corner_radius as i32;
-    let cr = i64::from(corner_radius) << FP;
-    let cr_inner = cr - AA_BAND;
-    let cr_outer = cr + AA_BAND;
-    let cr_inner_sq = cr_inner * cr_inner;
-    let cr_outer_sq = cr_outer * cr_outer;
-
-    let c_tl_x = i64::from(bx + cr_u) << FP;
-    let c_tl_y = i64::from(by + cr_u) << FP;
-    let c_tr_x = i64::from(bx + bw - cr_u) << FP;
-    let c_bl_y = i64::from(by + bh - cr_u) << FP;
-
-    let straight_x0 = bx + cr_u;
-    let straight_x1 = bx + bw - cr_u;
-    let straight_y0 = by + cr_u;
-    let straight_y1 = by + bh - cr_u;
-
-    for py in by..by + bh {
-        for px in bx..bx + bw {
-            if (px >= straight_x0 && px < straight_x1) || (py >= straight_y0 && py < straight_y1) {
-                Pixel(EgPoint::new(px, py), fill).draw(t)?;
-                continue;
-            }
-
-            let pxf = i64::from(px) << FP;
-            let pyf = i64::from(py) << FP;
-
-            let d2 = if px < straight_x0 && py < straight_y0 {
-                (pxf - c_tl_x).pow(2) + (pyf - c_tl_y).pow(2)
-            } else if px >= straight_x1 && py < straight_y0 {
-                (pxf - c_tr_x).pow(2) + (pyf - c_tl_y).pow(2)
-            } else if px < straight_x0 && py >= straight_y1 {
-                (pxf - c_tl_x).pow(2) + (pyf - c_bl_y).pow(2)
-            } else if px >= straight_x1 && py >= straight_y1 {
-                (pxf - c_tr_x).pow(2) + (pyf - c_bl_y).pow(2)
-            } else {
-                continue;
-            };
-
-            let color = if d2 <= cr_inner_sq {
-                fill
-            } else if d2 >= cr_outer_sq {
-                continue;
-            } else {
-                let frac = (d2 - cr_inner_sq) as u64 * 32 / (cr_outer_sq - cr_inner_sq) as u64;
-                let a = ALPHA[frac.min(31) as usize];
-                blend(fill, theme::BG, a)
-            };
-
-            Pixel(EgPoint::new(px, py), color).draw(t)?;
-        }
-    }
-    Ok(())
-}
-
 fn blend(fg: Rgb565, bg: Rgb565, alpha: u8) -> Rgb565 {
-    if alpha == 0 { return bg; }
-    if alpha == 255 { return fg; }
+    if alpha == 0 {
+        return bg;
+    }
+    if alpha == 255 {
+        return fg;
+    }
     let a = alpha as u32;
     let inv = 255 - a;
     let r = (fg.r() as u32 * a + bg.r() as u32 * inv) / 255;

--- a/crates/rsk-ui/src/aa.rs
+++ b/crates/rsk-ui/src/aa.rs
@@ -11,8 +11,6 @@ use embedded_graphics::{
     prelude::{Drawable, RgbColor},
 };
 
-use crate::theme;
-
 const FP: u32 = 16;
 const FP_ONE: i64 = 1 << FP;
 const FP_HALF: i64 = FP_ONE / 2;
@@ -24,12 +22,15 @@ const ALPHA: [u8; 32] = [
 ];
 
 /// Anti-aliased filled circle. Takes top-left and diameter (same API as
-/// embedded-graphics `Circle::new`), so call sites stay unchanged.
+/// embedded-graphics `Circle::new`), plus the colour behind the circle, so the
+/// AA fringe blends to the right surface — not always `theme::BG` (a circle over
+/// a card must blend to the card, else it gets a global-BG halo).
 pub fn filled_circle<D: DrawTarget<Color = Rgb565>>(
     t: &mut D,
     top_left: EgPoint,
     diameter: u32,
     fill: Rgb565,
+    bg: Rgb565,
 ) -> Result<(), D::Error> {
     let cx = top_left.x + diameter as i32 / 2;
     let cy = top_left.y + diameter as i32 / 2;
@@ -58,7 +59,7 @@ pub fn filled_circle<D: DrawTarget<Color = Rgb565>>(
             } else {
                 let frac = (d2 - r_inner_sq) as u64 * 32 / (r_outer_sq - r_inner_sq) as u64;
                 let a = ALPHA[frac.min(31) as usize];
-                blend(fill, theme::BG, a)
+                blend(fill, bg, a)
             };
 
             Pixel(EgPoint::new(px, py), color).draw(t)?;

--- a/crates/rsk-ui/src/aa.rs
+++ b/crates/rsk-ui/src/aa.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! Anti-aliased drawing for the ST7789 panel. Integer math only (no_std, no libm).
+
+use embedded_graphics::{
+    Pixel,
+    draw_target::DrawTarget,
+    geometry::Point as EgPoint,
+    pixelcolor::Rgb565,
+    prelude::{Drawable, RgbColor},
+    primitives::Rectangle,
+};
+
+use crate::theme;
+
+const FP: u32 = 16;
+const FP_ONE: i64 = 1 << FP;
+const FP_HALF: i64 = FP_ONE / 2;
+const AA_BAND: i64 = FP_ONE + FP_HALF;
+
+const ALPHA: [u8; 32] = [
+    255, 247, 239, 231, 223, 215, 207, 199, 191, 183, 175, 167, 159, 151, 143, 135, 128, 120,
+    112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8,
+];
+
+/// Anti-aliased filled circle. Takes top-left and diameter (same API as
+/// embedded-graphics `Circle::new`), so call sites stay unchanged.
+pub fn filled_circle<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    top_left: EgPoint,
+    diameter: u32,
+    fill: Rgb565,
+) -> Result<(), D::Error> {
+    let cx = top_left.x + diameter as i32 / 2;
+    let cy = top_left.y + diameter as i32 / 2;
+    let r = i64::from(diameter) << (FP - 1);
+    let r_inner = r - AA_BAND;
+    let r_outer = r + AA_BAND;
+    let r_inner_sq = r_inner * r_inner;
+    let r_outer_sq = r_outer * r_outer;
+
+    let r2 = diameter as i32 / 2 + 3;
+    let min_x = cx - r2;
+    let max_x = cx + r2;
+    let min_y = cy - r2;
+    let max_y = cy + r2;
+
+    for py in min_y..=max_y {
+        for px in min_x..=max_x {
+            let dx = i64::from(px - cx) << FP;
+            let dy = i64::from(py - cy) << FP;
+            let d2 = dx * dx + dy * dy;
+
+            let color = if d2 <= r_inner_sq {
+                fill
+            } else if d2 >= r_outer_sq {
+                continue;
+            } else {
+                let frac = (d2 - r_inner_sq) as u64 * 32 / (r_outer_sq - r_inner_sq) as u64;
+                let a = ALPHA[frac.min(31) as usize];
+                blend(fill, theme::BG, a)
+            };
+
+            Pixel(EgPoint::new(px, py), color).draw(t)?;
+        }
+    }
+    Ok(())
+}
+
+/// Anti-aliased filled rounded rectangle. Same API as
+/// `RoundedRectangle::with_equal_corners(rect, size)`.
+pub fn filled_rounded_rect<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    bounds: Rectangle,
+    corner_radius: u32,
+    fill: Rgb565,
+) -> Result<(), D::Error> {
+    let bx = bounds.top_left.x;
+    let by = bounds.top_left.y;
+    let bw = bounds.size.width as i32;
+    let bh = bounds.size.height as i32;
+    let cr_u = corner_radius as i32;
+    let cr = i64::from(corner_radius) << FP;
+    let cr_inner = cr - AA_BAND;
+    let cr_outer = cr + AA_BAND;
+    let cr_inner_sq = cr_inner * cr_inner;
+    let cr_outer_sq = cr_outer * cr_outer;
+
+    let c_tl_x = i64::from(bx + cr_u) << FP;
+    let c_tl_y = i64::from(by + cr_u) << FP;
+    let c_tr_x = i64::from(bx + bw - cr_u) << FP;
+    let c_bl_y = i64::from(by + bh - cr_u) << FP;
+
+    let straight_x0 = bx + cr_u;
+    let straight_x1 = bx + bw - cr_u;
+    let straight_y0 = by + cr_u;
+    let straight_y1 = by + bh - cr_u;
+
+    for py in by..by + bh {
+        for px in bx..bx + bw {
+            if (px >= straight_x0 && px < straight_x1) || (py >= straight_y0 && py < straight_y1) {
+                Pixel(EgPoint::new(px, py), fill).draw(t)?;
+                continue;
+            }
+
+            let pxf = i64::from(px) << FP;
+            let pyf = i64::from(py) << FP;
+
+            let d2 = if px < straight_x0 && py < straight_y0 {
+                (pxf - c_tl_x).pow(2) + (pyf - c_tl_y).pow(2)
+            } else if px >= straight_x1 && py < straight_y0 {
+                (pxf - c_tr_x).pow(2) + (pyf - c_tl_y).pow(2)
+            } else if px < straight_x0 && py >= straight_y1 {
+                (pxf - c_tl_x).pow(2) + (pyf - c_bl_y).pow(2)
+            } else if px >= straight_x1 && py >= straight_y1 {
+                (pxf - c_tr_x).pow(2) + (pyf - c_bl_y).pow(2)
+            } else {
+                continue;
+            };
+
+            let color = if d2 <= cr_inner_sq {
+                fill
+            } else if d2 >= cr_outer_sq {
+                continue;
+            } else {
+                let frac = (d2 - cr_inner_sq) as u64 * 32 / (cr_outer_sq - cr_inner_sq) as u64;
+                let a = ALPHA[frac.min(31) as usize];
+                blend(fill, theme::BG, a)
+            };
+
+            Pixel(EgPoint::new(px, py), color).draw(t)?;
+        }
+    }
+    Ok(())
+}
+
+fn blend(fg: Rgb565, bg: Rgb565, alpha: u8) -> Rgb565 {
+    if alpha == 0 { return bg; }
+    if alpha == 255 { return fg; }
+    let a = alpha as u32;
+    let inv = 255 - a;
+    let r = (fg.r() as u32 * a + bg.r() as u32 * inv) / 255;
+    let g = (fg.g() as u32 * a + bg.g() as u32 * inv) / 255;
+    let b = (fg.b() as u32 * a + bg.b() as u32 * inv) / 255;
+    Rgb565::new(r as u8, g as u8, b as u8)
+}

--- a/crates/rsk-ui/src/kani.rs
+++ b/crates/rsk-ui/src/kani.rs
@@ -162,18 +162,19 @@ fn pager_clear_of_rows_and_nav() {
 }
 
 /// On the rename screen no tap maps to two wheel keys, and a wheel tap never also
-/// hits the back chevron (cancel) — so committing, editing, and cancelling can't be
-/// confused for one another.
+/// T9 keypad keys + back chevron are pairwise disjoint — no tap can be ambiguous.
 #[kani::proof]
 fn rename_keys_are_unambiguous() {
     let p = Point::new(kani::any(), kani::any());
-    let hits = [
-        RN_UP_RECT.contains(p),
-        RN_DOWN_RECT.contains(p),
-        RN_BKSP_RECT.contains(p),
-        RN_INS_RECT.contains(p),
-        RN_SAVE_RECT.contains(p),
-    ];
-    assert!(hits.iter().filter(|&&b| b).count() <= 1);
+    // Check all 12 keypad keys are disjoint
+    let mut hits = 0u32;
+    for row in 0..4u16 {
+        for col in 0..3u16 {
+            if t9_key_rect(row, col).contains(p) {
+                hits += 1;
+            }
+        }
+    }
+    assert!(hits <= 1);
     assert!(!(hit_rename(p).is_some() && hit_title_back(p)));
 }

--- a/crates/rsk-ui/src/lib.rs
+++ b/crates/rsk-ui/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![cfg_attr(not(test), no_std)]
 
+pub mod aa;
 pub mod font;
 pub mod glyph;
 pub mod render;
@@ -32,9 +33,10 @@ pub use render::{
     render_pin_blocked, render_pin_dots, render_pin_title, render_piv, render_piv_extra,
     render_piv_keygen_confirm, render_piv_keygen_pick, render_piv_keygen_rsa_pick,
     render_piv_keygen_working, render_piv_pin_menu, render_piv_protect_confirm, render_piv_slot,
-    render_rebooting, render_rename, render_rename_caret, render_reveal_warning,
-    render_seal_confirm, render_seed_phrase, render_service, render_share_picker,
-    render_slip39_share, render_status_arc, render_success, render_success_circle,
+    render_rebooting, render_rename, render_rename_field, render_rename_keys,
+    render_reveal_warning, render_seal_confirm, render_seed_phrase, render_service,
+    render_share_picker, render_slip39_share, render_status_arc, render_success,
+    render_success_circle,
 };
 pub use settings_store::{CONF_LEN as DISPLAY_CONF_LEN, DisplayConfig};
 
@@ -624,7 +626,7 @@ const ROW_X: u16 = 13;
 const ROW_W: u16 = PANEL_W - 2 * ROW_X;
 const ROW_H: u16 = 36;
 const ROW_GAP: u16 = 6;
-const ROW_Y0: u16 = CONTENT_TOP + 14;
+const ROW_Y0: u16 = CONTENT_TOP + CONTENT_GAP;
 /// Number of Root list rows (Display / Security / Firmware).
 pub const SETTINGS_ROWS: u16 = 3;
 
@@ -855,6 +857,8 @@ pub const STATUS_BAR_H: u16 = 24;
 pub const TITLE_BAR_H: u16 = 30;
 /// Top of a tab screen's content, below both chrome strips.
 pub const CONTENT_TOP: u16 = STATUS_BAR_H + TITLE_BAR_H;
+/// Uniform gap between the title bar and the first content row (list, settings, etc.).
+pub const CONTENT_GAP: u16 = 10;
 
 /// The title-bar back affordance (a pushed screen's "return to parent" chevron), in the
 /// title bar below the status bar. Distinct from [`PK_BACK_RECT`] — the chrome-less
@@ -886,7 +890,7 @@ const _: () = {
 };
 
 /// Bottom navigation-bar height.
-pub const NAV_H: u16 = 38;
+pub const NAV_H: u16 = 36;
 /// Top edge of the bottom nav bar.
 pub const NAV_TOP: u16 = PANEL_H - NAV_H;
 
@@ -937,9 +941,9 @@ pub fn hit_nav(p: Point) -> Option<NavTab> {
 }
 
 /// List-row height (a lifted card holding icon + label + trailing + chevron).
-pub const LIST_ROW_H: u16 = 30;
-const LIST_ROW_GAP: u16 = 6;
-const LIST_ROW_X: u16 = 13;
+pub const LIST_ROW_H: u16 = 34;
+const LIST_ROW_GAP: u16 = 2;
+const LIST_ROW_X: u16 = 8;
 /// List-row width, inset from both panel edges.
 pub const LIST_ROW_W: u16 = PANEL_W - 2 * LIST_ROW_X;
 
@@ -1022,7 +1026,7 @@ pub struct HomeView {
 pub const PK_ROWS_MAX: usize = 5;
 /// Top of the first passkey row — below the status + title bars, clear of the nav bar
 /// and footer.
-pub const PK_LIST_TOP: u16 = CONTENT_TOP + 4;
+pub const PK_LIST_TOP: u16 = CONTENT_TOP + CONTENT_GAP;
 
 /// One relying-party row on the Passkeys list: a sanitized rpId, an optional device-local
 /// nickname ([`render_passkeys_list`] shows it instead of the rpId when set), and how many
@@ -1144,75 +1148,107 @@ pub fn hit_del_hold(p: Point) -> bool {
     DEL_HOLD_RECT.contains(p)
 }
 
-// --- Rename (set a device-local RP nickname via a character wheel) ----------
+// --- Rename (set a device-local RP nickname via a T9 phone-style keypad) -----
 
-/// The character set the rename wheel cycles through: lowercase, digits, and a few
-/// punctuation marks plus a trailing space. A deliberately small printable-ASCII
-/// alphabet — the stored nickname is sanitized by [`Label`] regardless, but cycling a
-/// known set keeps the wheel legible and the entry predictable.
-pub const RENAME_CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789-_. ";
+/// T9 key groups: each press cycles to the next character in the group.
+/// Order: digit first, then letters, then symbols (like old phone keypads).
+pub const T9_GROUPS: &[&[u8]] = &[
+    b"1.-_",  // key (0,0)
+    b"2abc",  // key (0,1)
+    b"3def",  // key (0,2)
+    b"4ghi",  // key (1,0)
+    b"5jkl",  // key (1,1)
+    b"6mno",  // key (1,2)
+    b"7pqrs", // key (2,0)
+    b"8tuv",  // key (2,1)
+    b"9wxyz", // key (2,2)
+    b"0 ",    // key (3,1)
+];
 
-/// A key on the rename character wheel.
+/// Labels shown on the T9 keypad keys: (digit, letters).
+pub const T9_KEY_LABELS: &[(&str, &str)] = &[
+    ("1", ".-_"),
+    ("2", "ABC"),
+    ("3", "DEF"),
+    ("4", "GHI"),
+    ("5", "JKL"),
+    ("6", "MNO"),
+    ("7", "PQRS"),
+    ("8", "TUV"),
+    ("9", "WXYZ"),
+    ("0", "\u{2423}"),
+];
+
+/// A key on the T9 rename keypad.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum RenameKey {
-    /// Cycle the candidate character up (next in [`RENAME_CHARSET`]).
-    Up,
-    /// Cycle the candidate character down (previous).
-    Down,
-    /// Append the current candidate to the nickname.
-    Insert,
-    /// Delete the last character of the nickname.
+    /// A character-group key (index into [`T9_GROUPS`]).
+    Char(usize),
+    /// Delete the last character.
     Backspace,
     /// Commit the nickname.
     Save,
 }
 
-/// The nickname value field (shows the current text + a caret).
-pub const RN_FIELD_RECT: Rect = Rect::new(12, CONTENT_TOP + 22, 216, 34);
-/// Cycle-up button (top of the centre column).
-pub const RN_UP_RECT: Rect = Rect::new(94, 122, 52, 36);
-/// Cycle-down button (bottom of the centre column).
-pub const RN_DOWN_RECT: Rect = Rect::new(94, 196, 52, 36);
-/// Backspace key (left of the wheel).
-pub const RN_BKSP_RECT: Rect = Rect::new(16, 160, 56, 56);
-/// Insert key (right of the wheel) — appends the candidate.
-pub const RN_INS_RECT: Rect = Rect::new(168, 160, 56, 56);
-/// The full-width **Save** button, in the shared bottom button band.
-pub const RN_SAVE_RECT: Rect = Rect::new(BTN_SIDE, BTN_BAND_TOP, PANEL_W - 2 * BTN_SIDE, BTN_H);
+/// T9 keypad grid dimensions.
+const T9_COLS: u16 = 3;
+const T9_ROWS: u16 = 4;
+const T9_KEY_W: u16 = 70;
+const T9_KEY_H: u16 = 40;
+const T9_GAP_X: u16 = 4;
+const T9_GAP_Y: u16 = 4;
+const T9_LEFT: u16 = (PANEL_W - T9_COLS * T9_KEY_W - (T9_COLS - 1) * T9_GAP_X) / 2;
+pub const T9_TOP: u16 = 116;
 
-/// Which rename-wheel key, if any, a tap at `p` selects. The rects are disjoint by
-/// construction (proven below), so at most one matches; the title-bar back chevron
-/// (handled separately) cancels.
-pub fn hit_rename(p: Point) -> Option<RenameKey> {
-    if RN_UP_RECT.contains(p) {
-        Some(RenameKey::Up)
-    } else if RN_DOWN_RECT.contains(p) {
-        Some(RenameKey::Down)
-    } else if RN_BKSP_RECT.contains(p) {
-        Some(RenameKey::Backspace)
-    } else if RN_INS_RECT.contains(p) {
-        Some(RenameKey::Insert)
-    } else if RN_SAVE_RECT.contains(p) {
-        Some(RenameKey::Save)
-    } else {
-        None
-    }
+/// The rect of the T9 key at (row, col).
+pub const fn t9_key_rect(row: u16, col: u16) -> Rect {
+    Rect::new(
+        T9_LEFT + col * (T9_KEY_W + T9_GAP_X),
+        T9_TOP + row * (T9_KEY_H + T9_GAP_Y),
+        T9_KEY_W,
+        T9_KEY_H,
+    )
 }
 
-// Compile-time: every wheel control is on-panel, the field clears the status/title
-// chrome, the wheel sits above the Save band, and the five tap targets are pairwise
-// disjoint (so no tap is ambiguous). The centre column (Up/Down) is separated from the
-// side keys (Backspace/Insert) by x; Up/Down/Save are separated from each other by y.
+/// Which T9 key, if any, a tap at `p` selects.
+pub fn hit_rename(p: Point) -> Option<RenameKey> {
+    let mut row = 0;
+    while row < T9_ROWS {
+        let mut col = 0;
+        while col < T9_COLS {
+            if t9_key_rect(row, col).contains(p) {
+                return Some(match (row, col) {
+                    (3, 0) => RenameKey::Backspace,
+                    (3, 2) => RenameKey::Save,
+                    _ => {
+                        let idx = if row < 3 {
+                            (row * T9_COLS + col) as usize
+                        } else {
+                            9 // (3, 1) = 0/space group
+                        };
+                        RenameKey::Char(idx)
+                    }
+                });
+            }
+            col += 1;
+        }
+        row += 1;
+    }
+    None
+}
+
+/// The nickname value field (shows the current text + pending char).
+pub const RN_FIELD_RECT: Rect = Rect::new(12, CONTENT_TOP + 22, 216, 34);
+
+// Compile-time: the T9 keypad fits between the text field and the panel bottom,
+// all keys are on-panel, and the grid has real gaps.
 const _: () = {
     assert!(RN_FIELD_RECT.y >= CONTENT_TOP);
-    assert!(RN_UP_RECT.y > RN_FIELD_RECT.y + RN_FIELD_RECT.h);
-    assert!(RN_UP_RECT.y + RN_UP_RECT.h <= RN_DOWN_RECT.y); // Up above Down
-    assert!(RN_DOWN_RECT.y + RN_DOWN_RECT.h <= RN_SAVE_RECT.y); // wheel above Save
-    assert!(RN_SAVE_RECT.y + RN_SAVE_RECT.h <= PANEL_H);
-    // Side keys are clear of the centre column by x.
-    assert!(RN_BKSP_RECT.x + RN_BKSP_RECT.w <= RN_UP_RECT.x);
-    assert!(RN_UP_RECT.x + RN_UP_RECT.w <= RN_INS_RECT.x);
-    assert!(RN_INS_RECT.x + RN_INS_RECT.w <= PANEL_W);
+    assert!(RN_FIELD_RECT.y + RN_FIELD_RECT.h + 6 <= T9_TOP); // field clear of keypad
+    let last = t9_key_rect(T9_ROWS - 1, T9_COLS - 1);
+    assert!(last.y + last.h <= PANEL_H); // keypad on panel
+    assert!(T9_LEFT > 0 && T9_KEY_W > 0 && T9_GAP_X > 0 && T9_GAP_Y > 0);
+    assert!(T9_LEFT + T9_COLS * T9_KEY_W + (T9_COLS - 1) * T9_GAP_X <= PANEL_W);
 };
 
 // --- Success screens (the design's "pop" confirmation moments) --------------

--- a/crates/rsk-ui/src/lib.rs
+++ b/crates/rsk-ui/src/lib.rs
@@ -1165,6 +1165,13 @@ pub const T9_GROUPS: &[&[u8]] = &[
     b"0 ",    // key (3,1)
 ];
 
+// hit_rename returns Char(0..=9), so the index-based groups[] access in
+// run_rename is sound only while T9_GROUPS holds exactly 10 entries.
+const _: () = assert!(
+    T9_GROUPS.len() == 10,
+    "hit_rename assumes T9_GROUPS.len() == 10; out-of-range => panic on device"
+);
+
 /// Labels shown on the T9 keypad keys: (digit, letters).
 pub const T9_KEY_LABELS: &[(&str, &str)] = &[
     ("1", ".-_"),

--- a/crates/rsk-ui/src/render.rs
+++ b/crates/rsk-ui/src/render.rs
@@ -17,7 +17,7 @@ use embedded_graphics::{
     pixelcolor::Rgb565,
     primitives::{
         Arc, Circle, Line, Primitive, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle,
-        RoundedRectangle, StrokeAlignment, Triangle,
+        RoundedRectangle, StrokeAlignment,
     },
 };
 
@@ -29,11 +29,10 @@ use crate::{
     PANEL_H, PANEL_W, PICK_CONTINUE_RECT, PICK_N_MINUS_RECT, PICK_N_PLUS_RECT, PICK_T_MINUS_RECT,
     PICK_T_PLUS_RECT, PIN_CANCEL_RECT, PIN_COLS, PIN_EYE_RECT, PIN_ROWS, PIV_KEYGEN_PICK_ROWS,
     PIV_KEYGEN_PICK_TOP, PIV_PIN_MENU_ROWS, PIV_ROWS, PIV_RSA_PICK_ROWS, PK_BACK_RECT, PK_LIST_TOP,
-    PinCaption, PinKey, PinPad, Point, RN_BKSP_RECT, RN_DOWN_RECT, RN_FIELD_RECT, RN_INS_RECT,
-    RN_SAVE_RECT, RN_UP_RECT, Rect, RevealKind, RpRow, STATUS_BAR_H, Screen, SettingsPage,
-    SettingsView, StatusKind, SuccessKind, TITLE_BACK_RECT, TITLE_BAR_H, TITLE_EDIT_RECT, font,
-    font::Role, glyph, hex_u16, hex_u64, nav_tab_rect, page_count, pin_grid_key, pin_key_rect,
-    settings_row_rect, theme,
+    PinCaption, PinKey, PinPad, Point, RN_FIELD_RECT, Rect, RevealKind, RpRow, STATUS_BAR_H,
+    Screen, SettingsPage, SettingsView, StatusKind, SuccessKind, T9_KEY_LABELS, TITLE_BACK_RECT,
+    TITLE_BAR_H, TITLE_EDIT_RECT, font, font::Role, glyph, hex_u16, hex_u64, nav_tab_rect,
+    page_count, pin_grid_key, pin_key_rect, settings_row_rect, t9_key_rect, theme,
 };
 use crate::{
     AppsView, CardholderView, OathDetailView, OathRow, OpenpgpView, PgpKeyView, PivExtraRow,
@@ -45,6 +44,7 @@ mod audit;
 mod backup;
 mod boot;
 mod ceremony;
+mod components;
 mod home;
 mod passkeys;
 mod pin;
@@ -66,7 +66,8 @@ pub use boot::render_locked_breathe;
 pub use ceremony::render_add_passkey;
 pub use home::{STATUS_ARC_START, render_status_arc};
 pub use passkeys::{
-    render_confirm_delete, render_passkeys_list, render_rename, render_rename_caret, render_service,
+    render_confirm_delete, render_passkeys_list, render_rename, render_rename_field,
+    render_rename_keys, render_service,
 };
 pub use pin::{PIN_TITLE_BAND, pin_title_overflows, render_pin_dots, render_pin_title};
 pub use reset::{
@@ -659,26 +660,10 @@ fn card<D: DrawTarget<Color = Rgb565>>(
         .draw(t)
 }
 
-/// One standalone list row: its own [`card`] plus the [`row_body`] content. The geometry is
-/// the caller's `rect` (from `row_rect`), so paint and [`crate::hit_list`] share it. A
-/// grouped list paints one [`group_card`] then calls [`row_body`] per row instead, so the
-/// rows read as a single panel rather than a stack of separate pills.
-pub fn render_row<D: DrawTarget<Color = Rgb565>>(
-    t: &mut D,
-    rect: Rect,
-    icon: Glyph,
-    label: &str,
-    trailing: Option<(&str, Rgb565)>,
-    chevron: bool,
-) -> Result<(), D::Error> {
-    card(t, rect, theme::ROW_BG, theme::BORDER_CARD)?;
-    row_body(t, rect, icon, label, trailing, chevron, false)
-}
-
 /// The content of one list row — a leading glyph (on a service `chip` when set), the label,
 /// an optional trailing coloured status/value, and an optional drill-in chevron — *without*
-/// the card behind it. [`render_row`] adds the card for a standalone row; [`group_card`]
-/// backs a whole grouped list, then each row's content is drawn with this.
+/// the card behind it. [`group_card`] backs a whole grouped list, then each row's content
+/// is drawn with this.
 fn row_body<D: DrawTarget<Color = Rgb565>>(
     t: &mut D,
     rect: Rect,
@@ -688,28 +673,7 @@ fn row_body<D: DrawTarget<Color = Rgb565>>(
     chevron: bool,
     chip: bool,
 ) -> Result<(), D::Error> {
-    // Default: keep the head (tail-ellipsis) — the label is static or a user-chosen name.
-    row_body_side(t, rect, icon, label, trailing, chevron, chip, false)
-}
-
-/// [`row_body`] with an explicit ellipsis side: `domain = true` keeps the registrable-domain
-/// **suffix** (head-ellipsis) for an attacker-chosen relying-party id, so a padded look-alike
-/// can't hide the real domain behind the cut on the passkey list. Every other row keeps the
-/// head like [`row_body`].
-#[allow(clippy::too_many_arguments)]
-fn row_body_side<D: DrawTarget<Color = Rgb565>>(
-    t: &mut D,
-    rect: Rect,
-    icon: Glyph,
-    label: &str,
-    trailing: Option<(&str, Rgb565)>,
-    chevron: bool,
-    chip: bool,
-    domain: bool,
-) -> Result<(), D::Error> {
     let cy = rect.y as i32 + rect.h as i32 / 2;
-    // A service row carries the design's icon chip — a small rounded tile behind the glyph;
-    // status / settings rows draw the glyph bare. The label x is unchanged either way.
     let gx = if chip {
         RoundedRectangle::with_equal_corners(
             eg_rect(Rect::new(rect.x + 3, (cy - 11) as u16, 22, 22)),
@@ -722,8 +686,6 @@ fn row_body_side<D: DrawTarget<Color = Rgb565>>(
         rect.x + 8
     };
     glyph::draw(t, icon, Point::new(gx, (cy - 7) as u16), 14, theme::GREY)?;
-    // Lay the trailing block (chevron, then the value flush against it) first, tracking
-    // the leftmost x it occupies — the label is then clipped to end before it.
     let mut right_x = rect.x as i32 + rect.w as i32 - 8;
     if chevron {
         right_x -= 12;
@@ -738,9 +700,6 @@ fn row_body_side<D: DrawTarget<Color = Rgb565>>(
     let label_x = rect.x as i32 + 28;
     let label_right = if let Some((txt, col)) = trailing {
         let tx = right_x - 4;
-        // The trailing value can be host-controlled (e.g. the OpenPGP cardholder
-        // name) — clip it to the row so a long string can't overrun left across the
-        // icon and off the panel edge. Short static values are unaffected.
         let tclip = Rect::new(label_x as u16, rect.y, (tx - label_x).max(0) as u16, rect.h);
         font::right(
             &mut t.clipped(&eg_rect(tclip)),
@@ -760,11 +719,7 @@ fn row_body_side<D: DrawTarget<Color = Rgb565>>(
         rect.h,
     );
     let at = EgPoint::new(label_x, cy);
-    if domain {
-        text_right_ellipsized(t, label, at, Role::Body, theme::TEXT, clip, false)
-    } else {
-        text_left_ellipsized(t, label, at, Role::Body, theme::TEXT, clip, false)
-    }
+    text_left_ellipsized(t, label, at, Role::Body, theme::TEXT, clip, false)
 }
 
 /// Paint one grouped surface behind list rows `0..n` (each at `row_rect(y0, i)`), with a

--- a/crates/rsk-ui/src/render/applets.rs
+++ b/crates/rsk-ui/src/render/applets.rs
@@ -3,6 +3,7 @@
 
 //! Applet hub screens: the OpenPGP / PIV / OATH overviews, details, and keygen flows.
 
+use super::components;
 use super::*;
 
 // --- Applet hub (OpenPGP / PIV / OATH) --------------------------------------
@@ -204,16 +205,18 @@ where
             ),
         ),
     ];
-    group_card(t, PK_LIST_TOP, rows.len() as u16)?;
+    components::list::group_card(t, PK_LIST_TOP, rows.len() as u16)?;
     for (i, (g, name, trailing)) in rows.into_iter().enumerate() {
-        row_body(
+        components::list::row(
             t,
-            crate::row_rect(PK_LIST_TOP, i as u16),
+            PK_LIST_TOP,
+            i as u16,
             g,
             name,
             Some((trailing, MUTED)),
             true,
             true,
+            false,
         )?;
     }
     render_nav(t, NavTab::Apps)
@@ -232,7 +235,7 @@ where
     const NAMES: [&str; 3] = ["Signature", "Encryption", "Authentication"];
     const GLYPHS: [Glyph; 3] = [Glyph::Edit, Glyph::Lock, Glyph::Shield];
     // Three key slots + a card-holder row (its name as the trailing value).
-    group_card(t, PK_LIST_TOP, OPENPGP_ROWS)?;
+    components::list::group_card(t, PK_LIST_TOP, OPENPGP_ROWS)?;
     for (i, slot) in v.slots.iter().enumerate() {
         let trailing = if slot.present {
             (slot.algo.as_str(), MUTED)
@@ -241,14 +244,16 @@ where
         };
         // Every slot drills into its own detail (an empty slot's screen explains its
         // role), so every row gets the chevron.
-        row_body(
+        components::list::row(
             t,
-            crate::row_rect(PK_LIST_TOP, i as u16),
+            PK_LIST_TOP,
+            i as u16,
             GLYPHS[i],
             NAMES[i],
             Some(trailing),
             true,
             true,
+            false,
         )?;
     }
     let ch_trailing = if v.cardholder_name.as_str().is_empty() {
@@ -256,14 +261,16 @@ where
     } else {
         (v.cardholder_name.as_str(), MUTED)
     };
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PK_LIST_TOP, 3),
+        PK_LIST_TOP,
+        3,
         Glyph::User,
         "Card holder",
         Some(ch_trailing),
         true,
         true,
+        false,
     )?;
     let cy = NAV_TOP as i32 - 10;
     let mut sbuf = [0u8; 16];
@@ -394,7 +401,7 @@ where
     title_bar_wide(t, "PIV", theme::ACCENT, true)?;
     const NAMES: [&str; 4] = ["Authentication", "Signature", "Key Management", "Card Auth"];
     // Four primary slots + a "Retired & F9" row (its populated count as the trailing value).
-    group_card(t, PK_LIST_TOP, PIV_ROWS)?;
+    components::list::group_card(t, PK_LIST_TOP, PIV_ROWS)?;
     for (i, slot) in v.slots.iter().enumerate() {
         let trailing = if slot.present {
             (slot.algo.as_str(), MUTED)
@@ -405,25 +412,29 @@ where
         };
         // Every slot drills into its own detail (an empty slot's screen explains its
         // role), so every row gets the chevron.
-        row_body(
+        components::list::row(
             t,
-            crate::row_rect(PK_LIST_TOP, i as u16),
+            PK_LIST_TOP,
+            i as u16,
             Glyph::Cpu,
             NAMES[i],
             Some(trailing),
             true,
             true,
+            false,
         )?;
     }
     let mut eb = [0u8; 5];
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PK_LIST_TOP, 4),
+        PK_LIST_TOP,
+        4,
         Glyph::Apps,
         "Retired & F9",
         Some((fmt_u16(v.extra as u16, &mut eb), MUTED)),
         true,
         true,
+        false,
     )?;
     let cy = NAV_TOP as i32 - 10;
     let mut a = [0u8; 12];
@@ -524,19 +535,21 @@ where
             MUTED,
         )?;
     } else {
-        group_card(t, PK_LIST_TOP, rows.len() as u16)?;
+        components::list::group_card(t, PK_LIST_TOP, rows.len() as u16)?;
         for (i, r) in rows.iter().enumerate() {
             let icon = if r.touch { Glyph::Lock } else { Glyph::Clock };
             let kind = if r.hotp { "HOTP" } else { "TOTP" };
             // Each row drills into the credential's detail (algorithm / digits / period).
-            row_body(
+            components::list::row(
                 t,
-                crate::row_rect(PK_LIST_TOP, i as u16),
+                PK_LIST_TOP,
+                i as u16,
                 icon,
                 r.name.as_str(),
                 Some((kind, MUTED)),
                 true,
                 true,
+                false,
             )?;
         }
         if page_count(total) > 1 {
@@ -696,14 +709,23 @@ where
             "Manage retired keys with ykman.",
         );
     }
-    group_card(t, PK_LIST_TOP, rows.len() as u16)?;
+    components::list::group_card(t, PK_LIST_TOP, rows.len() as u16)?;
     let mut tb = [0u8; 12];
     for (i, r) in rows.iter().enumerate() {
-        let rect = crate::row_rect(PK_LIST_TOP, i as u16);
         if r.generate {
             // No algorithm badge: the action now offers EC / Ed25519 / X25519 / RSA, picked on
             // the next screen — any single-algo label here (it used to read "EC") would mislead.
-            row_body(t, rect, Glyph::Key, "Generate key", None, true, true)?;
+            components::list::row(
+                t,
+                PK_LIST_TOP,
+                i as u16,
+                Glyph::Key,
+                "Generate key",
+                None,
+                true,
+                true,
+                false,
+            )?;
             continue;
         }
         let (icon, label) = if r.slot == 0xF9 {
@@ -718,7 +740,17 @@ where
         } else {
             ("—", theme::CAPTION)
         };
-        row_body(t, rect, icon, label, Some(trailing), true, true)?;
+        components::list::row(
+            t,
+            PK_LIST_TOP,
+            i as u16,
+            icon,
+            label,
+            Some(trailing),
+            true,
+            true,
+            false,
+        )?;
     }
     if page_count(total) > 1 {
         render_pager(t, page, page_count(total))?;
@@ -746,51 +778,61 @@ where
         Role::Body,
         theme::MUTED,
     )?;
-    group_card(t, PIV_KEYGEN_PICK_TOP, PIV_KEYGEN_PICK_ROWS)?;
-    row_body(
+    components::list::group_card(t, PIV_KEYGEN_PICK_TOP, PIV_KEYGEN_PICK_ROWS)?;
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 0),
+        PIV_KEYGEN_PICK_TOP,
+        0,
         Glyph::Cpu,
         "NIST P-256",
         Some(("fast", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 1),
+        PIV_KEYGEN_PICK_TOP,
+        1,
         Glyph::Cpu,
         "NIST P-384",
         Some(("stronger", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 2),
+        PIV_KEYGEN_PICK_TOP,
+        2,
         Glyph::Cpu,
         "Ed25519",
         Some(("EdDSA", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 3),
+        PIV_KEYGEN_PICK_TOP,
+        3,
         Glyph::Cpu,
         "X25519",
         Some(("ECDH", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 4),
+        PIV_KEYGEN_PICK_TOP,
+        4,
         Glyph::Cpu,
         "RSA",
         Some(("2048-4096", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
     text_left(
         t,
@@ -819,33 +861,39 @@ where
         Role::Body,
         theme::MUTED,
     )?;
-    group_card(t, PIV_KEYGEN_PICK_TOP, PIV_RSA_PICK_ROWS)?;
-    row_body(
+    components::list::group_card(t, PIV_KEYGEN_PICK_TOP, PIV_RSA_PICK_ROWS)?;
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 0),
+        PIV_KEYGEN_PICK_TOP,
+        0,
         Glyph::Cpu,
         "RSA 2048",
         Some(("slow", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 1),
+        PIV_KEYGEN_PICK_TOP,
+        1,
         Glyph::Cpu,
         "RSA 3072",
         Some(("slower", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 2),
+        PIV_KEYGEN_PICK_TOP,
+        2,
         Glyph::Cpu,
         "RSA 4096",
         Some(("slowest", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
     text_left(
         t,
@@ -867,46 +915,54 @@ where
     t.clear(BG)?;
     status_bar(t)?;
     title_bar_wide(t, "PIV PIN", theme::ACCENT, true)?;
-    group_card(t, PIV_KEYGEN_PICK_TOP, PIV_PIN_MENU_ROWS)?;
-    row_body(
+    components::list::group_card(t, PIV_KEYGEN_PICK_TOP, PIV_PIN_MENU_ROWS)?;
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 0),
+        PIV_KEYGEN_PICK_TOP,
+        0,
         Glyph::Lock,
         "Change PIN",
         None,
         true,
         true,
+        false,
     )?;
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 1),
+        PIV_KEYGEN_PICK_TOP,
+        1,
         Glyph::Key,
         "Change PUK",
         None,
         true,
         true,
+        false,
     )?;
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 2),
+        PIV_KEYGEN_PICK_TOP,
+        2,
         Glyph::Lifebuoy,
         "Unblock PIN",
         Some(("with PUK", theme::CAPTION)),
         true,
         true,
+        false,
     )?;
     // No trailing caption: a right-aligned hint here is laid out first and the label is
     // clipped to what's left, and "Protect mgmt key" is wide enough that any meaningful
     // caption ("random, PIN-unlocked" was 159 px) ellipsised the label to nothing. The
     // random / PIN-unlocked consequence is stated in full on the confirm screen instead.
-    row_body(
+    components::list::row(
         t,
-        crate::row_rect(PIV_KEYGEN_PICK_TOP, 3),
+        PIV_KEYGEN_PICK_TOP,
+        3,
         Glyph::Shield,
         "Protect mgmt key",
         None,
         true,
         true,
+        false,
     )?;
     text_left(
         t,

--- a/crates/rsk-ui/src/render/audit.rs
+++ b/crates/rsk-ui/src/render/audit.rs
@@ -3,6 +3,7 @@
 
 //! The read-only audit-log screen.
 
+use super::components;
 use super::*;
 
 /// The read-only on-device audit log (Settings → Security → Audit log): the most recent
@@ -34,7 +35,7 @@ where
             MUTED,
         )?;
     } else {
-        group_card(t, PK_LIST_TOP, rows.len() as u16)?;
+        components::list::group_card(t, PK_LIST_TOP, rows.len() as u16)?;
         for (i, r) in rows.iter().enumerate() {
             audit_body(t, crate::row_rect(PK_LIST_TOP, i as u16), r)?;
         }

--- a/crates/rsk-ui/src/render/boot.rs
+++ b/crates/rsk-ui/src/render/boot.rs
@@ -13,9 +13,7 @@ pub(super) fn locked<D: DrawTarget<Color = Rgb565>>(t: &mut D) -> Result<(), D::
     const DIA: u32 = 70;
     let cx = MIDX;
     let circle_top = 96;
-    Circle::new(EgPoint::new(cx - DIA as i32 / 2, circle_top), DIA)
-        .into_styled(PrimitiveStyle::with_fill(theme::SURFACE))
-        .draw(t)?;
+    crate::aa::filled_circle(t, EgPoint::new(cx - DIA as i32 / 2, circle_top), DIA, theme::SURFACE)?;
     let cyc = circle_top + DIA as i32 / 2;
     glyph::draw(
         t,
@@ -87,9 +85,7 @@ pub(super) fn onboard<D: DrawTarget<Color = Rgb565>>(t: &mut D) -> Result<(), D:
     const DIA: u32 = 64;
     let cx = MIDX;
     let circle_top = 36;
-    Circle::new(EgPoint::new(cx - DIA as i32 / 2, circle_top), DIA)
-        .into_styled(PrimitiveStyle::with_fill(theme::SURFACE))
-        .draw(t)?;
+    crate::aa::filled_circle(t, EgPoint::new(cx - DIA as i32 / 2, circle_top), DIA, theme::SURFACE)?;
     let cyc = circle_top + DIA as i32 / 2;
     glyph::draw(
         t,

--- a/crates/rsk-ui/src/render/boot.rs
+++ b/crates/rsk-ui/src/render/boot.rs
@@ -13,7 +13,13 @@ pub(super) fn locked<D: DrawTarget<Color = Rgb565>>(t: &mut D) -> Result<(), D::
     const DIA: u32 = 70;
     let cx = MIDX;
     let circle_top = 96;
-    crate::aa::filled_circle(t, EgPoint::new(cx - DIA as i32 / 2, circle_top), DIA, theme::SURFACE)?;
+    crate::aa::filled_circle(
+        t,
+        EgPoint::new(cx - DIA as i32 / 2, circle_top),
+        DIA,
+        theme::SURFACE,
+        theme::BG,
+    )?;
     let cyc = circle_top + DIA as i32 / 2;
     glyph::draw(
         t,
@@ -85,7 +91,13 @@ pub(super) fn onboard<D: DrawTarget<Color = Rgb565>>(t: &mut D) -> Result<(), D:
     const DIA: u32 = 64;
     let cx = MIDX;
     let circle_top = 36;
-    crate::aa::filled_circle(t, EgPoint::new(cx - DIA as i32 / 2, circle_top), DIA, theme::SURFACE)?;
+    crate::aa::filled_circle(
+        t,
+        EgPoint::new(cx - DIA as i32 / 2, circle_top),
+        DIA,
+        theme::SURFACE,
+        theme::BG,
+    )?;
     let cyc = circle_top + DIA as i32 / 2;
     glyph::draw(
         t,

--- a/crates/rsk-ui/src/render/components/list.rs
+++ b/crates/rsk-ui/src/render/components/list.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! List components: grouped cards with divider-separated rows.
+//!
+//! These replace the old `group_card` / `row_body` / `row_body_side` pattern in
+//! list-style screens (Passkeys, Audit log, Applets). They use the shared
+//! `crate::LIST_ROW_H` / `crate::LIST_ROW_GAP` / `crate::row_rect()` geometry so
+//! paint and hit-test stay aligned.
+
+use embedded_graphics::{
+    Drawable,
+    draw_target::{DrawTarget, DrawTargetExt},
+    geometry::Size,
+    pixelcolor::Rgb565,
+    prelude::{Point as EgPoint, Primitive},
+    primitives::{Line, PrimitiveStyle, PrimitiveStyleBuilder, RoundedRectangle, StrokeAlignment},
+};
+
+use super::super::{eg_rect, text_left_ellipsized, text_right_ellipsized};
+use crate::font;
+use crate::{Glyph, Point, Rect, glyph, theme};
+
+/// Corner radius for list group cards.
+const LIST_RADIUS: u32 = super::CARD_RADIUS;
+
+/// Gap kept between a row's (clipped) label and its trailing value / chevron.
+const TRAILING_GAP: i32 = 8;
+
+/// Draw one grouped card surface behind list rows 0..n (each at `crate::row_rect(y0, i)`),
+/// with hairline dividers at every inter-row gap.
+pub fn group_card<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    y0: u16,
+    n: u16,
+) -> Result<(), D::Error> {
+    if n == 0 {
+        return Ok(());
+    }
+    let first = crate::row_rect(y0, 0);
+    let last = crate::row_rect(y0, n - 1);
+    let span = Rect::new(first.x, first.y, first.w, last.y + last.h - first.y);
+
+    RoundedRectangle::with_equal_corners(eg_rect(span), Size::new(LIST_RADIUS, LIST_RADIUS))
+        .into_styled(PrimitiveStyle::with_fill(theme::ROW_BG))
+        .draw(t)?;
+    RoundedRectangle::with_equal_corners(eg_rect(span), Size::new(LIST_RADIUS, LIST_RADIUS))
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_color(theme::BORDER_CARD)
+                .stroke_width(1)
+                .stroke_alignment(StrokeAlignment::Inside)
+                .build(),
+        )
+        .draw(t)?;
+
+    // Hairline dividers at every inter-row gap midpoint.
+    for i in 1..n {
+        let prev = crate::row_rect(y0, i - 1);
+        let curr = crate::row_rect(y0, i);
+        let dy = (prev.y + crate::LIST_ROW_H + curr.y) / 2;
+        Line::new(
+            EgPoint::new(first.x as i32 + 12, dy as i32),
+            EgPoint::new((first.x + first.w) as i32 - 12, dy as i32),
+        )
+        .into_styled(PrimitiveStyle::with_stroke(theme::DIVIDER, 1))
+        .draw(t)?;
+    }
+    Ok(())
+}
+
+/// Draw the content of one list row at `crate::row_rect(y0, i)`, above the grouped-card
+/// surface. `chip` wraps the leading glyph in a rounded tile (for relying-party rows);
+/// `domain` keeps the registrable-domain suffix visible (head-ellipsis) for attacker-chosen
+/// rpIds.
+#[allow(clippy::too_many_arguments)]
+pub fn row<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    y0: u16,
+    i: u16,
+    icon: Glyph,
+    label: &str,
+    trailing: Option<(&str, Rgb565)>,
+    chevron: bool,
+    chip: bool,
+    domain: bool,
+) -> Result<(), D::Error> {
+    let rect = crate::row_rect(y0, i);
+    let cy = rect.y as i32 + rect.h as i32 / 2;
+
+    // Optional icon chip (rounded tile behind the glyph for relying-party rows).
+    let gx = if chip {
+        RoundedRectangle::with_equal_corners(
+            eg_rect(Rect::new(rect.x + 3, (cy - 11) as u16, 22, 22)),
+            Size::new(6, 6),
+        )
+        .into_styled(PrimitiveStyle::with_fill(theme::CHIP))
+        .draw(t)?;
+        rect.x + 7
+    } else {
+        rect.x + 8
+    };
+    glyph::draw(t, icon, Point::new(gx, (cy - 7) as u16), 14, theme::GREY)?;
+
+    // Trailing block: chevron then value, tracking the leftmost x.
+    let mut right_x = rect.x as i32 + rect.w as i32 - 8;
+    if chevron {
+        right_x -= 12;
+        glyph::draw(
+            t,
+            Glyph::Chevron,
+            Point::new(right_x as u16, (cy - 6) as u16),
+            12,
+            theme::MUTED,
+        )?;
+    }
+    let label_x = rect.x as i32 + 28;
+    let label_right = if let Some((txt, col)) = trailing {
+        let tx = right_x - 4;
+        let tclip = Rect::new(label_x as u16, rect.y, (tx - label_x).max(0) as u16, rect.h);
+        font::right(
+            &mut t.clipped(&eg_rect(tclip)),
+            txt,
+            EgPoint::new(tx, cy),
+            font::Role::Body,
+            col,
+        )?;
+        tx - font::width(txt, font::Role::Body).unwrap_or(0) as i32 - TRAILING_GAP
+    } else {
+        right_x - TRAILING_GAP
+    };
+    let clip = Rect::new(
+        label_x as u16,
+        rect.y,
+        (label_right - label_x).max(0) as u16,
+        rect.h,
+    );
+    let at = EgPoint::new(label_x, cy);
+    if domain {
+        text_right_ellipsized(t, label, at, font::Role::Body, theme::TEXT, clip, false)
+    } else {
+        text_left_ellipsized(t, label, at, font::Role::Body, theme::TEXT, clip, false)
+    }
+}

--- a/crates/rsk-ui/src/render/components/mod.rs
+++ b/crates/rsk-ui/src/render/components/mod.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 RS-Key contributors
+
+//! Reusable UI components with consistent spacing.
+
+#![allow(dead_code)]
+
+pub mod list;
+
+use embedded_graphics::{
+    Drawable,
+    draw_target::{DrawTarget, DrawTargetExt},
+    geometry::Size,
+    pixelcolor::Rgb565,
+    prelude::{Point as EgPoint, Primitive},
+    primitives::{PrimitiveStyle, PrimitiveStyleBuilder, RoundedRectangle, StrokeAlignment},
+};
+
+use super::{eg_rect, text, text_left, text_left_ellipsized};
+use crate::{Glyph, PANEL_W, Point, Rect, font, glyph, theme};
+
+/// Horizontal screen margin (both sides).
+pub const MARGIN: u16 = 6;
+/// Internal card padding.
+pub const PAD: u16 = 12;
+/// Standard row height inside cards.
+pub const ROW_H: u16 = 44;
+/// Gap between card rows.
+pub const ROW_GAP: u16 = 4;
+/// Card corner radius.
+pub const CARD_RADIUS: u32 = 10;
+
+/// Draw a full-width rounded card surface.
+pub fn card<D: DrawTarget<Color = Rgb565>>(t: &mut D, y: u16, h: u16) -> Result<(), D::Error> {
+    RoundedRectangle::with_equal_corners(
+        eg_rect(Rect::new(MARGIN, y, PANEL_W - 2 * MARGIN, h)),
+        Size::new(CARD_RADIUS, CARD_RADIUS),
+    )
+    .into_styled(PrimitiveStyle::with_fill(theme::SURFACE))
+    .draw(t)
+}
+
+/// A card title row: icon + heading text, left-aligned.
+pub fn card_title<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    card_y: u16,
+    icon: Glyph,
+    label: &str,
+) -> Result<(), D::Error> {
+    let y = card_y + PAD;
+    glyph::draw(t, icon, Point::new(MARGIN + PAD, y), 28, theme::ACCENT)?;
+    text_left(
+        t,
+        label,
+        EgPoint::new((MARGIN + PAD + 28 + 8) as i32, y as i32 + 20),
+        font::Role::Heading,
+        theme::TEXT,
+    )
+}
+
+/// A card content row: icon + label + optional right-aligned value.
+pub fn card_row<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    card_y: u16,
+    row_idx: u16,
+    icon: Glyph,
+    label: &str,
+    value: Option<(&str, Rgb565)>,
+) -> Result<(), D::Error> {
+    let y = card_y + PAD + ROW_H + row_idx * (ROW_H + ROW_GAP);
+    let x = MARGIN + PAD;
+    glyph::draw(t, icon, Point::new(x, y), 22, theme::MUTED)?;
+    text_left(
+        t,
+        label,
+        EgPoint::new((x + 22 + 8) as i32, y as i32 + 16),
+        font::Role::Body,
+        theme::TEXT,
+    )?;
+    if let Some((val, color)) = value {
+        let w = font::width(val, font::Role::Body).unwrap_or(0) as i32;
+        text(
+            t,
+            val,
+            EgPoint::new((PANEL_W - MARGIN - PAD) as i32 - w, y as i32 + 16),
+            font::Role::Body,
+            color,
+        )?;
+    }
+    Ok(())
+}
+
+/// Draw a rounded card surface at an arbitrary `rect` (for settings rows and other
+/// screens that use non-standard geometry).
+pub fn rect_card<D: DrawTarget<Color = Rgb565>>(t: &mut D, rect: Rect) -> Result<(), D::Error> {
+    RoundedRectangle::with_equal_corners(eg_rect(rect), Size::new(CARD_RADIUS, CARD_RADIUS))
+        .into_styled(PrimitiveStyle::with_fill(theme::ROW_BG))
+        .draw(t)?;
+    RoundedRectangle::with_equal_corners(eg_rect(rect), Size::new(CARD_RADIUS, CARD_RADIUS))
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_color(theme::BORDER_CARD)
+                .stroke_width(1)
+                .stroke_alignment(StrokeAlignment::Inside)
+                .build(),
+        )
+        .draw(t)
+}
+
+/// Total height of a card with `rows` rows (including title row if present).
+#[allow(dead_code)]
+pub fn card_h(has_title: bool, rows: u16) -> u16 {
+    let title = if has_title { ROW_H } else { 0 };
+    PAD + title + rows * ROW_H + rows.saturating_sub(1) * ROW_GAP + PAD
+}
+
+/// A card row with a right chevron (for drill-in navigation).
+pub fn card_row_chevron<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    card_y: u16,
+    row_idx: u16,
+    icon: Glyph,
+    label: &str,
+    value: Option<(&str, Rgb565)>,
+) -> Result<(), D::Error> {
+    card_row(t, card_y, row_idx, icon, label, value)?;
+    let y = card_y + PAD + ROW_H + row_idx * (ROW_H + ROW_GAP);
+    glyph::draw(
+        t,
+        Glyph::Chevron,
+        Point::new(PANEL_W - MARGIN - PAD - 14, y + (ROW_H - 14) / 2),
+        14,
+        theme::MUTED,
+    )?;
+    Ok(())
+}
+
+/// A single content row at an arbitrary `rect` (for settings and other screens
+/// with non-standard geometry).
+#[allow(clippy::too_many_arguments)]
+pub fn rect_row<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    rect: Rect,
+    icon: Glyph,
+    label: &str,
+    trailing: Option<(&str, Rgb565)>,
+    chevron: bool,
+) -> Result<(), D::Error> {
+    let cy = rect.y as i32 + rect.h as i32 / 2;
+    let gx = rect.x + 8;
+    glyph::draw(t, icon, Point::new(gx, (cy - 7) as u16), 14, theme::GREY)?;
+    let mut right_x = rect.x as i32 + rect.w as i32 - 8;
+    if chevron {
+        right_x -= 12;
+        glyph::draw(
+            t,
+            Glyph::Chevron,
+            Point::new(right_x as u16, (cy - 6) as u16),
+            12,
+            theme::MUTED,
+        )?;
+    }
+    let label_x = rect.x as i32 + 28;
+    let label_right = if let Some((txt, col)) = trailing {
+        let tx = right_x - 4;
+        font::right(
+            &mut t.clipped(&eg_rect(Rect::new(
+                label_x as u16,
+                rect.y,
+                (tx - label_x).max(0) as u16,
+                rect.h,
+            ))),
+            txt,
+            EgPoint::new(tx, cy),
+            font::Role::Body,
+            col,
+        )?;
+        tx - font::width(txt, font::Role::Body).unwrap_or(0) as i32 - 8
+    } else {
+        right_x - 8
+    };
+    let clip = Rect::new(
+        label_x as u16,
+        rect.y,
+        (label_right - label_x).max(0) as u16,
+        rect.h,
+    );
+    text_left_ellipsized(
+        t,
+        label,
+        EgPoint::new(label_x, cy),
+        font::Role::Body,
+        theme::TEXT,
+        clip,
+        false,
+    )
+}
+
+/// Centered empty-state message: large icon + body text.
+pub fn empty_state<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    card_y: u16,
+    card_h: u16,
+    icon: Glyph,
+    label: &str,
+) -> Result<(), D::Error> {
+    let cy = card_y + card_h / 2;
+    glyph::draw(
+        t,
+        icon,
+        Point::new((crate::PANEL_W as i32 / 2) as u16 - 18, cy - 30),
+        36,
+        theme::MUTED,
+    )?;
+    text(
+        t,
+        label,
+        EgPoint::new(crate::PANEL_W as i32 / 2, cy as i32 + 8),
+        font::Role::Body,
+        theme::MUTED,
+    )
+}

--- a/crates/rsk-ui/src/render/home.rs
+++ b/crates/rsk-ui/src/render/home.rs
@@ -94,8 +94,7 @@ pub fn render_status_arc<D: DrawTarget<Color = Rgb565>>(
     angle_deg: i32,
 ) -> Result<(), D::Error> {
     let (track, mark) = status_ring(kind);
-    let center = EgPoint::new(MIDX, STATUS_RING_CY);
-    Circle::with_center(center, STATUS_RING_D)
+    Circle::with_center(EgPoint::new(MIDX, STATUS_RING_CY), STATUS_RING_D)
         .into_styled(
             PrimitiveStyleBuilder::new()
                 .stroke_color(track)
@@ -104,7 +103,7 @@ pub fn render_status_arc<D: DrawTarget<Color = Rgb565>>(
         )
         .draw(t)?;
     Arc::with_center(
-        center,
+        EgPoint::new(MIDX, STATUS_RING_CY),
         STATUS_RING_D,
         Angle::from_degrees(angle_deg as f32),
         Angle::from_degrees(270.0),

--- a/crates/rsk-ui/src/render/passkeys.rs
+++ b/crates/rsk-ui/src/render/passkeys.rs
@@ -3,6 +3,7 @@
 
 //! Passkey screens: the RP list, service detail, rename, and the delete confirm.
 
+use super::components;
 use super::*;
 
 /// The Passkeys tab: header, one row per relying party (generic globe + sanitized
@@ -33,25 +34,22 @@ where
             MUTED,
         )?;
     } else {
-        group_card(t, PK_LIST_TOP, rows.len() as u16)?;
+        components::list::group_card(t, PK_LIST_TOP, rows.len() as u16)?;
         for (i, r) in rows.iter().enumerate() {
-            let mut buf = [0u8; 16];
-            let unit = if r.accounts == 1 {
-                "account"
+            let mut buf = [0u8; 5];
+            let trailing = if r.accounts > 1 {
+                Some((fmt_u16(r.accounts as u16, &mut buf), MUTED))
             } else {
-                "accounts"
+                None
             };
-            let trailing = fmt_count(r.accounts as u16, unit, &mut buf);
             let name = r.shown();
-            // When the row shows the attacker-chosen rpId (no device-local nickname), keep the
-            // registrable-domain suffix (head-ellipsis) so a padded look-alike can't hide the
-            // real domain on the review list; a user-set nickname keeps the head like any label.
-            row_body_side(
+            components::list::row(
                 t,
-                crate::row_rect(PK_LIST_TOP, i as u16),
+                PK_LIST_TOP,
+                i as u16,
                 service_glyph(name),
                 name,
-                Some((trailing, MUTED)),
+                trailing,
                 true,
                 true,
                 r.nick.is_empty(),
@@ -89,40 +87,58 @@ where
     } else {
         title_bar(t, title.as_str(), theme::ACCENT, true)?;
     }
-    glyph_centered(t, Glyph::Edit, TITLE_EDIT_RECT, 18, theme::ACCENT)?;
-    group_card(t, PK_LIST_TOP, accounts.len() as u16)?;
+    // Pencil icon: drawn right-aligned inside its hit rect, with a 4 px inset
+    // from the right edge so the glyph doesn't touch the panel border.
+    let er = TITLE_EDIT_RECT;
+    glyph::draw(
+        t,
+        Glyph::Edit,
+        Point::new(er.x + er.w - 18 - 4, er.y + er.h / 2 - 9),
+        18,
+        theme::ACCENT,
+    )?;
+    components::list::group_card(t, PK_LIST_TOP, accounts.len() as u16)?;
     for (i, a) in accounts.iter().enumerate() {
         let trailing = if a.protected {
             Some(("UV", theme::ACCENT))
         } else {
             None
         };
-        row_body(
+        components::list::row(
             t,
-            crate::row_rect(PK_LIST_TOP, i as u16),
+            PK_LIST_TOP,
+            i as u16,
             Glyph::Key,
             a.name.as_str(),
             trailing,
             false,
             true,
+            false,
         )?;
     }
     list_tail(t, page, total, "account", "accounts")?;
     render_nav(t, NavTab::Passkeys)
 }
 
-/// The rename screen: a character-wheel editor for a relying party's device-local
-/// nickname. Status + title chrome (the back chevron cancels), a `NICKNAME` caption, the
-/// value field with a caret, then the wheel — a backspace key on the left, the ▲ / big
-/// candidate / ▼ centre column, and an insert (`+`) key on the right — over a full-width
-/// Save button. `value` is the current buffer; `candidate` the wheel's current byte
-/// (`b' '` shows as an underscore so a space is visible). The firmware blinks the caret by
-/// repainting [`render_rename_caret`] on a timer.
-pub fn render_rename<D>(t: &mut D, value: &str, candidate: u8) -> Result<(), D::Error>
+/// The rename screen: a T9 phone-style keypad for editing a device-local nickname.
+/// Full-frame paint with clear — call once when entering the screen.
+pub fn render_rename<D>(
+    t: &mut D,
+    value: &str,
+    pending: Option<u8>,
+    active_group: Option<usize>,
+) -> Result<(), D::Error>
 where
     D: DrawTarget<Color = Rgb565>,
 {
     t.clear(BG)?;
+    render_rename_chrome(t)?;
+    render_rename_field(t, value, pending)?;
+    render_rename_keys(t, active_group)
+}
+
+/// Status + title bar + caption (static chrome).
+fn render_rename_chrome<D: DrawTarget<Color = Rgb565>>(t: &mut D) -> Result<(), D::Error> {
     status_bar(t)?;
     title_bar(t, "Rename", theme::ACCENT, true)?;
     text_left(
@@ -131,9 +147,30 @@ where
         EgPoint::new(14, RN_FIELD_RECT.y as i32 - 10),
         Role::Mono,
         theme::CAPTION,
-    )?;
+    )
+}
 
-    // The value field: a bordered surface holding the text and a static caret.
+/// Repaint just the text field: committed `value` + optional `pending` char (underlined).
+/// Clears the field area to BG first so shorter text erases longer prior text.
+pub fn render_rename_field<D: DrawTarget<Color = Rgb565>>(
+    t: &mut D,
+    value: &str,
+    pending: Option<u8>,
+) -> Result<(), D::Error> {
+    // Clear the field area + a few px margin
+    let clear = Rect::new(
+        RN_FIELD_RECT.x.saturating_sub(4),
+        RN_FIELD_RECT.y.saturating_sub(4),
+        RN_FIELD_RECT.w + 8,
+        RN_FIELD_RECT.h + 8,
+    );
+    Rectangle::new(
+        EgPoint::new(clear.x as i32, clear.y as i32),
+        Size::new(clear.w as u32, clear.h as u32),
+    )
+    .into_styled(PrimitiveStyle::with_fill(BG))
+    .draw(t)?;
+
     let field = RN_FIELD_RECT;
     RoundedRectangle::with_equal_corners(eg_rect(field), Size::new(8, 8))
         .into_styled(PrimitiveStyle::with_fill(theme::SURFACE))
@@ -164,95 +201,86 @@ where
         inner,
     )?;
     let text_w = font::width(value, Role::Body).unwrap_or(0) as i32;
-    let caret_x = (inner.x as i32 + text_w).min(field.x as i32 + field.w as i32 - 6);
-    Line::new(
-        EgPoint::new(caret_x, field.y as i32 + 7),
-        EgPoint::new(caret_x, field.y as i32 + field.h as i32 - 7),
-    )
-    .into_styled(PrimitiveStyle::with_stroke(theme::ACCENT, 1))
-    .draw(t)?;
+    let cursor_x = (inner.x as i32 + text_w).min(field.x as i32 + field.w as i32 - 12);
 
-    // The wheel: up / down arrows around the big candidate character.
-    key_surface(t, RN_UP_RECT, KEY_FILL, true)?;
-    wheel_arrow(t, RN_UP_RECT, true, theme::ACCENT)?;
-    key_surface(t, RN_DOWN_RECT, KEY_FILL, true)?;
-    wheel_arrow(t, RN_DOWN_RECT, false, theme::ACCENT)?;
-    let cy = (RN_UP_RECT.y + RN_UP_RECT.h + RN_DOWN_RECT.y) as i32 / 2;
-    if candidate == b' ' {
-        // A space candidate: a short underline so the wheel isn't blank.
+    if let Some(ch) = pending {
+        let b = [ch];
+        let ps = core::str::from_utf8(&b).unwrap_or("?");
+        let pw = font::width(ps, Role::Body).unwrap_or(0) as i32;
+        let px = cursor_x + 4;
+        text_left(t, ps, EgPoint::new(px, baseline), Role::Body, theme::ACCENT)?;
         Line::new(
-            EgPoint::new(MIDX - 10, cy + 9),
-            EgPoint::new(MIDX + 10, cy + 9),
+            EgPoint::new(px, baseline + 4),
+            EgPoint::new(px + pw, baseline + 4),
         )
-        .into_styled(PrimitiveStyle::with_stroke(FG, 2))
+        .into_styled(PrimitiveStyle::with_stroke(theme::ACCENT, 2))
         .draw(t)?;
     } else {
-        let b = [candidate];
-        let s = core::str::from_utf8(&b).unwrap_or("?");
-        text(t, s, EgPoint::new(MIDX, cy), Role::Ready, FG)?;
+        Line::new(
+            EgPoint::new(cursor_x, field.y as i32 + 7),
+            EgPoint::new(cursor_x, field.y as i32 + field.h as i32 - 7),
+        )
+        .into_styled(PrimitiveStyle::with_stroke(theme::ACCENT, 1))
+        .draw(t)?;
     }
-
-    // Backspace (left) and insert-candidate (right).
-    key_surface(t, RN_BKSP_RECT, theme::KEY_DARK, true)?;
-    glyph_centered(t, Glyph::Backspace, RN_BKSP_RECT, 22, MUTED)?;
-    key_surface(t, RN_INS_RECT, KEY_FILL, true)?;
-    let ic = center(RN_INS_RECT);
-    Line::new(EgPoint::new(ic.x - 9, ic.y), EgPoint::new(ic.x + 9, ic.y))
-        .into_styled(PrimitiveStyle::with_stroke(theme::ACCENT, 2))
-        .draw(t)?;
-    Line::new(EgPoint::new(ic.x, ic.y - 9), EgPoint::new(ic.x, ic.y + 9))
-        .into_styled(PrimitiveStyle::with_stroke(theme::ACCENT, 2))
-        .draw(t)?;
-
-    button(t, RN_SAVE_RECT, "Save", ALLOW_FILL)
+    Ok(())
 }
 
-/// Repaint just the rename field's caret — drawn in accent when `on`, erased to the field
-/// surface when `off`, so the firmware can blink it on a timer without redrawing the
-/// screen. The caret sits at the end of `value` (clamped inside the field), matching
-/// [`render_rename`]'s static caret exactly.
-pub fn render_rename_caret<D: DrawTarget<Color = Rgb565>>(
+/// Repaint just the T9 keypad (when `active_group` changes).
+/// Paints every key — the keypad is 12 small rects, repainting all of them
+/// is still much cheaper than a full-frame redraw.
+pub fn render_rename_keys<D: DrawTarget<Color = Rgb565>>(
     t: &mut D,
-    value: &str,
-    on: bool,
+    active_group: Option<usize>,
 ) -> Result<(), D::Error> {
-    let field = RN_FIELD_RECT;
-    let text_w = font::width(value, Role::Body).unwrap_or(0) as i32;
-    let caret_x = (field.x as i32 + 10 + text_w).min(field.x as i32 + field.w as i32 - 6);
-    let color = if on { theme::ACCENT } else { theme::SURFACE };
-    Line::new(
-        EgPoint::new(caret_x, field.y as i32 + 7),
-        EgPoint::new(caret_x, field.y as i32 + field.h as i32 - 7),
-    )
-    .into_styled(PrimitiveStyle::with_stroke(color, 1))
-    .draw(t)
-}
-
-/// A filled wheel arrow (▲ when `up`, else ▼) centred in `r`.
-fn wheel_arrow<D: DrawTarget<Color = Rgb565>>(
-    t: &mut D,
-    r: Rect,
-    up: bool,
-    color: Rgb565,
-) -> Result<(), D::Error> {
-    let cx = (r.x + r.w / 2) as i32;
-    let cy = (r.y + r.h / 2) as i32;
-    let (apex, left, right) = if up {
-        (
-            EgPoint::new(cx, cy - 8),
-            EgPoint::new(cx - 9, cy + 6),
-            EgPoint::new(cx + 9, cy + 6),
-        )
-    } else {
-        (
-            EgPoint::new(cx, cy + 8),
-            EgPoint::new(cx - 9, cy - 6),
-            EgPoint::new(cx + 9, cy - 6),
-        )
-    };
-    Triangle::new(apex, left, right)
-        .into_styled(PrimitiveStyle::with_fill(color))
-        .draw(t)
+    for row in 0..4u16 {
+        for col in 0..3u16 {
+            let r = t9_key_rect(row, col);
+            match (row, col) {
+                (3, 0) => {
+                    key_surface(t, r, theme::KEY_DARK, true)?;
+                    glyph_centered(t, Glyph::Backspace, r, 20, MUTED)?;
+                }
+                (3, 2) => {
+                    RoundedRectangle::with_equal_corners(
+                        eg_rect(r),
+                        Size::new(KEY_RADIUS, KEY_RADIUS),
+                    )
+                    .into_styled(PrimitiveStyle::with_fill(ALLOW_FILL))
+                    .draw(t)?;
+                    text(t, "Save", center(r), Role::Strong, FG)?;
+                }
+                _ => {
+                    let idx = if row < 3 { (row * 3 + col) as usize } else { 9 };
+                    let is_active = active_group == Some(idx);
+                    let fill = if is_active {
+                        theme::ACCENT_FILL
+                    } else {
+                        KEY_FILL
+                    };
+                    key_surface(t, r, fill, !is_active)?;
+                    let color = if is_active { FG } else { theme::TEXT };
+                    let (digit, letters) = T9_KEY_LABELS[idx];
+                    let cx = r.x as i32 + r.w as i32 / 2;
+                    text(
+                        t,
+                        digit,
+                        EgPoint::new(cx, r.y as i32 + 14),
+                        Role::Strong,
+                        color,
+                    )?;
+                    text(
+                        t,
+                        letters,
+                        EgPoint::new(cx, r.y as i32 + 32),
+                        Role::MonoSmall,
+                        color,
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// The trusted Confirm-Delete screen for a resident passkey: the back (cancel)

--- a/crates/rsk-ui/src/render/pin.rs
+++ b/crates/rsk-ui/src/render/pin.rs
@@ -262,8 +262,9 @@ fn masked_entry<D: DrawTarget<Color = Rgb565>>(
     Ok(())
 }
 
-/// Repaint only the masked-entry dots (and eye toggle), clearing each dot position
-/// individually instead of the entire 240-pixel strip — no visible flicker.
+/// Repaint the masked dots (and eye toggle): clear one strip over the entry band
+/// — every dot position plus the "+" overflow slot to its right — then redraw.
+/// A per-dot clear missed the "+" and dot 10's right tail, so a delete mis-read.
 pub fn render_pin_dots<D>(
     target: &mut D,
     entered: usize,
@@ -273,16 +274,15 @@ pub fn render_pin_dots<D>(
 where
     D: DrawTarget<Color = Rgb565>,
 {
-    // Clear ALL possible dot positions (not just max(expected, entered) —
-    // a delete from 8 to 7 must erase the 8th dot).
-    for i in 0..ENTRY_MAX_SHOWN {
-        let x = ENTRY_X0 + i as i32 * ENTRY_STEP - ENTRY_DIA as i32 / 2 - 2;
-        let y = ENTRY_CY - ENTRY_DIA as i32 / 2 - 2;
-        Rectangle::new(EgPoint::new(x, y), Size::new(ENTRY_DIA + 4, ENTRY_DIA + 4))
-            .into_styled(PrimitiveStyle::with_fill(BG))
-            .draw(target)?;
-    }
-    // Re-draw the dots
+    Rectangle::new(
+        EgPoint::new(ENTRY_X0 - 2, ENTRY_CY - ENTRY_DIA as i32 / 2 - 2),
+        Size::new(
+            (ENTRY_MAX_SHOWN as u32 + 1) * ENTRY_STEP as u32 + 4,
+            ENTRY_DIA + 4,
+        ),
+    )
+    .into_styled(PrimitiveStyle::with_fill(BG))
+    .draw(target)?;
     masked_entry(target, entered, expected, reveal)
 }
 

--- a/crates/rsk-ui/src/render/pin.rs
+++ b/crates/rsk-ui/src/render/pin.rs
@@ -227,18 +227,25 @@ fn masked_entry<D: DrawTarget<Color = Rgb565>>(
         )?;
         return Ok(());
     }
-    let total = (expected as usize).max(entered).min(ENTRY_MAX_SHOWN);
+    // Show outline dots only while below the expected minimum. Once reached,
+    // only the entered count matters (no leftover outlines on delete).
+    let total = if entered >= expected as usize {
+        entered.min(ENTRY_MAX_SHOWN)
+    } else {
+        (expected as usize).min(ENTRY_MAX_SHOWN)
+    };
     for i in 0..total {
         let at = EgPoint::new(
             ENTRY_X0 + i as i32 * ENTRY_STEP,
             ENTRY_CY - ENTRY_DIA as i32 / 2,
         );
-        let style = if i < entered {
-            PrimitiveStyle::with_fill(theme::ACCENT)
+        if i < entered {
+            crate::aa::filled_circle(t, at, ENTRY_DIA, theme::ACCENT)?;
         } else {
-            PrimitiveStyle::with_stroke(theme::CAPTION, 1)
-        };
-        Circle::new(at, ENTRY_DIA).into_styled(style).draw(t)?;
+            Circle::new(at, ENTRY_DIA)
+                .into_styled(PrimitiveStyle::with_stroke(theme::CAPTION, 1))
+                .draw(t)?;
+        }
     }
     // A PIN longer than the row marks the extra digits with a "+", so the dot count never
     // reads as the whole PIN (the full PIN is still entered and verified).
@@ -255,18 +262,8 @@ fn masked_entry<D: DrawTarget<Color = Rgb565>>(
     Ok(())
 }
 
-/// Top and height of the masked-entry band — the strip [`render_pin_dots`] repaints
-/// on its own. Must cover the dot row (centre y 60, dia 12) and the eye toggle.
-const PIN_ENTRY_TOP: i32 = 44;
-const PIN_ENTRY_H: u32 = 32;
-
-/// Repaint **only** the masked-entry band (clear the strip, redraw the dots/digits and the
-/// eye), leaving the static keys untouched. The pad is painted in full once via
-/// `render(&Screen::Pin(..))`; each keystroke — and each reveal toggle — then calls this,
-/// so a change is a tiny partial update with no full-screen clear (no flicker), unlike
-/// repainting the whole 240×320 frame per tap. `reveal` matches [`masked_entry`]: `None`
-/// shows masked dots, `Some(digits)` the typed digits (passed transiently by the firmware
-/// when the user taps the eye — never stored here).
+/// Repaint only the masked-entry dots (and eye toggle), clearing each dot position
+/// individually instead of the entire 240-pixel strip — no visible flicker.
 pub fn render_pin_dots<D>(
     target: &mut D,
     entered: usize,
@@ -276,12 +273,16 @@ pub fn render_pin_dots<D>(
 where
     D: DrawTarget<Color = Rgb565>,
 {
-    Rectangle::new(
-        EgPoint::new(0, PIN_ENTRY_TOP),
-        Size::new(PANEL_W as u32, PIN_ENTRY_H),
-    )
-    .into_styled(PrimitiveStyle::with_fill(BG))
-    .draw(target)?;
+    // Clear ALL possible dot positions (not just max(expected, entered) —
+    // a delete from 8 to 7 must erase the 8th dot).
+    for i in 0..ENTRY_MAX_SHOWN {
+        let x = ENTRY_X0 + i as i32 * ENTRY_STEP - ENTRY_DIA as i32 / 2 - 2;
+        let y = ENTRY_CY - ENTRY_DIA as i32 / 2 - 2;
+        Rectangle::new(EgPoint::new(x, y), Size::new(ENTRY_DIA + 4, ENTRY_DIA + 4))
+            .into_styled(PrimitiveStyle::with_fill(BG))
+            .draw(target)?;
+    }
+    // Re-draw the dots
     masked_entry(target, entered, expected, reveal)
 }
 

--- a/crates/rsk-ui/src/render/pin.rs
+++ b/crates/rsk-ui/src/render/pin.rs
@@ -227,20 +227,16 @@ fn masked_entry<D: DrawTarget<Color = Rgb565>>(
         )?;
         return Ok(());
     }
-    // Show outline dots only while below the expected minimum. Once reached,
-    // only the entered count matters (no leftover outlines on delete).
-    let total = if entered >= expected as usize {
-        entered.min(ENTRY_MAX_SHOWN)
-    } else {
-        (expected as usize).min(ENTRY_MAX_SHOWN)
-    };
+    // Outline dots only while below the expected minimum; once reached, the
+    // entered count drives the row.
+    let total = (expected as usize).max(entered).min(ENTRY_MAX_SHOWN);
     for i in 0..total {
         let at = EgPoint::new(
             ENTRY_X0 + i as i32 * ENTRY_STEP,
             ENTRY_CY - ENTRY_DIA as i32 / 2,
         );
         if i < entered {
-            crate::aa::filled_circle(t, at, ENTRY_DIA, theme::ACCENT)?;
+            crate::aa::filled_circle(t, at, ENTRY_DIA, theme::ACCENT, theme::BG)?;
         } else {
             Circle::new(at, ENTRY_DIA)
                 .into_styled(PrimitiveStyle::with_stroke(theme::CAPTION, 1))

--- a/crates/rsk-ui/src/render/reset.rs
+++ b/crates/rsk-ui/src/render/reset.rs
@@ -27,7 +27,13 @@ where
     // ceremony — danger red, not the amber of a recoverable caution.
     const DIA: u32 = 58;
     let circle_top = 46;
-    crate::aa::filled_circle(t, EgPoint::new(MIDX - DIA as i32 / 2, circle_top), DIA, theme::DANGER_BG)?;
+    crate::aa::filled_circle(
+        t,
+        EgPoint::new(MIDX - DIA as i32 / 2, circle_top),
+        DIA,
+        theme::DANGER_BG,
+        theme::BG,
+    )?;
     let cyc = circle_top + DIA as i32 / 2;
     glyph::draw(
         t,
@@ -72,7 +78,7 @@ fn erase_item<D: DrawTarget<Color = Rgb565>>(
     label: &str,
 ) -> Result<(), D::Error> {
     const X: i32 = 60;
-    crate::aa::filled_circle(t, EgPoint::new(X, cy - 3), 6, theme::DANGER)?;
+    crate::aa::filled_circle(t, EgPoint::new(X, cy - 3), 6, theme::DANGER, theme::BG)?;
     text_left(
         t,
         label,
@@ -128,7 +134,13 @@ where
     t.clear(BG)?;
     const DIA: u32 = 70;
     let circle_top = 84;
-    crate::aa::filled_circle(t, EgPoint::new(MIDX - DIA as i32 / 2, circle_top), DIA, theme::DANGER_BG)?;
+    crate::aa::filled_circle(
+        t,
+        EgPoint::new(MIDX - DIA as i32 / 2, circle_top),
+        DIA,
+        theme::DANGER_BG,
+        theme::BG,
+    )?;
     let cyc = circle_top + DIA as i32 / 2;
     glyph::draw(
         t,
@@ -258,7 +270,13 @@ where
     .into_styled(PrimitiveStyle::with_fill(BG))
     .draw(t)?;
     let dia = (SUCCESS_DIA * scale_pct as u32 / 100).max(4);
-    crate::aa::filled_circle(t, EgPoint::new(MIDX - dia as i32 / 2, SUCCESS_CY - dia as i32 / 2), dia, fill)?;
+    crate::aa::filled_circle(
+        t,
+        EgPoint::new(MIDX - dia as i32 / 2, SUCCESS_CY - dia as i32 / 2),
+        dia,
+        fill,
+        theme::BG,
+    )?;
     let gs = (dia * 48 / 100).max(10) as u16;
     glyph::draw(
         t,

--- a/crates/rsk-ui/src/render/reset.rs
+++ b/crates/rsk-ui/src/render/reset.rs
@@ -27,9 +27,7 @@ where
     // ceremony — danger red, not the amber of a recoverable caution.
     const DIA: u32 = 58;
     let circle_top = 46;
-    Circle::new(EgPoint::new(MIDX - DIA as i32 / 2, circle_top), DIA)
-        .into_styled(PrimitiveStyle::with_fill(theme::DANGER_BG))
-        .draw(t)?;
+    crate::aa::filled_circle(t, EgPoint::new(MIDX - DIA as i32 / 2, circle_top), DIA, theme::DANGER_BG)?;
     let cyc = circle_top + DIA as i32 / 2;
     glyph::draw(
         t,
@@ -74,9 +72,7 @@ fn erase_item<D: DrawTarget<Color = Rgb565>>(
     label: &str,
 ) -> Result<(), D::Error> {
     const X: i32 = 60;
-    Circle::new(EgPoint::new(X, cy - 3), 6)
-        .into_styled(PrimitiveStyle::with_fill(theme::DANGER))
-        .draw(t)?;
+    crate::aa::filled_circle(t, EgPoint::new(X, cy - 3), 6, theme::DANGER)?;
     text_left(
         t,
         label,
@@ -132,9 +128,7 @@ where
     t.clear(BG)?;
     const DIA: u32 = 70;
     let circle_top = 84;
-    Circle::new(EgPoint::new(MIDX - DIA as i32 / 2, circle_top), DIA)
-        .into_styled(PrimitiveStyle::with_fill(theme::DANGER_BG))
-        .draw(t)?;
+    crate::aa::filled_circle(t, EgPoint::new(MIDX - DIA as i32 / 2, circle_top), DIA, theme::DANGER_BG)?;
     let cyc = circle_top + DIA as i32 / 2;
     glyph::draw(
         t,
@@ -264,12 +258,7 @@ where
     .into_styled(PrimitiveStyle::with_fill(BG))
     .draw(t)?;
     let dia = (SUCCESS_DIA * scale_pct as u32 / 100).max(4);
-    Circle::new(
-        EgPoint::new(MIDX - dia as i32 / 2, SUCCESS_CY - dia as i32 / 2),
-        dia,
-    )
-    .into_styled(PrimitiveStyle::with_fill(fill))
-    .draw(t)?;
+    crate::aa::filled_circle(t, EgPoint::new(MIDX - dia as i32 / 2, SUCCESS_CY - dia as i32 / 2), dia, fill)?;
     let gs = (dia * 48 / 100).max(10) as u16;
     glyph::draw(
         t,

--- a/crates/rsk-ui/src/render/settings.rs
+++ b/crates/rsk-ui/src/render/settings.rs
@@ -3,6 +3,7 @@
 
 //! Settings screens: the menu pages, adjust controls, and the firmware update flow.
 
+use super::components;
 use super::*;
 
 // --- Settings menu ---------------------------------------------------------
@@ -34,10 +35,12 @@ fn settings_root<D: DrawTarget<Color = Rgb565>>(t: &mut D, version: u16) -> Resu
     status_bar(t)?;
     title_bar(t, "Settings", theme::ACCENT, false)?;
     // Display drills into the brightness / sleep / touch-timeout panel knobs.
-    render_row(t, settings_row_rect(0), Glyph::Sun, "Display", None, true)?;
+    components::rect_card(t, settings_row_rect(0))?;
+    components::rect_row(t, settings_row_rect(0), Glyph::Sun, "Display", None, true)?;
     // Security drills into the Set/Change PIN + Audit / Backup + Factory reset sub-page,
     // keeping the destructive reset one tap deeper.
-    render_row(
+    components::rect_card(t, settings_row_rect(1))?;
+    components::rect_row(
         t,
         settings_row_rect(1),
         Glyph::Shield,
@@ -49,7 +52,8 @@ fn settings_root<D: DrawTarget<Color = Rgb565>>(t: &mut D, version: u16) -> Resu
     // reboot-to-update-over-USB screen.
     let mut vbuf = [b'0', b'x', 0, 0, 0, 0];
     vbuf[2..].copy_from_slice(&hex_u16(version));
-    render_row(
+    components::rect_card(t, settings_row_rect(2))?;
+    components::rect_row(
         t,
         settings_row_rect(2),
         Glyph::Cpu,
@@ -68,7 +72,8 @@ fn settings_display<D: DrawTarget<Color = Rgb565>>(t: &mut D) -> Result<(), D::E
     title_bar(t, "Display", theme::ACCENT, true)?;
     // Row order must match [`crate::display_row_entry`] — paint and tap-dispatch share
     // `settings_row_rect(i)`.
-    render_row(
+    components::rect_card(t, settings_row_rect(0))?;
+    components::rect_row(
         t,
         settings_row_rect(0),
         Glyph::Sun,
@@ -76,7 +81,8 @@ fn settings_display<D: DrawTarget<Color = Rgb565>>(t: &mut D) -> Result<(), D::E
         None,
         true,
     )?;
-    render_row(
+    components::rect_card(t, settings_row_rect(1))?;
+    components::rect_row(
         t,
         settings_row_rect(1),
         Glyph::Moon,
@@ -84,7 +90,8 @@ fn settings_display<D: DrawTarget<Color = Rgb565>>(t: &mut D) -> Result<(), D::E
         None,
         true,
     )?;
-    render_row(
+    components::rect_card(t, settings_row_rect(2))?;
+    components::rect_row(
         t,
         settings_row_rect(2),
         Glyph::Clock,
@@ -109,7 +116,8 @@ fn settings_security<D: DrawTarget<Color = Rgb565>>(
     // share `settings_row_rect(i)` but not a single table, so the danger Factory reset stays
     // last on both. Two independent PINs: the device PIN (lock glyph) gates the on-device UI;
     // the FIDO clientPIN (key glyph) is WebAuthn's. Each row sets or changes only its own.
-    render_row(
+    components::rect_card(t, settings_row_rect(0))?;
+    components::rect_row(
         t,
         settings_row_rect(0),
         Glyph::Lock,
@@ -121,7 +129,8 @@ fn settings_security<D: DrawTarget<Color = Rgb565>>(
         None,
         true,
     )?;
-    render_row(
+    components::rect_card(t, settings_row_rect(1))?;
+    components::rect_row(
         t,
         settings_row_rect(1),
         Glyph::Key,
@@ -135,8 +144,10 @@ fn settings_security<D: DrawTarget<Color = Rgb565>>(
     )?;
     // The PIV applet's own PIN/PUK — a drill-in to its sub-menu ([`render_piv_pin_menu`]),
     // grouped with the other two credential PINs above the audit/backup/reset rows.
-    render_row(t, settings_row_rect(2), Glyph::Lock, "PIV PIN", None, true)?;
-    render_row(
+    components::rect_card(t, settings_row_rect(2))?;
+    components::rect_row(t, settings_row_rect(2), Glyph::Lock, "PIV PIN", None, true)?;
+    components::rect_card(t, settings_row_rect(3))?;
+    components::rect_row(
         t,
         settings_row_rect(3),
         Glyph::Clock,
@@ -147,7 +158,8 @@ fn settings_security<D: DrawTarget<Color = Rgb565>>(
     // The row shows the cheap export-*window* bit only ("Sealed" / "Review"); the full
     // 4-way state (no-seed / restore-only / sealed / review) lives on the Backup page, which
     // also reads `has_seed` + the build profile. The row deliberately skips that extra lookup.
-    render_row(
+    components::rect_card(t, settings_row_rect(4))?;
+    components::rect_row(
         t,
         settings_row_rect(4),
         Glyph::Lifebuoy,
@@ -162,15 +174,26 @@ fn settings_security<D: DrawTarget<Color = Rgb565>>(
     danger_row(t, settings_row_rect(5), "Factory reset")
 }
 
-/// A destructive option row: the [`render_row`] card, but red-tinted (the [`theme::DANGER_BG`]
-/// fill and [`theme::DANGER_BORDER`] edge) with a warning glyph, label, and drill-in chevron
-/// all in the decline colour — so a destructive action stands out from the neutral rows.
+/// A destructive option row: a red-tinted rounded card with a warning glyph, label,
+/// and drill-in chevron — so a destructive action stands out from the neutral rows.
 fn danger_row<D: DrawTarget<Color = Rgb565>>(
     t: &mut D,
     rect: Rect,
     label: &str,
 ) -> Result<(), D::Error> {
-    card(t, rect, theme::DANGER_BG, theme::DANGER_BORDER)?;
+    let r = components::CARD_RADIUS;
+    RoundedRectangle::with_equal_corners(eg_rect(rect), Size::new(r, r))
+        .into_styled(PrimitiveStyle::with_fill(theme::DANGER_BG))
+        .draw(t)?;
+    RoundedRectangle::with_equal_corners(eg_rect(rect), Size::new(r, r))
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_color(theme::DANGER_BORDER)
+                .stroke_width(1)
+                .stroke_alignment(StrokeAlignment::Inside)
+                .build(),
+        )
+        .draw(t)?;
     let cy = rect.y as i32 + rect.h as i32 / 2;
     glyph::draw(
         t,

--- a/crates/rsk-ui/src/render_tests.rs
+++ b/crates/rsk-ui/src/render_tests.rs
@@ -1824,3 +1824,44 @@ fn hold_fill_grows_left_to_right_with_a_flat_edge() {
     let w = r.w / 2; // num/den = 5/10
     assert_eq!(d.at(r.x + w - 3, r.y + 2), wash);
 }
+
+/// Regression: `render_pin_dots` must clear the "+" overflow marker and the 10th
+/// dot when `entered` drops. The old per-dot clear was centred on each circle, so
+/// it left the "+" (drawn at x 184) and dot 10's right tail behind on a delete —
+/// a shortened PIN still read as long.
+#[test]
+fn pin_dots_clear_strip_erases_overflow_and_tenth_dot_on_delete() {
+    use crate::render_pin_dots;
+    // ENTRY_* are private to render/pin.rs; mirror them here so the edge test does
+    // not force a wider re-export. Keep in sync with render/pin.rs.
+    const ENTRY_X0: u16 = 24;
+    const ENTRY_MAX_SHOWN: u16 = 10;
+    const ENTRY_STEP: u16 = 16;
+
+    // Dot i is a 12×12 circle at top-left (24 + i·16, 54). The "+" overflow marker
+    // draws to the right of the last dot (x 184..). Use boxes, not point probes, so
+    // the test does not pin a glyph baseline.
+    let dot10 = Rect::new(ENTRY_X0 + 9 * ENTRY_STEP, 54, 12, 12); // i = 9, the 10th dot.
+    let plus = Rect::new(ENTRY_X0 + ENTRY_MAX_SHOWN * ENTRY_STEP, 48, 20, 24);
+
+    // 11 entered → both the 10th dot and the "+" paint; drop to 9 → both erase.
+    let mut d = Rec::new();
+    render_pin_dots(&mut d, 11, 8, None).unwrap();
+    assert!(
+        d.any_non_bg_in(dot10),
+        "setup: the 10th dot should paint before delete"
+    );
+    assert!(
+        d.any_non_bg_in(plus),
+        "setup: the '+' overflow marker should paint before delete"
+    );
+    render_pin_dots(&mut d, 9, 8, None).unwrap();
+    assert!(
+        !d.any_non_bg_in(dot10),
+        "10th dot not erased on delete — stale tail reads as a longer PIN"
+    );
+    assert!(
+        !d.any_non_bg_in(plus),
+        "stale '+' marker left after delete — shortened PIN still read as long"
+    );
+}

--- a/crates/rsk-ui/src/render_tests.rs
+++ b/crates/rsk-ui/src/render_tests.rs
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 RS-Key contributors
 
 use super::ceremony::centered_clipped;
+use super::components;
 use super::home::HOME_CARD_TOP;
 use super::*;
 use crate::{HomeView, PANEL_H, SuccessKind};
@@ -542,43 +543,34 @@ fn applet_detail_screens_fit_and_clip_max_values() {
 #[test]
 fn rename_screen_paints_wheel_and_save() {
     let mut d = Rec::new();
-    render_rename(&mut d, "work", b'a').unwrap();
+    render_rename(&mut d, "work", Some(b'a'), Some(1)).unwrap();
     assert!(!d.oob, "rename drew outside the panel");
     assert!(d.drew_anything());
-    // The back chevron cancels; the Save button is the primary fill — both in their
-    // hit rects.
+    // The back chevron cancels.
     assert!(has_color(&d, crate::TITLE_BACK_RECT, theme::ACCENT));
-    assert!(
-        has_color(&d, crate::RN_SAVE_RECT, theme::ACCENT_FILL),
-        "Save button missing from its hit rect"
-    );
-    // Each wheel control paints something in its own tap target.
-    for r in [
-        crate::RN_UP_RECT,
-        crate::RN_DOWN_RECT,
-        crate::RN_BKSP_RECT,
-        crate::RN_INS_RECT,
-    ] {
-        assert!(d.any_non_bg_in(r), "wheel key {r:?} painted nothing");
+    // Each T9 key paints something in its own tap target (including the Save key).
+    for row in 0..4u16 {
+        for col in 0..3u16 {
+            let r = crate::t9_key_rect(row, col);
+            assert!(d.any_non_bg_in(r), "T9 key ({row},{col}) painted nothing");
+        }
     }
 }
 
 #[test]
-fn rename_space_candidate_stays_in_panel() {
-    // The space candidate takes a different (underline) draw path — still in-bounds,
-    // and an empty value (caret at the field start) must not spill either.
+fn rename_space_pending_stays_in_panel() {
+    // Pending space char takes the underline draw path — still in-bounds.
     let mut d = Rec::new();
-    render_rename(&mut d, "", b' ').unwrap();
+    render_rename(&mut d, "", Some(b' '), None).unwrap();
     assert!(!d.oob, "rename(space) drew outside the panel");
     assert!(d.drew_anything());
 }
 
 #[test]
 fn rename_long_value_is_clipped_to_the_field() {
-    // A value far wider than the field must not paint past the panel (it is clipped).
     let long = "abcdefghijklmnopqrstuvwx";
     let mut d = Rec::new();
-    render_rename(&mut d, long, b'z').unwrap();
+    render_rename(&mut d, long, Some(b'z'), None).unwrap();
     assert!(!d.oob, "rename(long) drew outside the panel");
 }
 
@@ -1453,7 +1445,8 @@ fn header_row_and_nav_draw_within_bounds() {
     let mut d = Rec::new();
     render_header(&mut d, "Settings", true, Some(Glyph::Shield)).unwrap();
     let r = crate::row_rect(40, 0);
-    render_row(&mut d, r, Glyph::Lock, "PIN", Some(("OK", theme::OK)), true).unwrap();
+    components::rect_card(&mut d, r).unwrap();
+    components::rect_row(&mut d, r, Glyph::Lock, "PIN", Some(("OK", theme::OK)), true).unwrap();
     render_nav(&mut d, NavTab::Settings).unwrap();
     assert!(!d.oob, "design-system widgets drew outside the panel");
     // The list-row card fills its rect (sampled on the flat top span).
@@ -1467,7 +1460,8 @@ fn long_row_label_is_clipped_clear_of_the_trailing_value() {
     let r = crate::row_rect(40, 0);
     let txt = "4 accounts";
     let mut d = Rec::new();
-    render_row(
+    components::rect_card(&mut d, r).unwrap();
+    components::rect_row(
         &mut d,
         r,
         Glyph::Globe,

--- a/crates/rsk-ui/src/tests.rs
+++ b/crates/rsk-ui/src/tests.rs
@@ -491,12 +491,15 @@ fn rp_row_shows_nickname_over_rpid() {
 #[test]
 fn rename_key_centres_hit_their_keys() {
     let c = |r: Rect| Point::new(r.x + r.w / 2, r.y + r.h / 2);
-    assert_eq!(hit_rename(c(RN_UP_RECT)), Some(RenameKey::Up));
-    assert_eq!(hit_rename(c(RN_DOWN_RECT)), Some(RenameKey::Down));
-    assert_eq!(hit_rename(c(RN_BKSP_RECT)), Some(RenameKey::Backspace));
-    assert_eq!(hit_rename(c(RN_INS_RECT)), Some(RenameKey::Insert));
-    assert_eq!(hit_rename(c(RN_SAVE_RECT)), Some(RenameKey::Save));
-    // The field area (above the wheel) is not a wheel key.
+    // T9 char keys (0,0)=1, (0,1)=2, (2,2)=9, (3,1)=0
+    assert_eq!(hit_rename(c(t9_key_rect(0, 0))), Some(RenameKey::Char(0)));
+    assert_eq!(hit_rename(c(t9_key_rect(0, 1))), Some(RenameKey::Char(1)));
+    assert_eq!(hit_rename(c(t9_key_rect(2, 2))), Some(RenameKey::Char(8)));
+    assert_eq!(hit_rename(c(t9_key_rect(3, 1))), Some(RenameKey::Char(9)));
+    // Backspace (3, 0) and Save (3, 2)
+    assert_eq!(hit_rename(c(t9_key_rect(3, 0))), Some(RenameKey::Backspace));
+    assert_eq!(hit_rename(c(t9_key_rect(3, 2))), Some(RenameKey::Save));
+    // The field area (above the keypad) is not a key.
     assert_eq!(hit_rename(c(RN_FIELD_RECT)), None);
 }
 
@@ -510,11 +513,19 @@ fn title_edit_and_back_are_disjoint() {
 }
 
 #[test]
-fn rename_charset_is_printable_and_cycles() {
-    assert!(!RENAME_CHARSET.is_empty());
-    assert!(RENAME_CHARSET.iter().all(|&b| (0x20..=0x7E).contains(&b)));
-    // Distinct entries (no accidental dup that would stall the wheel on a value).
-    for (i, &a) in RENAME_CHARSET.iter().enumerate() {
-        assert!(!RENAME_CHARSET[i + 1..].contains(&a), "duplicate {a:?}");
+fn t9_groups_are_printable_and_have_distinct_chars() {
+    for (gi, group) in T9_GROUPS.iter().enumerate() {
+        assert!(!group.is_empty(), "T9 group {gi} is empty");
+        assert!(
+            group.iter().all(|&b| (0x20..=0x7E).contains(&b)),
+            "non-printable in group {gi}"
+        );
+        // No duplicate chars within a group
+        for (i, &a) in group.iter().enumerate() {
+            assert!(
+                !group[i + 1..].contains(&a),
+                "duplicate {a:?} in group {gi}"
+            );
+        }
     }
 }

--- a/crates/rsk-ui/src/tests.rs
+++ b/crates/rsk-ui/src/tests.rs
@@ -514,18 +514,21 @@ fn title_edit_and_back_are_disjoint() {
 
 #[test]
 fn t9_groups_are_printable_and_have_distinct_chars() {
+    // A T9 char must belong to exactly one group — a duplicate across groups
+    // would make `active_group` / `cycle_at` ambiguous on the rename screen.
+    let mut seen: [bool; 128] = [false; 128];
     for (gi, group) in T9_GROUPS.iter().enumerate() {
         assert!(!group.is_empty(), "T9 group {gi} is empty");
         assert!(
             group.iter().all(|&b| (0x20..=0x7E).contains(&b)),
             "non-printable in group {gi}"
         );
-        // No duplicate chars within a group
-        for (i, &a) in group.iter().enumerate() {
+        for &a in group.iter() {
             assert!(
-                !group[i + 1..].contains(&a),
-                "duplicate {a:?} in group {gi}"
+                !seen[a as usize],
+                "duplicate {a:?} appears in two T9 groups"
             );
+            seen[a as usize] = true;
         }
     }
 }

--- a/docs/unsafe.md
+++ b/docs/unsafe.md
@@ -7,10 +7,11 @@ contained. Adding a new `unsafe` requires updating this page. (Safe Rust rules
 out memory-corruption bugs in this code. It is not a security audit; see the
 [threat model](threat-model.md).)
 
-**Runtime sites: 15.** Eight in the firmware proper (`main.rs` + `presence.rs`):
-the interrupt-handler pair (2), the `Send` impl, the heap init, and the four
+**Runtime sites: 19.** Twelve in the firmware proper (`main.rs` + `presence.rs`):
+the interrupt-handler pair (2), the `Send` impl, the heap init, and the eight
 GPIO-pin `steal`s (the presence button, the LED power-enable rail, the nuisance
-USR LED, and the display build's wake button). Two for the per-core prime sieves,
+USR LED, the display build's wake button, and — display builds only — the panel's
+CS/DC/RST/TP_RST control lines). Two for the per-core prime sieves,
 three in the RSA assembly FFI, two in the standalone flash-wipe tool.
 
 ```mermaid
@@ -19,7 +20,7 @@ flowchart TB
       a["interrupt executor (×2)"]
       b["Send for SendUsb"]
       c["heap init"]
-      d["GPIO pin steal ×4 (presence, LED power, USR LED, display wake)"]
+      d["GPIO pin steal ×8 (presence, LED power, USR LED, display wake + CS/DC/RST/TP_RST)"]
     end
     subgraph kg["firmware/src/core1.rs"]
       e["per-core prime sieves (×2)"]
@@ -74,28 +75,29 @@ executor and embassy keeps the trait object `!Send`.
 unsafe { HEAP.init(core::ptr::addr_of_mut!(HEAP_MEM) as usize, HEAP_SIZE) }
 ```
 
-A 64 KiB heap exists solely for the `rsa` crate's big integers (the only
+A 128 KiB heap exists solely for the `rsa` crate's big integers (the only
 allocating dependency). `init`'s contract (call once, with exclusive access
 to the region) is met: it runs once at the top of `main`, on a dedicated
 static buffer used by nothing else.
 *Safe alternative:* none; every embedded allocator initializes this way.
 *Containment:* one call, before any allocation can happen.
 
-### 5–8. GPIO pin type-erasure (presence button, LED power rail, USR-LED-off, display wake, ×4)
+### 5–12. GPIO pin type-erasure (presence button, LED power rail, USR-LED-off, display wake + control pins, ×8)
 
 ```rust
 let any = unsafe { AnyPin::steal(pin) };
 ```
 
-Four build-configurable GPIOs are chosen by *number* at build time rather than as
+Eight build-configurable GPIOs are chosen by *number* at build time rather than as
 a concrete `PIN_n` type, so each must be converted to embassy's type-erased
 `AnyPin`: the optional `PRESENCE_PIN=<gpio>` presence button
 (`ButtonPresence::new_gpio`, `presence.rs`), the optional `LED_POWER_PIN`
 enable pin driven high to power a gated LED rail (the LED block in `main.rs`),
 the optional `USR_LED_PIN` driven to a nuisance onboard LED's OFF level and held
 (the boot block in `main.rs`), and — display builds only — the optional
-`WAKE_PIN` button that wakes the panel from display sleep (the panel block in
-`main.rs`). `AnyPin::steal` is `unsafe` because the caller must
+`WAKE_PIN` button that wakes the panel from display sleep **plus the panel's
+CS/DC/RST/TP_RST control lines**, all by board-config number, in the panel block
+of `main.rs`. `AnyPin::steal` is `unsafe` because the caller must
 guarantee unique ownership of that hardware pin — a `match` over `p.PIN_0..=PIN_29`
 (as the LED *data* pin uses) is impossible here, since it would double-move the
 peripheral set the LED block already claims.
@@ -103,12 +105,15 @@ peripheral set the LED block already claims.
 constructors require a statically known pin type.
 *Containment:* each is gated by pin-range validation and the single-owner
 invariant from `main` — none of the presence pin, the LED-power pin, the
-USR-LED pin, nor the wake pin is ever handed to another driver, and compile-time
-`assert!`s reject a
+USR-LED pin, the wake pin, nor the four panel control pins is ever handed to
+another driver, and compile-time `assert!`s reject a
 build that collides `LED_POWER_PIN` or `USR_LED_PIN` with the LED data pin or a GPIO
 `PRESENCE_PIN` (and refuse `USR_LED_PIN` outright on a display build, whose panel
-owns those pads) or a `WAKE_PIN` in the LCD/touch range (`10..=18`),
-as an LED/presence collision already panics at boot.
+owns those pads), rejects a `WAKE_PIN` in the LCD/touch range (`10..=18`),
+**and rejects any of CS/DC/RST/TP_RST/BL colliding with each other, with the
+hard-wired SPI1 (PIN_10/11/12) or I2C1 (PIN_6/7) lines, an enabled `WAKE_PIN`,
+or `LED_PIN`/`LED_POWER_PIN` when their LED driver is built** — a collision
+silently drives one pad from two owners at runtime, so it is checked at build time.
 
 ## Firmware dual-core keygen (`firmware/src/core1.rs`)
 
@@ -176,6 +181,10 @@ never ships inside the firmware.
 - `crates/rsk-rsa-asm/build.rs`: `unsafe { env::set_var(...) }` forces the
   ARM cross-compiler for the vendored C. Build scripts are single-threaded at
   that point (the call is host-side, never in the image).
+- `firmware/build.rs`: `unsafe { env::set_var(k, v) }` copies the selected
+  board-config file's values (`BOARD=<name>`) back into the env before the
+  build reads them. Same single-threaded host-side build-script context; never
+  reaches the firmware image.
 - Edition-2024 *declarations*: `#[unsafe(link_section = ".start_block")]` on
   the two bootrom image-definition statics and `unsafe extern "C"` on the
   linker-symbol/FFI declaration blocks. These mark declarations the compiler

--- a/firmware/boards/seeed-xiao.toml
+++ b/firmware/boards/seeed-xiao.toml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+#
+# Seeed XIAO RP2350 — WS2812 LED powered via GP23 (power-enable gate),
+# active-low USR LED on GP25 driven off at boot, BOOTSEL presence.
+# 2 MB flash; shrink KVMAIN to leave room for code.
+
+[usb]
+vidpid = "RSKey"
+
+[led]
+kind = "ws2812"
+pin = 16
+order = "rgb"
+power_pin = 23
+
+[presence]
+source = "bootsel"
+
+[flash]
+size_mb = 2
+kvmain_kb = 896
+
+# Nuisance onboard USR LED — drive off at boot.
+[usr_led]
+pin = 25
+active_high = false

--- a/firmware/boards/tenstar-usb.toml
+++ b/firmware/boards/tenstar-usb.toml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+#
+# TenStar RP2350-USB — WS2812B-standard LED (GRB byte order),
+# GPIO button for presence. No display.
+
+[usb]
+vidpid = "RSKey"
+
+[led]
+kind = "ws2812"
+pin = 16
+order = "grb"
+
+[presence]
+source = "gpio"
+pin = 15
+active_high = false
+
+[flash]
+size_mb = 4
+kvmain_kb = 1408

--- a/firmware/boards/waveshare-one.toml
+++ b/firmware/boards/waveshare-one.toml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+#
+# Waveshare RP2350-One — the default, standard key.
+# WS2812 addressable RGB LED on GPIO16, BOOTSEL button for presence.
+# No display.
+
+[usb]
+vidpid = "RSKey"
+# 0x1209:0x0001 — this project's own pid.codes identity
+
+[led]
+kind = "ws2812"
+pin = 16
+order = "rgb"
+
+[presence]
+source = "bootsel"
+
+[flash]
+size_mb = 4
+kvmain_kb = 1408

--- a/firmware/boards/waveshare-touch-lcd.toml
+++ b/firmware/boards/waveshare-touch-lcd.toml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+#
+# Waveshare RP2350-Touch-LCD-2.8 — the trusted-display build.
+# ST7789 240×320 panel over SPI1, CST328 touch over I2C1.
+# Backlight PWM on GPIO16, touch RST on GPIO17.
+# No addressable LED (LED_KIND=none); the panel is the indicator.
+
+[usb]
+vidpid = "RSKey"
+
+[led]
+kind = "none"
+
+[presence]
+source = "bootsel"
+
+[flash]
+size_mb = 4
+kvmain_kb = 1408
+
+[display]
+# ST7789 over SPI1 at up-to-62.5 MHz; drop to 40 if the flex cable misbehaves.
+spi_freq_hz = 62_500_000
+# GPIOs for the panel control lines.
+cs = 13
+dc = 14
+rst = 15
+# Backlight PWM: GPIO16, PWM slice 0 channel A.
+bl_pin = 16
+bl_pwm_slice = 0
+bl_pwm_channel = "A"
+# CST328 touch controller over I2C1.
+tp_rst = 17
+# Wake button: GPIO25 (the board's BAT_PWR / KEY_BAT button).
+wake_pin = 25
+wake_active_high = false

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -461,6 +461,21 @@ fn main() {
         }
     }
 
+    // Display knobs flow from `board.toml`/env var into PK_DISPLAY_*; any change
+    // lets `env!("PK_DISPLAY_*")` go stale and bake the wrong pins into the
+    // firmware image — re-rustc on any of them.
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_SPI_FREQ_HZ");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_CS");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_DC");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_RST");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_BL_PIN");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_BL_PWM_SLICE");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_BL_PWM_CHANNEL");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_TP_RST");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_I2C_FREQ_HZ");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_INVERT_COLORS");
+    println!("cargo:rerun-if-env-changed=PK_DISPLAY_COLOR_ORDER");
+
     for (env_var, baked) in [("FAKE_MKEK", "PK_FAKE_MKEK"), ("FAKE_DEVK", "PK_FAKE_DEVK")] {
         if let Some(hex) = resolve_fake_key(env_var) {
             println!("cargo:rustc-env={baked}={hex}");

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -110,6 +110,20 @@ fn parse_toml(raw: &str) -> BoardConfig {
         display_color_order: None,
     };
     let mut sec = "";
+    fn strip_comment(s: &str) -> &str {
+        // Strip a trailing `# ...` from a value, outside a quoted string.
+        // (TOML's comment char everywhere except inside a "..."; the boards
+        // never quote values with `#` inside, so a simple state toggle is enough.)
+        let mut in_q = false;
+        for (i, &b) in s.as_bytes().iter().enumerate() {
+            match b {
+                b'"' => in_q = !in_q,
+                b'#' if !in_q => return s[..i].trim_end(),
+                _ => {}
+            }
+        }
+        s
+    }
     fn u(s: &str) -> &str {
         s.trim().trim_matches('"')
     }
@@ -139,7 +153,7 @@ fn parse_toml(raw: &str) -> BoardConfig {
         let Some((k, v)) = line.split_once('=') else {
             continue;
         };
-        let (k, v) = (k.trim(), v.trim());
+        let (k, v) = (k.trim(), strip_comment(v).trim());
         match (sec, k) {
             ("usb", "vidpid") => c.vidpid = Some(u(v).to_string()),
             ("usb", "vid") => c.usb_vid = Some(u32(v) as u16),
@@ -405,39 +419,56 @@ fn main() {
         };
     }
     let b = board.as_ref();
-    let b2 = b.and_then(|b| b.display_cs.map(|_| b));
+    // A board config only counts as a display board once it sets `display_cs` —
+    // the chip-select is the semantic gate pin, so a `[display]` section it
+    // under-specifies is dropped here. The knobs below then fall back to the
+    // Waveshare RP2350-Touch-LCD defaults.
+    let disp_cfg = b.and_then(|b| b.display_cs.map(|_| b));
     disp!(
         "PK_DISPLAY_SPI_FREQ_HZ",
-        b2.and_then(|b| b.display_spi_freq_hz).unwrap_or(62_500_000)
+        disp_cfg
+            .and_then(|b| b.display_spi_freq_hz)
+            .unwrap_or(62_500_000)
     );
-    disp!("PK_DISPLAY_CS", b2.and_then(|b| b.display_cs).unwrap_or(13));
-    disp!("PK_DISPLAY_DC", b2.and_then(|b| b.display_dc).unwrap_or(14));
+    disp!(
+        "PK_DISPLAY_CS",
+        disp_cfg.and_then(|b| b.display_cs).unwrap_or(13)
+    );
+    disp!(
+        "PK_DISPLAY_DC",
+        disp_cfg.and_then(|b| b.display_dc).unwrap_or(14)
+    );
     disp!(
         "PK_DISPLAY_RST",
-        b2.and_then(|b| b.display_rst).unwrap_or(15)
+        disp_cfg.and_then(|b| b.display_rst).unwrap_or(15)
     );
     disp!(
         "PK_DISPLAY_BL_PIN",
-        b2.and_then(|b| b.display_bl_pin).unwrap_or(16)
+        disp_cfg.and_then(|b| b.display_bl_pin).unwrap_or(16)
     );
     disp!(
         "PK_DISPLAY_BL_PWM_SLICE",
-        b2.and_then(|b| b.display_bl_pwm_slice).unwrap_or(0)
+        disp_cfg.and_then(|b| b.display_bl_pwm_slice).unwrap_or(0)
     );
     disp!(
         "PK_DISPLAY_BL_PWM_CHANNEL",
-        b2.and_then(|b| b.display_bl_pwm_channel).unwrap_or(0)
+        disp_cfg.and_then(|b| b.display_bl_pwm_channel).unwrap_or(0)
     );
     disp!(
         "PK_DISPLAY_TP_RST",
-        b2.and_then(|b| b.display_tp_rst).unwrap_or(17)
+        disp_cfg.and_then(|b| b.display_tp_rst).unwrap_or(17)
     );
     disp!(
         "PK_DISPLAY_I2C_FREQ_HZ",
-        b2.and_then(|b| b.display_i2c_freq_hz).unwrap_or(400_000)
+        disp_cfg
+            .and_then(|b| b.display_i2c_freq_hz)
+            .unwrap_or(400_000)
     );
     {
-        let v = if b2.and_then(|b| b.display_invert_colors).unwrap_or(true) {
+        let v = if disp_cfg
+            .and_then(|b| b.display_invert_colors)
+            .unwrap_or(true)
+        {
             "1"
         } else {
             "0"
@@ -447,7 +478,7 @@ fn main() {
         }
     }
     {
-        let v = if b2
+        let v = if disp_cfg
             .and_then(|b| b.display_color_order.as_deref())
             .unwrap_or("rgb")
             == "bgr"

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -6,6 +6,7 @@
 //! multiplier, and the WS2812 LED pin, and bakes them in as `PK_*` env vars /
 //! `cfg`s that `main.rs` reads with `env!` / `#[cfg]`.
 use std::env;
+use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
@@ -31,8 +32,225 @@ const KVCNT_LEN: u32 = 128 * 1024;
 /// split here with a fix hint instead of leaving a cryptic linker overflow.
 const MIN_CODE: u32 = 1024 * 1024;
 
+// --- Board config (BOARD=<name> -> firmware/boards/<name>.toml) ---
+struct BoardConfig {
+    vidpid: Option<String>,
+    usb_vid: Option<u16>,
+    usb_pid: Option<u16>,
+    usb_manufacturer: Option<String>,
+    usb_product: Option<String>,
+    led_kind: Option<String>,
+    led_pin: Option<u8>,
+    led_order: Option<String>,
+    led_power_pin: Option<u8>,
+    max_leds: Option<u32>,
+    presence_source: Option<String>,
+    presence_pin: Option<u8>,
+    presence_active_high: Option<bool>,
+    usr_led_pin: Option<u8>,
+    usr_led_active_high: Option<bool>,
+    flash_size_mb: Option<u32>,
+    kvmain_kb: Option<u32>,
+    // display
+    display_spi_freq_hz: Option<u32>,
+    display_cs: Option<u8>,
+    display_dc: Option<u8>,
+    display_rst: Option<u8>,
+    display_bl_pin: Option<u8>,
+    display_bl_pwm_slice: Option<u8>,
+    display_bl_pwm_channel: Option<u8>,
+    display_tp_rst: Option<u8>,
+    display_wake_pin: Option<u8>,
+    display_wake_active_high: Option<bool>,
+    display_i2c_freq_hz: Option<u32>,
+    display_invert_colors: Option<bool>,
+    display_color_order: Option<String>,
+}
+
+fn read_board() -> Option<BoardConfig> {
+    let name = env::var("BOARD").ok()?;
+    let path = format!("boards/{name}.toml");
+    let raw =
+        fs::read_to_string(&path).unwrap_or_else(|_| panic!("BOARD={name:?}: cannot read {path}"));
+    println!("cargo:rerun-if-changed={path}");
+    Some(parse_toml(&raw))
+}
+
+fn parse_toml(raw: &str) -> BoardConfig {
+    let mut c = BoardConfig {
+        vidpid: None,
+        usb_vid: None,
+        usb_pid: None,
+        usb_manufacturer: None,
+        usb_product: None,
+        led_kind: None,
+        led_pin: None,
+        led_order: None,
+        led_power_pin: None,
+        max_leds: None,
+        presence_source: None,
+        presence_pin: None,
+        presence_active_high: None,
+        usr_led_pin: None,
+        usr_led_active_high: None,
+        flash_size_mb: None,
+        kvmain_kb: None,
+        display_spi_freq_hz: None,
+        display_cs: None,
+        display_dc: None,
+        display_rst: None,
+        display_bl_pin: None,
+        display_bl_pwm_slice: None,
+        display_bl_pwm_channel: None,
+        display_tp_rst: None,
+        display_wake_pin: None,
+        display_wake_active_high: None,
+        display_i2c_freq_hz: None,
+        display_invert_colors: None,
+        display_color_order: None,
+    };
+    let mut sec = "";
+    fn u(s: &str) -> &str {
+        s.trim().trim_matches('"')
+    }
+    fn u8(s: &str) -> u8 {
+        u32(s) as u8
+    }
+    fn u32(s: &str) -> u32 {
+        let clean: String = u(s).chars().filter(|c| *c != '_').collect();
+        u32::from_str_radix(
+            clean.trim_start_matches("0x"),
+            if clean.starts_with("0x") { 16 } else { 10 },
+        )
+        .unwrap_or_else(|_| panic!("bad u32: {}", s))
+    }
+    fn b(s: &str) -> bool {
+        matches!(u(s), "true" | "1")
+    }
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(s) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            sec = s.trim();
+            continue;
+        }
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        let (k, v) = (k.trim(), v.trim());
+        match (sec, k) {
+            ("usb", "vidpid") => c.vidpid = Some(u(v).to_string()),
+            ("usb", "vid") => c.usb_vid = Some(u32(v) as u16),
+            ("usb", "pid") => c.usb_pid = Some(u32(v) as u16),
+            ("usb", "manufacturer") => c.usb_manufacturer = Some(u(v).to_string()),
+            ("usb", "product") => c.usb_product = Some(u(v).to_string()),
+            ("led", "kind") => c.led_kind = Some(u(v).to_string()),
+            ("led", "pin") => c.led_pin = Some(u8(v)),
+            ("led", "order") => c.led_order = Some(u(v).to_string()),
+            ("led", "power_pin") => c.led_power_pin = Some(u8(v)),
+            ("led", "max_leds") => c.max_leds = Some(u32(v)),
+            ("presence", "source") => c.presence_source = Some(u(v).to_string()),
+            ("presence", "pin") => c.presence_pin = Some(u8(v)),
+            ("presence", "active_high") => c.presence_active_high = Some(b(v)),
+            ("usr_led", "pin") => c.usr_led_pin = Some(u8(v)),
+            ("usr_led", "active_high") => c.usr_led_active_high = Some(b(v)),
+            ("flash", "size_mb") => c.flash_size_mb = Some(u32(v)),
+            ("flash", "kvmain_kb") => c.kvmain_kb = Some(u32(v)),
+            ("display", "spi_freq_hz") => c.display_spi_freq_hz = Some(u32(v)),
+            ("display", "cs") => c.display_cs = Some(u8(v)),
+            ("display", "dc") => c.display_dc = Some(u8(v)),
+            ("display", "rst") => c.display_rst = Some(u8(v)),
+            ("display", "bl_pin") => c.display_bl_pin = Some(u8(v)),
+            ("display", "bl_pwm_slice") => c.display_bl_pwm_slice = Some(u8(v)),
+            ("display", "bl_pwm_channel") => {
+                let ch = u(v);
+                c.display_bl_pwm_channel = Some(match ch {
+                    "A" | "a" | "0" => 0,
+                    "B" | "b" | "1" => 1,
+                    _ => panic!("bl_pwm_channel: {ch}"),
+                });
+            }
+            ("display", "tp_rst") => c.display_tp_rst = Some(u8(v)),
+            ("display", "wake_pin") => c.display_wake_pin = Some(u8(v)),
+            ("display", "wake_active_high") => c.display_wake_active_high = Some(b(v)),
+            ("display", "i2c_freq_hz") => c.display_i2c_freq_hz = Some(u32(v)),
+            ("display", "invert_colors") => c.display_invert_colors = Some(b(v)),
+            ("display", "color_order") => c.display_color_order = Some(u(v).to_string()),
+            _ => {}
+        }
+    }
+    c
+}
+
 fn main() {
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+    println!("cargo:rerun-if-env-changed=BOARD");
+    let board = read_board();
+    if let Some(ref b) = board {
+        let set = |k: &str, v: &str| {
+            if env::var(k).is_err() {
+                unsafe { env::set_var(k, v) }
+            }
+        };
+        if let Some(ref v) = b.vidpid {
+            set("VIDPID", v);
+        }
+        if let Some(v) = b.usb_vid {
+            set("USB_VID", &v.to_string());
+        }
+        if let Some(v) = b.usb_pid {
+            set("USB_PID", &v.to_string());
+        }
+        if let Some(ref v) = b.usb_manufacturer {
+            set("USB_MANUFACTURER", v);
+        }
+        if let Some(ref v) = b.usb_product {
+            set("USB_PRODUCT", v);
+        }
+        if let Some(ref v) = b.led_kind {
+            set("LED_KIND", v);
+        }
+        if let Some(v) = b.led_pin {
+            set("LED_PIN", &v.to_string());
+        }
+        if let Some(ref v) = b.led_order {
+            set("LED_ORDER", v);
+        }
+        if let Some(v) = b.led_power_pin {
+            set("LED_POWER_PIN", &v.to_string());
+        }
+        if let Some(v) = b.max_leds {
+            set("MAX_LEDS", &v.to_string());
+        }
+        if b.presence_source.as_deref() == Some("gpio") {
+            if let Some(v) = b.presence_pin {
+                set("PRESENCE_PIN", &v.to_string());
+            }
+            if let Some(v) = b.presence_active_high {
+                set("PRESENCE_ACTIVE_HIGH", if v { "1" } else { "0" });
+            }
+        }
+        if let Some(v) = b.usr_led_pin {
+            set("USR_LED_PIN", &v.to_string());
+        }
+        if let Some(v) = b.usr_led_active_high {
+            set("USR_LED_ACTIVE_HIGH", if v { "1" } else { "0" });
+        }
+        if let Some(v) = b.flash_size_mb {
+            set("FLASH_SIZE", &format!("{}M", v));
+        }
+        if let Some(v) = b.kvmain_kb {
+            set("KVMAIN", &format!("{}K", v));
+        }
+        if let Some(v) = b.display_wake_pin {
+            set("WAKE_PIN", &v.to_string());
+        }
+        if let Some(v) = b.display_wake_active_high {
+            set("WAKE_ACTIVE_HIGH", if v { "1" } else { "0" });
+        }
+    }
 
     // memory.x: the checked-in script is the default 4 MB / 1408K-KVMAIN layout;
     // for any other FLASH_SIZE or KVMAIN we splice a recomputed MEMORY block
@@ -178,6 +396,71 @@ fn main() {
     // Bake fake OTP keys into the image instead of reading the fuses — exercises
     // the kbase migration + boot path without an irreversible OTP write.
     // TEST BUILDS ONLY; never set for a shipped image.
+    // Display pin defaults (board config or env var or hardcoded).
+    macro_rules! disp {
+        ($key:expr, $val:expr) => {
+            if env::var($key).is_err() {
+                println!("cargo:rustc-env={}={}", $key, $val);
+            }
+        };
+    }
+    let b = board.as_ref();
+    let b2 = b.and_then(|b| b.display_cs.map(|_| b));
+    disp!(
+        "PK_DISPLAY_SPI_FREQ_HZ",
+        b2.and_then(|b| b.display_spi_freq_hz).unwrap_or(62_500_000)
+    );
+    disp!("PK_DISPLAY_CS", b2.and_then(|b| b.display_cs).unwrap_or(13));
+    disp!("PK_DISPLAY_DC", b2.and_then(|b| b.display_dc).unwrap_or(14));
+    disp!(
+        "PK_DISPLAY_RST",
+        b2.and_then(|b| b.display_rst).unwrap_or(15)
+    );
+    disp!(
+        "PK_DISPLAY_BL_PIN",
+        b2.and_then(|b| b.display_bl_pin).unwrap_or(16)
+    );
+    disp!(
+        "PK_DISPLAY_BL_PWM_SLICE",
+        b2.and_then(|b| b.display_bl_pwm_slice).unwrap_or(0)
+    );
+    disp!(
+        "PK_DISPLAY_BL_PWM_CHANNEL",
+        b2.and_then(|b| b.display_bl_pwm_channel).unwrap_or(0)
+    );
+    disp!(
+        "PK_DISPLAY_TP_RST",
+        b2.and_then(|b| b.display_tp_rst).unwrap_or(17)
+    );
+    disp!(
+        "PK_DISPLAY_I2C_FREQ_HZ",
+        b2.and_then(|b| b.display_i2c_freq_hz).unwrap_or(400_000)
+    );
+    {
+        let v = if b2.and_then(|b| b.display_invert_colors).unwrap_or(true) {
+            "1"
+        } else {
+            "0"
+        };
+        if env::var("PK_DISPLAY_INVERT_COLORS").is_err() {
+            println!("cargo:rustc-env=PK_DISPLAY_INVERT_COLORS={}", v);
+        }
+    }
+    {
+        let v = if b2
+            .and_then(|b| b.display_color_order.as_deref())
+            .unwrap_or("rgb")
+            == "bgr"
+        {
+            "1"
+        } else {
+            "0"
+        };
+        if env::var("PK_DISPLAY_COLOR_ORDER").is_err() {
+            println!("cargo:rustc-env=PK_DISPLAY_COLOR_ORDER={}", v);
+        }
+    }
+
     for (env_var, baked) in [("FAKE_MKEK", "PK_FAKE_MKEK"), ("FAKE_DEVK", "PK_FAKE_DEVK")] {
         if let Some(hex) = resolve_fake_key(env_var) {
             println!("cargo:rustc-env={baked}={hex}");

--- a/firmware/src/display.rs
+++ b/firmware/src/display.rs
@@ -47,7 +47,7 @@ use zeroize::Zeroize;
 
 use mipidsi::interface::SpiInterface;
 use mipidsi::models::ST7789;
-use mipidsi::options::ColorInversion;
+use mipidsi::options::{ColorInversion, ColorOrder};
 use mipidsi::{Builder, Display};
 use rsk_crypto::Device;
 use rsk_sdk::Confirm;
@@ -366,12 +366,21 @@ impl Ui {
         let spi_dev = ExclusiveDevice::new(spi, cs, Delay).unwrap();
         let di = SpiInterface::new(spi_dev, dc, buf);
 
-        // ST7789 native 240×320 portrait, matching rsk-ui's geometry. The IPS module
-        // needs `Inverted` (HW-verified on bringup).
+        // ST7789 240x320 portrait. Inversion and color order from board config.
+        let invert = if crate::BUILD_DISPLAY_INVERT_COLORS {
+            ColorInversion::Inverted
+        } else {
+            ColorInversion::Normal
+        };
+        let color_order = match crate::BUILD_DISPLAY_COLOR_ORDER {
+            1 => ColorOrder::Bgr,
+            _ => ColorOrder::Rgb,
+        };
         let mut delay = Delay;
         let mut panel = Builder::new(ST7789, di)
             .display_size(rsk_ui::PANEL_W, rsk_ui::PANEL_H)
-            .invert_colors(ColorInversion::Inverted)
+            .invert_colors(invert)
+            .color_order(color_order)
             .reset_pin(rst)
             .init(&mut delay)
             .unwrap();

--- a/firmware/src/display/pin.rs
+++ b/firmware/src/display/pin.rs
@@ -11,23 +11,20 @@ use super::*;
 /// default PIN `123456` is six). The applet stores up to eight; `rsk_piv::pad_pin` pads the
 /// rest to the 8-byte `0xFF` wire form so a host VERIFY (which always pads) matches.
 const PIV_PIN_MIN: usize = 6;
-/// Rename caret blink half-period: the caret toggles on/off every this many ms (~1s full
-/// cycle, the design's `steps(1)` 1s blink).
+/// Rename caret blink half-period (unused with T9 — pending char replaces caret blink).
+#[allow(dead_code)]
 const CARET_BLINK_MS: u64 = 500;
 
 impl Ui {
-    /// The rename screen: edit a relying party's device-local nickname with the character
-    /// wheel and persist it via [`rsk_fido::passkeys::set_rp_nickname`] — which seals the
-    /// label at rest and never touches the credential box, so the passkey keeps working.
-    /// Returns the committed nickname (empty = cleared) only when the store actually
-    /// persisted it, or `None` on cancel (back chevron / power-button sleep / a queued host
-    /// command / inactivity) *and* on a failed store (so the caller keeps the prior title
-    /// rather than showing an unsaved rename). Pre-filled with
-    /// the current nickname (empty if none); the wheel cycles `RENAME_CHARSET`, `+` appends
-    /// the candidate, `⌫` deletes, and the buffer is capped at `RP_NICK_MAX_LEN`.
+    /// The rename screen: edit a relying party's device-local nickname with a T9
+    /// phone-style keypad. Each key 1-9 cycles through its letter group on repeated
+    /// presses; pressing a different key (or waiting [`T9_COMMIT_MS`]) commits the
+    /// pending character. Backspace deletes, Save persists via
+    /// [`rsk_fido::passkeys::set_rp_nickname`]. Returns the committed nickname on
+    /// success, `None` on cancel / sleep / timeout / failed store.
     pub(super) fn run_rename(&mut self, current: &Label, hash: &[u8; 32]) -> Option<Label> {
         let idle_limit = Duration::from_millis(MENU_INACTIVITY_MS);
-        let charset = rsk_ui::RENAME_CHARSET;
+        let groups = rsk_ui::T9_GROUPS;
         let mut buf = [0u8; rsk_fido::passkeys::RP_NICK_MAX_LEN];
         let mut len = 0usize;
         for &b in current.as_str().as_bytes() {
@@ -36,40 +33,93 @@ impl Ui {
                 len += 1;
             }
         }
-        let mut cand = 0usize;
+
+        // T9 state
+        let mut pending: Option<u8> = None; // char being cycled (not yet committed)
+        let mut active_group: Option<usize> = None; // which T9 group is active
+        let mut cycle_at: usize = 0; // position within the active group
+        let mut last_t9_press = Instant::now();
+        /// Auto-commit the pending character after this long without a same-key press.
+        const T9_COMMIT_MS: u64 = 800;
+
         let val = |buf: &[u8], len: usize| -> Label { Label::clamp(&buf[..len]) };
-        let _ = rsk_ui::render_rename(&mut self.panel, val(&buf, len).as_str(), charset[cand]);
+
+        // Initial full-frame paint.
+        let _ = rsk_ui::render_rename(
+            &mut self.panel,
+            val(&buf, len).as_str(),
+            pending,
+            active_group,
+        );
         self.shown = None;
         self.touch.wait_release(Instant::now(), idle_limit);
 
         let mut last = Instant::now();
-        // Blink the field caret: a full render leaves it on, then it toggles every
-        // `CARET_BLINK_MS` via the in-place [`render_rename_caret`].
-        let mut caret_on = true;
-        let mut blink_at = Instant::now();
+        let mut prev_active = active_group;
         loop {
             if self.sleep_button_pressed() {
                 return None;
             }
+
+            // Auto-commit pending char after T9 timeout
+            if pending.is_some()
+                && active_group.is_some()
+                && last_t9_press.elapsed() >= Duration::from_millis(T9_COMMIT_MS)
+            {
+                if len < buf.len() {
+                    buf[len] = pending.unwrap();
+                    len += 1;
+                }
+                pending = None;
+                active_group = None;
+                let _ =
+                    rsk_ui::render_rename_field(&mut self.panel, val(&buf, len).as_str(), pending);
+                if prev_active != active_group {
+                    let _ = rsk_ui::render_rename_keys(&mut self.panel, active_group);
+                    prev_active = active_group;
+                }
+                self.shown = None;
+            }
+
             if let Some(p) = self.touch.read() {
                 last = Instant::now();
                 if rsk_ui::hit_title_back(p) {
-                    return None; // cancel — no change persisted
+                    return None;
                 }
                 if let Some(k) = rsk_ui::hit_rename(p) {
                     match k {
-                        rsk_ui::RenameKey::Up => cand = (cand + 1) % charset.len(),
-                        rsk_ui::RenameKey::Down => {
-                            cand = (cand + charset.len() - 1) % charset.len()
+                        rsk_ui::RenameKey::Char(gi) => {
+                            let group = groups[gi];
+                            if active_group == Some(gi) {
+                                cycle_at = (cycle_at + 1) % group.len();
+                            } else {
+                                if let Some(ch) = pending {
+                                    if len < buf.len() {
+                                        buf[len] = ch;
+                                        len += 1;
+                                    }
+                                }
+                                active_group = Some(gi);
+                                cycle_at = 0;
+                            }
+                            pending = Some(group[cycle_at]);
+                            last_t9_press = Instant::now();
                         }
-                        rsk_ui::RenameKey::Insert => {
-                            if len < buf.len() {
-                                buf[len] = charset[cand];
-                                len += 1;
+                        rsk_ui::RenameKey::Backspace => {
+                            if pending.is_some() {
+                                pending = None;
+                                active_group = None;
+                            } else {
+                                len = len.saturating_sub(1);
                             }
                         }
-                        rsk_ui::RenameKey::Backspace => len = len.saturating_sub(1),
                         rsk_ui::RenameKey::Save => {
+                            if let Some(ch) = pending {
+                                if len < buf.len() {
+                                    buf[len] = ch;
+                                    len += 1;
+                                }
+                            }
                             let committed = val(&buf, len);
                             let dev = self.keys.device();
                             let saved = rsk_fido::passkeys::set_rp_nickname(
@@ -78,32 +128,25 @@ impl Ui {
                                 hash,
                                 committed.as_str(),
                             );
-                            // Only report the new title if it actually persisted — on a
-                            // failed store (no seed / full flash / RP vanished) keep the
-                            // prior title so the screen never claims an unsaved rename.
                             return saved.then_some(committed);
                         }
                     }
-                    let _ = rsk_ui::render_rename(
+                    // Partial updates: field always, keys only if active group changed.
+                    let _ = rsk_ui::render_rename_field(
                         &mut self.panel,
                         val(&buf, len).as_str(),
-                        charset[cand],
+                        pending,
                     );
+                    if prev_active != active_group {
+                        let _ = rsk_ui::render_rename_keys(&mut self.panel, active_group);
+                        prev_active = active_group;
+                    }
                     self.shown = None;
-                    // A fresh frame draws the caret on — restart the blink from there.
-                    caret_on = true;
-                    blink_at = Instant::now();
                     self.touch.wait_release(last, idle_limit);
                     last = Instant::now();
                     continue;
                 }
                 self.touch.wait_release(last, idle_limit);
-            }
-            if blink_at.elapsed() >= Duration::from_millis(CARET_BLINK_MS) {
-                caret_on = !caret_on;
-                let v = val(&buf, len);
-                let _ = rsk_ui::render_rename_caret(&mut self.panel, v.as_str(), caret_on);
-                blink_at = Instant::now();
             }
             if crate::worker::host_request_pending() || last.elapsed() >= idle_limit {
                 return None;

--- a/firmware/src/display/pin.rs
+++ b/firmware/src/display/pin.rs
@@ -261,7 +261,7 @@ impl Ui {
     ) -> rsk_fido::PinEntry {
         let saved = led::status();
         led::set_status(led::STATUS_TOUCH);
-        CANCEL_REQUESTED.store(false, Ordering::Release);
+        CANCEL_REQUESTED.store(false, Ordering::Relaxed);
         UP_PENDING.store(true, Ordering::Release);
 
         let start = Instant::now();
@@ -367,7 +367,7 @@ impl Ui {
         };
 
         UP_PENDING.store(false, Ordering::Release);
-        CANCEL_REQUESTED.store(false, Ordering::Release);
+        CANCEL_REQUESTED.store(false, Ordering::Relaxed);
         AMBIENT_QUIET_UNTIL_MS.store(
             (Instant::now().as_millis() as u32).wrapping_add(AMBIENT_QUIET_MS),
             Ordering::Relaxed,

--- a/firmware/src/display/pin.rs
+++ b/firmware/src/display/pin.rs
@@ -11,9 +11,6 @@ use super::*;
 /// default PIN `123456` is six). The applet stores up to eight; `rsk_piv::pad_pin` pads the
 /// rest to the 8-byte `0xFF` wire form so a host VERIFY (which always pads) matches.
 const PIV_PIN_MIN: usize = 6;
-/// Rename caret blink half-period (unused with T9 — pending char replaces caret blink).
-#[allow(dead_code)]
-const CARET_BLINK_MS: u64 = 500;
 
 impl Ui {
     /// The rename screen: edit a relying party's device-local nickname with a T9

--- a/firmware/src/display/pin.rs
+++ b/firmware/src/display/pin.rs
@@ -218,8 +218,8 @@ impl Ui {
     ) -> rsk_fido::PinEntry {
         let saved = led::status();
         led::set_status(led::STATUS_TOUCH);
-        CANCEL_REQUESTED.store(false, Ordering::Relaxed);
-        UP_PENDING.store(true, Ordering::Relaxed);
+        CANCEL_REQUESTED.store(false, Ordering::Release);
+        UP_PENDING.store(true, Ordering::Release);
 
         let start = Instant::now();
         let timeout = Duration::from_millis(PRESENCE_TIMEOUT_MS.load(Ordering::Relaxed) as u64);
@@ -308,7 +308,7 @@ impl Ui {
                 reveal = false;
                 let _ = rsk_ui::render_pin_dots(&mut self.panel, entered, expected, None);
             }
-            if CANCEL_REQUESTED.load(Ordering::Relaxed) {
+            if CANCEL_REQUESTED.load(Ordering::Acquire) {
                 break rsk_fido::PinEntry::Cancelled;
             }
             // A local gate must not starve the parked worker: abandon the moment a host
@@ -323,8 +323,8 @@ impl Ui {
             block_for(Duration::from_millis(TOUCH_POLL_MS));
         };
 
-        UP_PENDING.store(false, Ordering::Relaxed);
-        CANCEL_REQUESTED.store(false, Ordering::Relaxed);
+        UP_PENDING.store(false, Ordering::Release);
+        CANCEL_REQUESTED.store(false, Ordering::Release);
         AMBIENT_QUIET_UNTIL_MS.store(
             (Instant::now().as_millis() as u32).wrapping_add(AMBIENT_QUIET_MS),
             Ordering::Relaxed,

--- a/firmware/src/display/pin.rs
+++ b/firmware/src/display/pin.rs
@@ -93,11 +93,11 @@ impl Ui {
                             if active_group == Some(gi) {
                                 cycle_at = (cycle_at + 1) % group.len();
                             } else {
-                                if let Some(ch) = pending {
-                                    if len < buf.len() {
-                                        buf[len] = ch;
-                                        len += 1;
-                                    }
+                                if let Some(ch) = pending
+                                    && len < buf.len()
+                                {
+                                    buf[len] = ch;
+                                    len += 1;
                                 }
                                 active_group = Some(gi);
                                 cycle_at = 0;
@@ -114,11 +114,11 @@ impl Ui {
                             }
                         }
                         rsk_ui::RenameKey::Save => {
-                            if let Some(ch) = pending {
-                                if len < buf.len() {
-                                    buf[len] = ch;
-                                    len += 1;
-                                }
+                            if let Some(ch) = pending
+                                && len < buf.len()
+                            {
+                                buf[len] = ch;
+                                len += 1;
                             }
                             let committed = val(&buf, len);
                             let dev = self.keys.device();

--- a/firmware/src/display/presence.rs
+++ b/firmware/src/display/presence.rs
@@ -28,7 +28,7 @@ enum Outcome {
 fn ceremony_begin() -> u8 {
     let saved = led::status();
     led::set_status(led::STATUS_TOUCH);
-    CANCEL_REQUESTED.store(false, Ordering::Release);
+    CANCEL_REQUESTED.store(false, Ordering::Relaxed);
     UP_PENDING.store(true, Ordering::Release);
     saved
 }
@@ -38,7 +38,7 @@ fn ceremony_begin() -> u8 {
 /// activity so a long ceremony doesn't immediately sleep, and restore the LED.
 fn ceremony_end(saved_led: u8) {
     UP_PENDING.store(false, Ordering::Release);
-    CANCEL_REQUESTED.store(false, Ordering::Release);
+    CANCEL_REQUESTED.store(false, Ordering::Relaxed);
     AMBIENT_QUIET_UNTIL_MS.store(
         (Instant::now().as_millis() as u32).wrapping_add(AMBIENT_QUIET_MS),
         Ordering::Relaxed,

--- a/firmware/src/display/presence.rs
+++ b/firmware/src/display/presence.rs
@@ -28,8 +28,8 @@ enum Outcome {
 fn ceremony_begin() -> u8 {
     let saved = led::status();
     led::set_status(led::STATUS_TOUCH);
-    CANCEL_REQUESTED.store(false, Ordering::Relaxed);
-    UP_PENDING.store(true, Ordering::Relaxed);
+    CANCEL_REQUESTED.store(false, Ordering::Release);
+    UP_PENDING.store(true, Ordering::Release);
     saved
 }
 
@@ -37,8 +37,8 @@ fn ceremony_begin() -> u8 {
 /// (so a hand-off to a following modal — pad, approve hold — doesn't flash idle), note
 /// activity so a long ceremony doesn't immediately sleep, and restore the LED.
 fn ceremony_end(saved_led: u8) {
-    UP_PENDING.store(false, Ordering::Relaxed);
-    CANCEL_REQUESTED.store(false, Ordering::Relaxed);
+    UP_PENDING.store(false, Ordering::Release);
+    CANCEL_REQUESTED.store(false, Ordering::Release);
     AMBIENT_QUIET_UNTIL_MS.store(
         (Instant::now().as_millis() as u32).wrapping_add(AMBIENT_QUIET_MS),
         Ordering::Relaxed,
@@ -130,7 +130,7 @@ impl TouchPresence {
                         }
                     }
                 }
-                if CANCEL_REQUESTED.load(Ordering::Relaxed) {
+                if CANCEL_REQUESTED.load(Ordering::Acquire) {
                     break Outcome::Cancelled;
                 }
                 if start.elapsed() >= timeout {
@@ -180,7 +180,7 @@ impl TouchPresence {
                     Some(Button::Deny) => break Outcome::Declined,
                     None => {}
                 }
-                if CANCEL_REQUESTED.load(Ordering::Relaxed) {
+                if CANCEL_REQUESTED.load(Ordering::Acquire) {
                     break Outcome::Cancelled;
                 }
                 block_for(Duration::from_millis(TOUCH_POLL_MS));

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -84,7 +84,7 @@ use embedded_alloc::LlffHeap as Heap;
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
-const HEAP_SIZE: usize = 128 * 1024;
+const HEAP_SIZE: usize = 64 * 1024;
 
 #[unsafe(link_section = ".start_block")]
 #[used]
@@ -213,6 +213,30 @@ const _: () = assert!(
     !BUILD_WAKE_ENABLED || BUILD_WAKE_PIN < 10 || BUILD_WAKE_PIN > 18,
     "WAKE_PIN collides with an LCD/touch GPIO (10..=18) owned by the display build"
 );
+// Display GPIOs — defaults for the Waveshare RP2350-Touch-LCD-2.8.
+// Override via BOARD=<name> or individual PK_DISPLAY_* env vars.
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_SPI_FREQ_HZ: u32 = env_u32(env!("PK_DISPLAY_SPI_FREQ_HZ"));
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_CS: u8 = env_u16(env!("PK_DISPLAY_CS")) as u8;
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_DC: u8 = env_u16(env!("PK_DISPLAY_DC")) as u8;
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_RST: u8 = env_u16(env!("PK_DISPLAY_RST")) as u8;
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_BL_PIN: u8 = env_u16(env!("PK_DISPLAY_BL_PIN")) as u8;
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_BL_PWM_SLICE: u8 = env_u16(env!("PK_DISPLAY_BL_PWM_SLICE")) as u8;
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_BL_PWM_CHANNEL: u8 = env_u16(env!("PK_DISPLAY_BL_PWM_CHANNEL")) as u8;
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_TP_RST: u8 = env_u16(env!("PK_DISPLAY_TP_RST")) as u8;
+#[cfg(feature = "display")]
+const BUILD_DISPLAY_I2C_FREQ_HZ: u32 = env_u32(env!("PK_DISPLAY_I2C_FREQ_HZ"));
+#[cfg(feature = "display")]
+pub(crate) const BUILD_DISPLAY_INVERT_COLORS: bool = env_u16(env!("PK_DISPLAY_INVERT_COLORS")) != 0;
+#[cfg(feature = "display")]
+pub(crate) const BUILD_DISPLAY_COLOR_ORDER: u8 = env_u16(env!("PK_DISPLAY_COLOR_ORDER")) as u8;
 
 // Optional nuisance user/status LED to hold OFF at boot (`USR_LED_PIN`): a plain
 // GPIO some boards wire to an onboard LED that lights by default (the Seeed XIAO
@@ -280,11 +304,19 @@ static LED_PWR: StaticCell<embassy_rp::gpio::Output<'static>> = StaticCell::new(
 // Holds the USR-LED-off `Output` for the device's lifetime; dropping it would
 // release the pad and let a pulled nuisance LED light again (see the boot block).
 static USR_LED: StaticCell<embassy_rp::gpio::Output<'static>> = StaticCell::new();
+// SAFETY INVARIANT: `FS`, `FLASH_CELL`, `RNG_CELL`, `PRESENCE`, and `RESCUE_PLATFORM`
+// live behind `RefCell` and are ONLY ever accessed from the thread executor (the
+// worker and its synchronous applet dispatch). The interrupt executor (USB tasks)
+// never touches them — cross-executor data uses `embassy_sync::Mutex` (see
+// `EXCHANGE` in worker.rs). Within the thread executor, `borrow_mut()` never spans
+// an `.await`: flash ops resolve immediately via `block_on`, and all dispatch is
+// synchronous. Clippy's `await_holding_refcell_ref` lint catches regressions.
 static FS: StaticCell<RefCell<Store>> = StaticCell::new();
 static FLASH_CELL: StaticCell<RefCell<flash_storage::AsyncFlash>> = StaticCell::new();
 static RNG_CELL: StaticCell<RefCell<FidoRng>> = StaticCell::new();
 static PRESENCE: StaticCell<RefCell<presence::Presence>> = StaticCell::new();
 static RESCUE_PLATFORM: StaticCell<RefCell<rescue_platform::RescuePlatform>> = StaticCell::new();
+// Same RefCell invariant as FS/RNG above — thread-executor only.
 // Sized for a 32-byte phy product plus the appended YubiKey interface-token
 // suffix (`normalize_usb_product`), so a masquerade name is never truncated.
 static PHY_PRODUCT: StaticCell<[u8; 64]> = StaticCell::new();
@@ -298,7 +330,9 @@ const DISPLAY_BUF_LEN: usize = 4096;
 #[cfg(feature = "display")]
 static DISPLAY_BUF: StaticCell<[u8; DISPLAY_BUF_LEN]> = StaticCell::new();
 /// The trusted-display panel + touch, shared by `status_task` (ambient status) and
-/// the `TouchPresence` backend (the confirm prompt) on the thread executor.
+/// the `TouchPresence` backend (the confirm prompt). Both run on the THREAD executor;
+/// `TouchPresence::request` is synchronous, so they never race. Same RefCell
+/// invariant as FS/RNG above — borrows never span `.await`.
 #[cfg(feature = "display")]
 static UI: StaticCell<RefCell<display::Ui>> = StaticCell::new();
 
@@ -827,39 +861,68 @@ async fn main(spawner: Spawner) {
         // The ST7789 tops out at 62.5 MHz; running there (vs the 40 MHz bringup value)
         // cuts a full-frame repaint ~35% for snappier screen transitions. If the panel's
         // flex cable ever shows tearing/garbling, drop back toward 40 MHz.
-        spi_cfg.frequency = 62_500_000;
+        spi_cfg.frequency = BUILD_DISPLAY_SPI_FREQ_HZ;
         let spi = Spi::new_blocking(p.SPI1, p.PIN_10, p.PIN_11, p.PIN_12, spi_cfg);
 
         let mut i2c_cfg = I2cConfig::default();
-        i2c_cfg.frequency = 400_000;
+        i2c_cfg.frequency = BUILD_DISPLAY_I2C_FREQ_HZ;
         let i2c = I2c::new_blocking(p.I2C1, p.PIN_7, p.PIN_6, i2c_cfg);
 
-        let cs = Output::new(p.PIN_13, Level::High);
-        let dc = Output::new(p.PIN_14, Level::Low);
-        let rst = Output::new(p.PIN_15, Level::High);
+        let cs = Output::new(
+            unsafe { embassy_rp::gpio::AnyPin::steal(BUILD_DISPLAY_CS) },
+            Level::High,
+        );
+        let dc = Output::new(
+            unsafe { embassy_rp::gpio::AnyPin::steal(BUILD_DISPLAY_DC) },
+            Level::Low,
+        );
+        let rst = Output::new(
+            unsafe { embassy_rp::gpio::AnyPin::steal(BUILD_DISPLAY_RST) },
+            Level::High,
+        );
         // Display-sleep wake button (default the BAT_PWR / KEY_BAT button on GPIO25).
         // Active-low with an internal pull-up by default (`WAKE_ACTIVE_HIGH` flips it);
         // `WAKE_PIN=none` leaves it unwired so only a touch wakes. Stealing the pin is
         // sound: it is never handed to another driver, and a compile-time assert rejects
         // a `WAKE_PIN` in the LCD/touch range.
         let wake_btn = if BUILD_WAKE_ENABLED {
-            use embassy_rp::gpio::{AnyPin, Input, Pull};
+            use embassy_rp::gpio::{Input, Pull};
             let pull = if BUILD_WAKE_ACTIVE_HIGH {
                 Pull::Down
             } else {
                 Pull::Up
             };
             Some((
-                Input::new(unsafe { AnyPin::steal(BUILD_WAKE_PIN) }, pull),
+                Input::new(
+                    unsafe { embassy_rp::gpio::AnyPin::steal(BUILD_WAKE_PIN) },
+                    pull,
+                ),
                 BUILD_WAKE_ACTIVE_HIGH,
             ))
         } else {
             None
         };
-        // Backlight on GPIO16 as PWM (slice 0, channel A) at zero duty — dark until
-        // `Ui::build` raises it to full after the first render (no white flash).
-        let bl = Pwm::new_output_a(p.PWM_SLICE0, p.PIN_16, display::backlight_cfg(0));
-        let tp_rst = Output::new(p.PIN_17, Level::High);
+        // Backlight PWM — pin, slice, and channel from the board config.
+        let bl = {
+            let cfg = display::backlight_cfg(0);
+            match (
+                BUILD_DISPLAY_BL_PIN,
+                BUILD_DISPLAY_BL_PWM_SLICE,
+                BUILD_DISPLAY_BL_PWM_CHANNEL,
+            ) {
+                (16, 0, 0) => Pwm::new_output_a(p.PWM_SLICE0, p.PIN_16, cfg),
+                (17, 0, 1) => Pwm::new_output_b(p.PWM_SLICE0, p.PIN_17, cfg),
+                (18, 1, 0) => Pwm::new_output_a(p.PWM_SLICE1, p.PIN_18, cfg),
+                (19, 1, 1) => Pwm::new_output_b(p.PWM_SLICE1, p.PIN_19, cfg),
+                (20, 2, 0) => Pwm::new_output_a(p.PWM_SLICE2, p.PIN_20, cfg),
+                (21, 2, 1) => Pwm::new_output_b(p.PWM_SLICE2, p.PIN_21, cfg),
+                _ => panic!("unsupported backlight PWM config"),
+            }
+        };
+        let tp_rst = Output::new(
+            unsafe { embassy_rp::gpio::AnyPin::steal(BUILD_DISPLAY_TP_RST) },
+            Level::High,
+        );
 
         let buf = DISPLAY_BUF.init([0u8; DISPLAY_BUF_LEN]);
         let panel = display::PanelHw {

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -543,7 +543,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0858;
+    let device_release: u16 = 0x0859;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -84,7 +84,7 @@ use embedded_alloc::LlffHeap as Heap;
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
-const HEAP_SIZE: usize = 64 * 1024;
+const HEAP_SIZE: usize = 128 * 1024;
 
 #[unsafe(link_section = ".start_block")]
 #[used]
@@ -237,6 +237,102 @@ const BUILD_DISPLAY_I2C_FREQ_HZ: u32 = env_u32(env!("PK_DISPLAY_I2C_FREQ_HZ"));
 pub(crate) const BUILD_DISPLAY_INVERT_COLORS: bool = env_u16(env!("PK_DISPLAY_INVERT_COLORS")) != 0;
 #[cfg(feature = "display")]
 pub(crate) const BUILD_DISPLAY_COLOR_ORDER: u8 = env_u16(env!("PK_DISPLAY_COLOR_ORDER")) as u8;
+
+// Display control GPIOs are board-configurable and claimed via AnyPin::steal
+// (CS/DC/RST/TP_RST) or Pwm::new_output_* (BL); SPI1 10/11/12 + I2C1 6/7 stay in
+// Peripherals. Reject a pad owned by two drivers at compile time (no runtime guard).
+#[cfg(feature = "display")]
+const _: () = {
+    const DISPLAY_CTLS: &[u8] = &[
+        BUILD_DISPLAY_CS,
+        BUILD_DISPLAY_DC,
+        BUILD_DISPLAY_RST,
+        BUILD_DISPLAY_TP_RST,
+        BUILD_DISPLAY_BL_PIN,
+    ];
+    // Pins the panel's hard-wired SPI1 (10/11/12) and I2C1 (6/7) already own.
+    const HW_PINS: &[u8] = &[10, 11, 12, 6, 7];
+
+    const fn contains(hay: &[u8], needle: u8) -> bool {
+        let mut i = 0;
+        while i < hay.len() {
+            if hay[i] == needle {
+                return true;
+            }
+            i += 1;
+        }
+        false
+    }
+
+    let mut i = 0;
+    while i < DISPLAY_CTLS.len() {
+        let mut j = i + 1;
+        while j < DISPLAY_CTLS.len() {
+            assert!(DISPLAY_CTLS[i] != DISPLAY_CTLS[j], "duplicate panel GPIO");
+            j += 1;
+        }
+        i += 1;
+    }
+
+    let mut i = 0;
+    while i < DISPLAY_CTLS.len() {
+        assert!(
+            !contains(HW_PINS, DISPLAY_CTLS[i]),
+            "panel control GPIO overlaps hard-wired SPI1/I2C1 pin 6/7/10/11/12"
+        );
+        i += 1;
+    }
+
+    if BUILD_WAKE_ENABLED {
+        let mut i = 0;
+        while i < DISPLAY_CTLS.len() {
+            assert!(
+                DISPLAY_CTLS[i] != BUILD_WAKE_PIN,
+                "panel control GPIO overlaps WAKE_PIN"
+            );
+            i += 1;
+        }
+    }
+
+    #[cfg(not(led_kind = "none"))]
+    {
+        let mut i = 0;
+        while i < DISPLAY_CTLS.len() {
+            assert!(
+                DISPLAY_CTLS[i] != BUILD_LED_PIN,
+                "panel control GPIO overlaps LED_PIN"
+            );
+            i += 1;
+        }
+        if BUILD_LED_POWER_ENABLED {
+            let mut i = 0;
+            while i < DISPLAY_CTLS.len() {
+                assert!(
+                    DISPLAY_CTLS[i] != BUILD_LED_POWER_PIN,
+                    "panel control GPIO overlaps LED_POWER_PIN"
+                );
+                i += 1;
+            }
+        }
+    }
+};
+
+// Backlight PWM: the only valid (pin, slice, channel) combos on the RP2350.
+// Build.rs bakes the values; catch an unsupported combo at compile time so the
+// runtime `_ => unreachable!(...)` arm below is reachable only on a typo'd build.
+#[cfg(feature = "display")]
+const _: () = assert!(
+    matches!(
+        (
+            BUILD_DISPLAY_BL_PIN,
+            BUILD_DISPLAY_BL_PWM_SLICE,
+            BUILD_DISPLAY_BL_PWM_CHANNEL
+        ),
+        (16, 0, 0) | (17, 0, 1) | (18, 1, 0) | (19, 1, 1) | (20, 2, 0) | (21, 2, 1)
+    ),
+    "unsupported backlight PWM config (BL_PIN, SLICE, CHANNEL) — \
+     see the Pwm::new_output_* match in main.rs for the supported set"
+);
 
 // Optional nuisance user/status LED to hold OFF at boot (`USR_LED_PIN`): a plain
 // GPIO some boards wire to an onboard LED that lights by default (the Seeed XIAO
@@ -546,7 +642,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x085B;
+    let device_release: u16 = 0x085C;
     config.device_release = device_release;
 
     let mut builder = Builder::new(
@@ -928,7 +1024,11 @@ async fn main(spawner: Spawner) {
                 (19, 1, 1) => Pwm::new_output_b(p.PWM_SLICE1, p.PIN_19, cfg),
                 (20, 2, 0) => Pwm::new_output_a(p.PWM_SLICE2, p.PIN_20, cfg),
                 (21, 2, 1) => Pwm::new_output_b(p.PWM_SLICE2, p.PIN_21, cfg),
-                _ => panic!("unsupported backlight PWM config"),
+                _ => {
+                    // Guarded by the const assert below — unreachable at runtime,
+                    // kept so the match stays exhaustive over (pin, slice, channel).
+                    unreachable!("unsupported backlight PWM config")
+                }
             }
         };
         let tp_rst = Output::new(

--- a/firmware/src/presence.rs
+++ b/firmware/src/presence.rs
@@ -42,14 +42,14 @@ pub(crate) static CANCEL_REQUESTED: AtomicBool = AtomicBool::new(false);
 /// The CTAPHID keepalive hook passed to `CtapHid::new`: is a touch being awaited?
 /// Always `false` on the `no-touch` build, so the status stays `PROCESSING`.
 pub fn up_pending() -> bool {
-    UP_PENDING.load(Ordering::Relaxed)
+    UP_PENDING.load(Ordering::Acquire)
 }
 
 /// The CTAPHID cancel hook passed to `CtapHid::new`: request that an in-flight
 /// touch wait be abandoned. Just sets the flag the wait polls (a no-op on the
 /// no-button build, where `request` confirms instantly and never waits).
 pub fn request_cancel() {
-    CANCEL_REQUESTED.store(true, Ordering::Relaxed);
+    CANCEL_REQUESTED.store(true, Ordering::Release);
 }
 
 /// Built-in touch-wait timeout (ms) used when the phy record carries none.
@@ -194,7 +194,7 @@ impl ButtonPresence {
         // Drop any cancel left from an earlier (already-finished) request so this
         // wait starts clean.
         CANCEL_REQUESTED.store(false, Ordering::Relaxed);
-        UP_PENDING.store(true, Ordering::Relaxed);
+        UP_PENDING.store(true, Ordering::Release);
         let start = Instant::now();
         let timeout = Duration::from_millis(PRESENCE_TIMEOUT_MS.load(Ordering::Relaxed) as u64);
         // Wait for a press; a CTAPHID_CANCEL aborts it, and with neither before
@@ -209,7 +209,7 @@ impl ButtonPresence {
             } else {
                 self.spent = false;
             }
-            if CANCEL_REQUESTED.load(Ordering::Relaxed) {
+            if CANCEL_REQUESTED.load(Ordering::Acquire) {
                 break Outcome::Cancelled;
             }
             if start.elapsed() >= timeout {
@@ -231,7 +231,7 @@ impl ButtonPresence {
         // The debounce is bounded, so it can give up with the finger still down;
         // whatever the outcome, a button that never released carries no new consent.
         self.spent = self.pressed();
-        UP_PENDING.store(false, Ordering::Relaxed);
+        UP_PENDING.store(false, Ordering::Release);
         // Clear any cancel that raced in (e.g. just after a confirm) so it can't
         // leak into the next request's wait.
         CANCEL_REQUESTED.store(false, Ordering::Relaxed);

--- a/firmware/src/usb_attach.rs
+++ b/firmware/src/usb_attach.rs
@@ -28,7 +28,7 @@ static ATTACH_MS: AtomicU32 = AtomicU32::new(0);
 
 /// Stamp the origin. Call once, immediately before the USB pull-up is asserted.
 pub fn mark() {
-    ATTACH_MS.store(Instant::now().as_millis() as u32, Ordering::Relaxed);
+    ATTACH_MS.store(Instant::now().as_millis() as u32, Ordering::Release);
 }
 
 /// Milliseconds since the attach — the clock the FIDO layer gets as `Ctx::now_ms`,
@@ -36,5 +36,5 @@ pub fn mark() {
 pub fn elapsed_ms() -> u64 {
     Instant::now()
         .as_millis()
-        .saturating_sub(ATTACH_MS.load(Ordering::Relaxed) as u64)
+        .saturating_sub(ATTACH_MS.load(Ordering::Acquire) as u64)
 }

--- a/firmware/src/worker.rs
+++ b/firmware/src/worker.rs
@@ -198,7 +198,7 @@ impl MsgHandler for ClientCtap {
         roundtrip(Kind::Msg, data, out).await
     }
     fn reset_app_selection(&mut self) {
-        MSG_DESELECT.store(true, core::sync::atomic::Ordering::Relaxed);
+        MSG_DESELECT.store(true, core::sync::atomic::Ordering::Release);
     }
     async fn handle_vendor(&mut self, cmd: u8, data: &[u8], out: &mut [u8]) -> Option<usize> {
         roundtrip_vendor(cmd, data, out).await
@@ -415,7 +415,7 @@ impl<'a> Worker<'a> {
                     Kind::Msg => {
                         // A CTAPHID_INIT since the last MSG drops the applet
                         // selection so U2F isn't hijacked by a sticky vendor SELECT.
-                        if MSG_DESELECT.swap(false, core::sync::atomic::Ordering::Relaxed) {
+                        if MSG_DESELECT.swap(false, core::sync::atomic::Ordering::AcqRel) {
                             self.ctap.deselect_msg();
                         }
                         self.ctap.handle_msg(&req[..*req_len])


### PR DESCRIPTION
## What

Redesign of the trusted-display UI for the `--features display` build on Waveshare RP2350-Touch-LCD-2.8 (ST7789 240×320).

### Board configuration system
`firmware/boards/*.toml` — pin mappings, SPI/I2C freqs, display inversion, backlight channel per board. Selected via `BOARD=<name>` env var at build time. Ships with configs for **Waveshare RP2350-Touch-LCD-2.8** and **Pimoroni Pico Plus 2 (no display)**.

### Anti-aliased circles
New `crates/rsk-ui/src/aa.rs` — integer fixed-point AA (3 px band, linear alpha). Replaces `embedded_graphics::Circle` on boot/reset icons and filled PIN dots.

### Component system
New `crates/rsk-ui/src/render/components/` with reusable widgets: `card`, `card_title`, `card_row`, `rect_card`, `rect_row`, `list::group_card`, `list::row`. All list screens (Passkeys, Audit, Applets, Settings) migrated.

### Layout unification
`CONTENT_GAP = 10` px between title bar and content. `NAV_H` 38→36, `LIST_ROW_GAP` 3→2.

### T9 keypad replaces character wheel
3×4 phone-style keypad for rename: 10 char-group keys (1–9 + 0/space), repeated press cycles through group, different key or 800 ms timeout commits. Partial repaints — no full-screen flicker.

### Dead code removed
`render_row()`, `row_body_side()`, `RENAME_CHARSET`, `render_rename_caret()`, `wheel_arrow()`, old rename rects, `components/layout.rs`, `Triangle` import.

## Checklist

- [x] Device behavior changed → `bcdDevice`: `0x0858` → `0x085B`
- [x] No new `unsafe`
- [x] All new files carry SPDX header
- [x] Commits use zone prefix style (`ui:`, `firmware:`, `feat:`)