### PR TITLE
rsk-tui runtime fix

### DIFF
--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -51,7 +51,7 @@ let
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = lib.optionals pkgs.stdenv.isLinux [
       pkgs.pcsclite
-      pkgs.systemd # libudev (hidapi's hidraw backend)
+      pkgs.udev 
     ];
     meta = {
       description = "RS-Key device dashboard — a self-contained ratatui cockpit";


### PR DESCRIPTION
libudev for hidapi's hidraw backend. 
pkgs.udev (systemd-minimal-libs) carries libudev.so.1 in lib/; pkgs.systemd does not, which is why the original build lost it at runtime.

## What

<!-- What changes, and why. A couple of sentences is fine; link the issue if there is one. -->

## How it was tested

Test on local machine.

<!-- Keep what applies, delete the rest. -->

- [x] Host-only change (CLI / docs / CI) — no device behavior touched

## Checklist

<!-- Tick what applies; "N/A" is fine — most host-only PRs leave the firmware lines blank. -->

Previous built but errored at runtime.

This change builds and runs correctly at runtime.