### PR TITLE
docs: say what RS-Key is before saying how it's built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Changed
+
+- **The README and the docs landing page say what RS-Key is before they say how
+  it works.** Both now open with one line ("an open-source hardware passkey"),
+  a three-row what-this-is / what-you-need / what-you-get table, and a figure
+  ([`docs/images/what-it-is.svg`](docs/images/what-it-is.svg)): board, plus this
+  firmware, equals passkey logins, `ssh` and `git` signing, an OpenPGP card, PIV
+  and TOTP. A first-time reader could previously not tell whether the project
+  was a device for sale, a mod for an existing key, or firmware. The board photo
+  that made it read as a shop moves down to Hardware, and the CI badges move to
+  Development setup.
+- **The quick start starts from a released `.uf2`, not from a toolchain.**
+  Downloading `rs-key-<version>-default.uf2` and dropping it on the board is the
+  documented path in both `README.md` and [quickstart.md](docs/quickstart.md);
+  building it yourself is the alternative behind a fold. The README gained a
+  four-row "which image for my board" table pointing at
+  [releases.md](docs/releases.md).
+
 ## [0.4.5] - 2026-08-03
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -4,23 +4,17 @@
 [![deep-checks](https://github.com/TheMaxMur/RS-Key/actions/workflows/deep-checks.yml/badge.svg)](https://github.com/TheMaxMur/RS-Key/actions/workflows/deep-checks.yml)
 [![docs](https://github.com/TheMaxMur/RS-Key/actions/workflows/pages.yml/badge.svg)](https://themaxmur.github.io/RS-Key/)
 
-<table align="center">
-  <tr>
-    <td align="center" valign="top"><img src="assets/hero-boards.jpg" height="440" alt="Three RS-Key boards on a blueprint background: a bare RP2350 USB stick, the trusted-display variant showing its Home &quot;Ready&quot; screen (USB connected, Device PIN set, 2 passkeys), and a Waveshare RP2350-One"></td>
-    <td align="center" valign="top"><img src="assets/webauthn-demo.gif" height="440" alt="Registering a passkey on webauthn.io with the trusted-display build: the device screen shows a Device PIN pad, then an Approve / Save-passkey prompt, and the browser confirms you are logged in — the PIN and the approval both happen on the device's own screen"></td>
-  </tr>
-  <tr>
-    <td align="center"><sub>Three boards, one firmware — stick · trusted display · RP2350-One</sub></td>
-    <td align="center"><sub>Registering a passkey — the PIN &amp; Approve/Deny happen on the device's own screen</sub></td>
-  </tr>
-</table>
+**An open-source hardware passkey.** Flash one file onto a Raspberry Pi
+**RP2350** board and it becomes a USB security key: passkey logins in the
+browser, `ssh` and `git` signing, GPG, PIV, and TOTP codes.
 
-RS-Key (RSK, *Raspberry Security Key* — also a nod to its being written in Rust)
-is open-source security-key firmware for the Raspberry Pi **RP2350**. It makes an
-RP2350 board behave like a USB authenticator and ships the host tooling to drive
-it. It is written in Rust (`no_std`, [embassy](https://embassy.dev)) and is meant
-for development, research, and controlled experiments — **not** as a drop-in
-replacement for an audited commercial key.
+| | |
+|---|---|
+| **What this is** | Firmware. A `.uf2` file you drop onto a board. Nothing here is for sale. |
+| **What you need** | Any RP2350 board (from about $5) and a USB cable. No soldering, no programmer, no toolchain. |
+| **What you get** | A USB authenticator your browser, `ssh`, `gpg` and `ykman` already know how to talk to. |
+
+![What RS-Key is: any RP2350 board, plus this firmware, gives you passkey and WebAuthn logins, ssh and git signing, an OpenPGP card for gpg, a PIV smart card, and TOTP codes](docs/images/what-it-is.svg)
 
 > **This project is experimental.** It has had no external security audit, the
 > RP2350 is not a secure element, and a stolen board is only as strong as the
@@ -29,22 +23,40 @@ replacement for an audited commercial key.
 > [threat model](docs/threat-model.md) and [limitations](docs/limitations.md)
 > before trusting it with anything real.
 
-## Documentation
+## Quick start
 
-The docs live in [docs/](docs/) and are published as a site:
-**<https://themaxmur.github.io/RS-Key/>**.
+From a fresh board to a passkey login. Nothing to build.
 
-| | |
+1. Download the newest **`rs-key-<version>-default.uf2`** from the
+   [releases page](https://github.com/TheMaxMur/RS-Key/releases/latest).
+2. Hold the board's **BOOT** button while you plug it in. A drive named
+   `RP2350` appears.
+3. Copy the `.uf2` onto that drive. The board reboots as a security key.
+4. Go to [webauthn.io](https://webauthn.io) and register a passkey. The browser
+   walks you through setting a PIN the first time, then asks for a touch: press
+   the **BOOT** button.
+
+Which file to take:
+
+| Your board | Image |
 |---|---|
-| [Quick start](docs/quickstart.md) | flash, enroll, first login |
-| [Hardware](docs/hardware.md) | supported boards and build knobs |
-| [Build options](docs/build.md) | every flag: VID/PID presets, version, touch, PQC, FIPS profile |
-| [Production setup](docs/production.md) | OTP fuses + secure boot, step by step (**irreversible**) |
-| [Feature guides](docs/guides/) | FIDO2, SSH, OpenPGP, PIV, OATH, OTP, backup, soft-lock, LED, audit, … |
-| [Threat model](docs/threat-model.md) · [Limitations](docs/limitations.md) | what it protects against, and what it does not |
-| [Architecture](docs/architecture.md) · [`unsafe` audit](docs/unsafe.md) | how it's built; every `unsafe` site |
-| [Testing](docs/testing.md) · [Interop](docs/interop.md) | host tests, fuzzing; real-tool results |
-| [Linux setup](docs/linux.md) · [Motivation](docs/motivation.md) | pcscd/udev/polkit; why this exists |
+| Most RP2350 boards, 4 MB flash | `default` |
+| 2 MB flash (Seeed XIAO RP2350, Waveshare RP2350-Zero-CM) | `2mb` |
+| 16 MB flash (TenStar RP2350-USB) | `16mb` |
+| Waveshare RP2350-Touch-LCD-2.8 | `display` |
+
+The other ten images are behaviour variants (post-quantum algorithms, the FIPS
+profile, `alwaysUv`, PIN hardening). Full table, plus how to verify the cosign
+signature and reproduce the build yourself: [docs/releases.md](docs/releases.md).
+
+The longer walkthrough, with the PIN, `ssh` and `gpg` steps, is
+[docs/quickstart.md](docs/quickstart.md). On Linux the smart-card half needs a
+little host setup first: [docs/linux.md](docs/linux.md).
+
+<p align="center">
+  <img src="assets/webauthn-demo.gif" width="240" alt="Registering a passkey on webauthn.io with the trusted-display build: the device screen shows a Device PIN pad, then an Approve / Save-passkey prompt, and the browser confirms you are logged in. The PIN and the approval both happen on the device's own screen"><br>
+  <sub>Step 4 on the <code>display</code> image: the PIN and the Approve/Deny happen on the device's own screen</sub>
+</p>
 
 ## What it supports
 
@@ -98,16 +110,41 @@ Any RP2350 board with USB. Developed and tested on the **Waveshare RP2350-One**
 size, LED pin, or presence-button GPIO is a one-line build knob. Details:
 [docs/hardware.md](docs/hardware.md).
 
-## Quick start
+<p align="center">
+  <img src="assets/hero-boards.jpg" width="330" alt="Three RS-Key boards on a blueprint background: a bare RP2350 USB stick, the trusted-display variant showing its Home &quot;Ready&quot; screen (USB connected, Device PIN set, 2 passkeys), and a Waveshare RP2350-One"><br>
+  <sub>Three boards, one firmware: stick · trusted display · RP2350-One</sub>
+</p>
+
+## Documentation
+
+The docs live in [docs/](docs/) and are published as a site:
+**<https://themaxmur.github.io/RS-Key/>**.
+
+| | |
+|---|---|
+| [Quick start](docs/quickstart.md) | flash, enroll, first login |
+| [Hardware](docs/hardware.md) | supported boards and build knobs |
+| [Build options](docs/build.md) | every flag: VID/PID presets, version, touch, PQC, FIPS profile |
+| [Production setup](docs/production.md) | OTP fuses + secure boot, step by step (**irreversible**) |
+| [Feature guides](docs/guides/) | FIDO2, SSH, OpenPGP, PIV, OATH, OTP, backup, soft-lock, LED, audit, … |
+| [Threat model](docs/threat-model.md) · [Limitations](docs/limitations.md) | what it protects against, and what it does not |
+| [Architecture](docs/architecture.md) · [`unsafe` audit](docs/unsafe.md) | how it's built; every `unsafe` site |
+| [Testing](docs/testing.md) · [Interop](docs/interop.md) | host tests, fuzzing; real-tool results |
+| [Linux setup](docs/linux.md) · [Motivation](docs/motivation.md) | pcscd/udev/polkit; why this exists |
+
+## Build it yourself
+
+The release images are reproducible, so you can rebuild any of them bit for bit
+([docs/releases.md](docs/releases.md)). To build your own:
 
 ```sh
 git clone https://github.com/TheMaxMur/RS-Key && cd RS-Key
-nix develop                       # toolchain, picotool, host tools — everything
+nix develop                       # toolchain, picotool, host tools, everything
 
 cargo build --release -p firmware
 picotool uf2 convert target/thumbv8m.main-none-eabihf/release/firmware -t elf firmware.uf2
 
-# hold BOOTSEL, plug the board in, then flash — either way:
+# hold BOOTSEL, plug the board in, then flash, either way:
 cp firmware.uf2 /Volumes/RP2350/                    # macOS drag-and-drop; Linux: the mounted RP2350 volume
 picotool load -v firmware.uf2 && picotool reboot    # more robust; verifies the write (use if cp flakes)
 ```
@@ -115,12 +152,12 @@ picotool load -v firmware.uf2 && picotool reboot    # more robust; verifies the 
 Re-plug the board and it enumerates as a composite USB authenticator. The default
 build requires a **physical touch** (the BOOTSEL button) for FIDO operations;
 build with `--features no-touch` for a no-touch build (the automated test
-suites need it). Full walkthrough: [docs/quickstart.md](docs/quickstart.md).
-On Linux, the CCID half needs a little host setup: [docs/linux.md](docs/linux.md).
+suites need it). Every compile-time knob, including the flash size, LED pin and
+USB identity, is in [docs/build.md](docs/build.md).
 
 ## Development setup
 
-`nix develop` is the whole setup — Rust with the `thumbv8m.main-none-eabihf`
+`nix develop` is the whole setup: Rust with the `thumbv8m.main-none-eabihf`
 target, `picotool`, the Python host stack, and the security tooling. One command
 is the merge gate, and CI runs exactly the same script:
 
@@ -197,3 +234,6 @@ the AGPL-3.0-**only** [pico-keys](https://github.com/polhenarejos) firmware
 family (pico-fido / pico-openpgp / pico-keys-sdk) by Pol Henarejos; the upstream
 grant is version-3-only, so RS-Key inherits it and so must forks. Not affiliated
 with or endorsed by Yubico, Nitrokey, or Raspberry Pi. See [motivation](docs/motivation.md).
+
+<sub>The name: **R**aspberry **S**ecurity **Key**, and a nod to Rust. Nothing to
+do with RSA. The crates and the CLI shorten it to `rsk`.</sub>

--- a/docs/images/README.md
+++ b/docs/images/README.md
@@ -19,6 +19,7 @@ the mdBook site.
 
 | File | What | Source |
 |---|---|---|
+| `what-it-is.svg` | Landing figure: board + this firmware = what it then does | original — from `README.md` / `index.md` |
 | `flash-map.svg` | RP2350-One 4 MB flash address map | original — from `firmware/memory.x` / `flash_storage.rs` |
 | `flash-map-sizes.svg` | 4 MB vs 16 MB layout (how `FLASH_SIZE` scales it) | original — from `firmware/build.rs` |
 | `ctaphid-frame.svg` | CTAPHID 64-byte init + continuation frame layout | original — from `protocol.md` §1.2 / `tools/rsk/ctaphid.py` |

--- a/docs/images/what-it-is.svg
+++ b/docs/images/what-it-is.svg
@@ -1,0 +1,78 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+<!-- Copyright (C) 2026 RS-Key contributors -->
+<svg viewBox="0 0 900 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ttl dsc" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <title id="ttl">What RS-Key is</title>
+  <desc id="dsc">Three columns. Left: any RP2350 board, from about five dollars, such as a Pico 2, a Waveshare stick or a Seeed XIAO. An arrow labelled "flash one .uf2" leads to the middle: RS-Key, open-source firmware written in Rust. A second arrow labelled USB leads to what the board then does: passkey and WebAuthn logins, ssh and git signing, an OpenPGP card for gpg, a PIV smart card, and TOTP or HOTP codes. RS-Key is firmware, not a product for sale and not a mod for an existing key.</desc>
+  <defs>
+    <style>
+      .hd{font-size:11px;font-weight:700;fill:#948A7F;letter-spacing:1.2px}
+      .big{font-size:15px;font-weight:700;fill:#2B2723}
+      .sub{font-size:11.5px;fill:#6B645C}
+      .dim{font-size:11px;fill:#948A7F}
+      .brand{font-size:26px;font-weight:700;fill:#fff}
+      .bsub{font-size:12.5px;fill:#F6DCCE}
+      .bmono{font-size:11px;fill:#EFC4AB;font-family:'SF Mono','Roboto Mono',ui-monospace,monospace}
+      .chip{font-size:12.5px;fill:#2B2723}
+      .arw{font-size:11.5px;font-weight:700;fill:#5A534B}
+      .foot{font-size:10.5px;fill:#ADA398}
+    </style>
+  </defs>
+  <rect x="6" y="6" width="888" height="308" rx="16" fill="#FBFAF8" stroke="#E4DED5" stroke-width="1.5"/>
+
+  <text class="hd" x="36" y="44">A BOARD YOU BUY</text>
+  <text class="hd" x="350" y="44">THIS REPOSITORY</text>
+  <text class="hd" x="640" y="44">WHAT IT THEN DOES</text>
+
+  <!-- left: the board -->
+  <rect x="36" y="62" width="200" height="160" rx="12" fill="#fff" stroke="#E4DED5" stroke-width="1.5"/>
+  <rect x="66" y="104" width="22" height="18" rx="2" fill="#ADA398"/>
+  <rect x="86" y="96" width="100" height="34" rx="6" fill="#3E3A36"/>
+  <circle cx="170" cy="113" r="4" fill="#2F7E75"/>
+  <rect x="98" y="106" width="30" height="14" rx="3" fill="#5A534B"/>
+  <text class="big" x="136" y="164" text-anchor="middle">Any RP2350 board</text>
+  <text class="sub" x="136" y="184" text-anchor="middle">Pico 2 · Waveshare · XIAO</text>
+  <text class="dim" x="136" y="203" text-anchor="middle">from about $5, plus a USB cable</text>
+
+  <!-- arrow 1 -->
+  <text class="arw" x="296" y="124" text-anchor="middle">flash one .uf2</text>
+  <line x1="248" y1="142" x2="328" y2="142" stroke="#D9D2C8" stroke-width="6"/>
+  <path d="M326 131 L344 142 L326 153 z" fill="#A9764F"/>
+  <text class="dim" x="296" y="170" text-anchor="middle">drag and drop</text>
+
+  <!-- middle: the firmware -->
+  <rect x="350" y="62" width="200" height="160" rx="12" fill="#C0562B"/>
+  <text class="brand" x="450" y="124" text-anchor="middle">RS-Key</text>
+  <text class="bsub" x="450" y="148" text-anchor="middle">open-source firmware</text>
+  <text class="bmono" x="450" y="182" text-anchor="middle">Rust · no_std · AGPL-3.0</text>
+
+  <!-- arrow 2 -->
+  <text class="arw" x="595" y="124" text-anchor="middle">USB</text>
+  <line x1="562" y1="142" x2="618" y2="142" stroke="#D9D2C8" stroke-width="6"/>
+  <path d="M616 131 L634 142 L616 153 z" fill="#A9764F"/>
+
+  <!-- right: the capabilities -->
+  <g fill="#fff" stroke="#E4DED5" stroke-width="1.5">
+    <rect x="640" y="62"  width="224" height="26" rx="8"/>
+    <rect x="640" y="94"  width="224" height="26" rx="8"/>
+    <rect x="640" y="126" width="224" height="26" rx="8"/>
+    <rect x="640" y="158" width="224" height="26" rx="8"/>
+    <rect x="640" y="190" width="224" height="26" rx="8"/>
+  </g>
+  <g fill="#2F7E75">
+    <circle cx="659" cy="75"  r="4"/>
+    <circle cx="659" cy="107" r="4"/>
+    <circle cx="659" cy="139" r="4"/>
+    <circle cx="659" cy="171" r="4"/>
+    <circle cx="659" cy="203" r="4"/>
+  </g>
+  <text class="chip" x="675" y="79">Passkey / WebAuthn logins</text>
+  <text class="chip" x="675" y="111">ssh and git signing</text>
+  <text class="chip" x="675" y="143">OpenPGP card for gpg</text>
+  <text class="chip" x="675" y="175">PIV smart card</text>
+  <text class="chip" x="675" y="207">TOTP / HOTP codes</text>
+
+  <line x1="36" y1="252" x2="864" y2="252" stroke="#EFEAE3" stroke-width="1.5"/>
+  <text class="foot" x="36" y="274">Firmware, not a product for sale, and not a mod for an existing key.</text>
+  <text class="foot" x="36" y="292">Experimental: no external audit, and the RP2350 is not a secure element. Read the threat model first.</text>
+  <text class="foot" x="864" y="274" text-anchor="end">github.com/TheMaxMur/RS-Key</text>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,13 +3,17 @@
 
 # RS-Key
 
-RS-Key (RSK) is open-source security-key firmware for the Raspberry Pi RP2350.
-It turns an RP2350 board into a USB authenticator: FIDO2/WebAuthn/U2F,
-OpenPGP card, PIV, OATH, Yubico-style OTP. It ships the host-side tooling to
-drive and provision it.
+**An open-source hardware passkey.** Flash one file onto a Raspberry Pi RP2350
+board and it becomes a USB security key: passkey logins in the browser, `ssh`
+and `git` signing, GPG, PIV, and TOTP codes.
 
-Written in Rust (`no_std`, [embassy](https://embassy.dev)). For development,
-research, and controlled experiments.
+| | |
+|---|---|
+| **What this is** | Firmware. A `.uf2` file you drop onto a board. Nothing here is for sale. |
+| **What you need** | Any RP2350 board (from about $5) and a USB cable. No soldering, no programmer, no toolchain. |
+| **What you get** | A USB authenticator your browser, `ssh`, `gpg` and `ykman` already know how to talk to. |
+
+![What RS-Key is: any RP2350 board, plus this firmware, gives you passkey and WebAuthn logins, ssh and git signing, an OpenPGP card for gpg, a PIV smart card, and TOTP codes](images/what-it-is.svg)
 
 > **This project is experimental.** It has had no external security audit. The
 > RP2350 is not a secure element. A stolen board is only as strong as the
@@ -18,16 +22,16 @@ research, and controlled experiments.
 > [threat model](threat-model.md) and [limitations](limitations.md) before
 > trusting it with anything real.
 
-```mermaid
-flowchart TD
-    user["You"] --> tools["Host tools<br/>browser · ssh · gpg · ykman · rsk"]
-    tools -->|USB| dev["RS-Key firmware (applets)"]
-    dev --> hw["RP2350 board<br/>flash · TRNG · OTP"]
-```
+Written in Rust (`no_std`, [embassy](https://embassy.dev)). Under the hood it is
+FIDO2/WebAuthn/U2F, an OpenPGP card, PIV, OATH and Yubico-style OTP, plus the
+host-side tooling to drive and provision all of it.
 
 ## Start here
 
-- **[Quick start](quickstart.md)**: build, flash, set a PIN, enroll something
+- **[Quick start](quickstart.md)**: flash a released image, set a PIN, enroll
+  something. No toolchain needed; the images are on the
+  [releases page](https://github.com/TheMaxMur/RS-Key/releases/latest) and
+  [releases.md](releases.md) says which one to take
 - **[Hardware](hardware.md)**: supported boards and the knobs for them
 - **[Build options](build.md)**: every compile-time flag and environment knob
 - **[Using the device](guides/fido2.md)**: per-feature guides for FIDO2, SSH,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,8 +8,7 @@ From zero to a working security key in about ten minutes.
 
 ```mermaid
 flowchart TD
-    a["nix develop · cargo build"] --> b["firmware.uf2"]
-    b --> c["hold BOOT, plug in"]
+    a["download rs-key-&lt;version&gt;-default.uf2<br/>(or build it yourself)"] --> c["hold BOOT, plug in"]
     c --> d["flash: drag-and-drop or picotool load"]
     d --> e["board reboots, enumerates over USB"]
     e --> f["set PIN, enroll a passkey / ssh key"]
@@ -19,12 +18,28 @@ flowchart TD
 
 - An RP2350 board (tested: Waveshare RP2350-One; any RP2350 with USB works)
 - A USB cable
-- [Nix](https://nixos.org/download/) with flakes enabled (the dev shell provides
-  everything: toolchain, `picotool`, host tools). Without Nix:
-  rustup + `rustup target add thumbv8m.main-none-eabihf` + picotool ≥ 2.0,
-  and the Python deps from `flake.nix` for the host tools.
 
-## 1. Build
+That is the whole list. You only need a toolchain if you want to build the
+firmware yourself instead of downloading it.
+
+## 1. Get the firmware
+
+Download the newest `rs-key-<version>-default.uf2` from the
+[releases page](https://github.com/TheMaxMur/RS-Key/releases/latest). Take
+`2mb`, `16mb` or `display` instead if that is your board;
+[releases.md](releases.md) has the table of all fourteen images, the cosign
+signature check, and the reproducibility check.
+
+Every published image is a **touch build**: FIDO operations (registering,
+logging in) require a press of the presence button, BOOTSEL by default.
+
+<details>
+<summary>Or build it yourself</summary>
+
+You need [Nix](https://nixos.org/download/) with flakes enabled; the dev shell
+provides the toolchain, `picotool` and the host tools. Without Nix: rustup +
+`rustup target add thumbv8m.main-none-eabihf` + picotool ≥ 2.0, and the Python
+deps from `flake.nix`.
 
 ```sh
 nix develop                                  # first run downloads the toolchain
@@ -32,17 +47,18 @@ cargo build --release -p firmware
 picotool uf2 convert target/thumbv8m.main-none-eabihf/release/firmware -t elf firmware.uf2
 ```
 
-This is the **touch build**: FIDO operations (registering, logging in) require
-a press of the presence button (BOOTSEL by default; set `PRESENCE_PIN=<gpio>` for
-a dedicated GPIO button). For a no-touch build (needed by the automated test
-suites, or if your board is hard to reach) add `--features no-touch`. All build knobs:
-[build.md](build.md).
+Set `PRESENCE_PIN=<gpio>` for a dedicated presence button instead of BOOTSEL.
+For a no-touch build (needed by the automated test suites, or if your board is
+hard to reach) add `--features no-touch`. All build knobs: [build.md](build.md).
+
+</details>
 
 ## 2. Flash
 
 1. Hold the **BOOT** button while plugging the board in (or hold BOOT, tap
    RESET). A mass-storage drive named `RP2350` appears.
-2. Flash it, either way:
+2. Flash it, either way (`firmware.uf2` here is whichever `.uf2` you got in
+   step 1):
    - **Drag-and-drop:** `cp firmware.uf2 /Volumes/RP2350/` (macOS) or copy it to
      the mounted drive on Linux.
    - **picotool (more reliable: it verifies and skips the mass-storage layer):**
@@ -62,7 +78,7 @@ suites, or if your board is hard to reach) add `--features no-touch`. All build 
    Authenticator auto-recognize it, build the opt-in `VIDPID=Yubikey5`
    flavor; see [build.md](build.md).)
 
-Check it:
+Check it (optional, needs the host tools from the dev shell or `tools/`):
 
 ```sh
 rsk status        # FIDO getInfo + secure-boot + backup state, over USB
@@ -78,6 +94,9 @@ place.
 ```sh
 rsk fido set-pin
 ```
+
+Without the host tools, your browser does the same job: it offers to set a PIN
+the first time you register a passkey.
 
 Browsers and `ssh-keygen` will prompt for it when enrolling. 8 wrong attempts
 lock the PIN until a reset. Standard security-key behaviour.


### PR DESCRIPTION
A first-time reader could not tell whether this was a device for sale, a mod for
an existing key, or firmware. The first screen was a title, CI badges, two
hardware photos captioned "three boards", and an opening sentence that spent its
first twelve words on the name's etymology.

- `README.md` and `docs/index.md` now open with one line ("an open-source
  hardware passkey"), a what-this-is / what-you-need / what-you-get table, and a
  new figure `docs/images/what-it-is.svg`: board, plus this firmware, equals
  passkey logins, `ssh` and `git` signing, an OpenPGP card, PIV and TOTP.
- The three-board photo moves down to Hardware, where it reads as an
  illustration instead of a shop.
- The quick start starts from a released `.uf2` instead of `nix develop`, with a
  "which image for my board" table pointing at `docs/releases.md`. Building it
  yourself is one fold down, in both the README and `docs/quickstart.md`.
- The experimental / no-audit warning is unchanged and still above the fold.

Docs only: no firmware or host-tool change, so no `bcdDevice` and no `rsk` /
`rsk-tui` version bump. Verified with `nix develop -c ./scripts/docs.sh check`
(mdBook build + 444 links, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)