### PR TITLE
fix(rsk): send PIN auth in `rsk backup finalize` when a PIN is set

### DIFF
--- a/tools/rsk/backup.py
+++ b/tools/rsk/backup.py
@@ -72,7 +72,7 @@ def register(sub):
     r.add_argument("--mnemonic", help="BIP-39 phrase (else read from stdin)")
     r.set_defaults(func=cmd_restore)
     f = g.add_parser("finalize", help="seal the one-time export window")
-    f.add_argument("--pin", help="(accepted for symmetry; finalize needs only touch)")
+    f.add_argument("--pin", help="FIDO2 PIN (needed when the device has a PIN set)")
     f.set_defaults(func=cmd_finalize)
     g.add_parser("status", help="print {sealed, has_seed}").set_defaults(func=cmd_status)
 
@@ -253,8 +253,9 @@ def cmd_restore(args):
 
 def cmd_finalize(args):
     dev, cid = connect_fido()
+    pin = resolve_pin(args, has_pin=device_has_pin(dev, cid))
     print("touch the device (BOOTSEL) to seal the export window…", file=sys.stderr)
-    st, _ = _vendor(dev, cid, {1: FINALIZE})
+    st, _ = _vendor(dev, cid, _gated(FINALIZE, None, dev, cid, pin))
     if st != 0:
         die(f"finalize failed: {st:#x}")
     print("export window sealed ✓ (a factory reset reopens it)")


### PR DESCRIPTION
`cmd_finalize` sent `{1: FINALIZE}` without a pinUvAuthToken, so the firmware's `pin_gate` returned `CTAP2_ERR_PUAT_REQUIRED` (0x36) on any device with `clientPin` enabled. Use `_gated()` like `cmd_export` already does to include the PIN auth token.

Fixes #59

## What

rsk backup finalize failed with CTAP2_ERR_PUAT_REQUIRED (0x36) on any device
that has a FIDO2 PIN set — the host tool sent the finalize subcommand without
a pinUvAuthParam, but the firmware's pin_gate() requires one when clientPin
is enabled. Updated cmd_finalize to resolve the PIN and use _gated() (matching
the pattern already used by cmd_export), which obtains a pinUvAuthToken with
acfg permission and includes it in the request.

fixes issue #59 

## How it was tested

<!-- Keep what applies, delete the rest. -->

- [x] `nix develop -c ./scripts/check.sh` passes locally
- [x]  On hardware: board = Waveshare RP2350-One, exercised = rsk backup finalize --pin <PIN>
    Before fix: error: finalize failed: 0x36 (PuatRequired)
    After fix: touch the device (BOOTSEL) to seal the export window… → accepted with correct PIN
- [x] Host-only change (CLI / docs / CI) — no device behavior touched

## Checklist

<!-- Tick what applies; "N/A" is fine — most host-only PRs leave the firmware lines blank. -->

- [ ] Device behavior / image changed → `config.device_release` (bcdDevice) bumped by one (hex)
      in `firmware/src/main.rs` — host-only (CLI / docs / CI / build) does not (CONTRIBUTING.md)
- [ ] Fixes something a downgrade would reopen → flag whether the next release should advance the
      rollback **epoch** (`docs/production.md`, stage 3) — a seal-time `--rollback` call, not a code bump
- [ ] New or changed `unsafe` → justified in `docs/unsafe.md`
- [x] User-visible behavior → the matching guide under `docs/` updated
- [x] New files carry the SPDX header (`AGPL-3.0-only`)
- [x] Commit messages use the zone prefix style (`fido:`, `piv:`, `rsk:`, `docs:`, …)
