### PR TITLE
Release v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-08-08
+
+Everything in 0.4.7 below, plus the fix for the reason it never shipped: the
+`v0.4.7` tag exists, but its release build failed on the 16 MB images and no
+release was ever published for it.
+
 ### Fixed
 
 - **A 16 MB image can carry the storage fence at all.** The partition table that
@@ -3936,7 +3942,8 @@ family that keeps the "enterprise" features in the open tree.
   signature of it, and a CycloneDX SBOM. See
   [docs/releases.md](docs/releases.md) to verify a download.
 
-[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.7...HEAD
+[Unreleased]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.8...HEAD
+[0.4.8]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.6...v0.4.7
 [0.4.6]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/TheMaxMur/RS-Key/compare/v0.4.4...v0.4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **A 16 MB image can carry the storage fence at all.** The partition table that
+  arrived in 0.4.7 covered the whole chip, and on a 16 MB part the store's last
+  sector holds `0x10FFFF00` — the absolute block the bootrom's RP2350-E10
+  workaround owns. `picotool partition create` refuses to claim it (and separately
+  requires unpartitioned space to accept the `absolute` family), so `nix build
+  .#firmware-display` failed in the release with no diagnostic: the error goes to
+  stdout, which `pt.sh` sends to `/dev/null`. The 16 MB layout now stops one
+  sector short of the top, leaving that block outside every partition, and `pt.sh`
+  no longer swallows picotool's message. This was never a 4 MB or 2 MB problem —
+  their stores end far below the E10 block, and their layouts are byte-identical
+  to 0.4.7.
+  **Upgrading a provisioned 16 MB key (the `display` and `16mb` flavors, the
+  `abrobot-16m` and `waveshare-touch-lcd` presets) moves its store 4 KB down, so
+  the device comes up factory-empty: export your seed first**
+  ([seed backup](docs/guides/seed-backup.md)). A 4 MB key upgrades in place, as
+  usual.
+- **The gate builds a 16 MB image and fences it.** The partition-table assertion
+  ran on the 4 MB default only, and the display smoke build did not set
+  `FLASH_SIZE=16M` either — so the one geometry with a special case in it was
+  checked by nothing until the release ran.
+
 ## [0.4.7] - 2026-08-08
 
 ### Security

--- a/docs/build.md
+++ b/docs/build.md
@@ -93,6 +93,12 @@ of flash and only the code region grows. A 16 MB board just gets more (unused)
 code headroom. The credential capacity is unchanged (why the flash is mostly
 empty by design: [architecture.md](architecture.md)).
 
+One exception, and only at 16 MB: the store stops a sector short of the top,
+because the bootrom's RP2350-E10 workaround owns the last 256 bytes of the XIP
+window (`0x10FFFF00`) and `picotool partition create` refuses a table that claims
+them — so a 16 MB image could not carry the fence at all. The reserved 4 KB is
+outside every partition, which is where the bootrom needs it.
+
 The KV store is 1.5 MB by default (`KVMAIN` 1408K + `KVCNT` 128K). On a **2 MB**
 board that leaves too little for the ~900K image, so the firmware can't link.
 `KVMAIN` shrinks the main partition to make room: build a 2 MB Seeed XIAO RP2350

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -32,6 +32,18 @@ const KVCNT_LEN: u32 = 128 * 1024;
 /// split here with a fix hint instead of leaving a cryptic linker overflow.
 const MIN_CODE: u32 = 1024 * 1024;
 
+/// First byte of the sector holding the RP2350-E10 absolute block (`0x10FFFF00`,
+/// the last 256 bytes of the XIP window). The bootrom's erratum workaround owns
+/// it, and `picotool partition create` refuses a table claiming it — so the store,
+/// which sits at the top of flash, must stop below it (see [`usable_flash`]).
+const E10_ABS_BLOCK_SECTOR: u32 = 0xFFF_000;
+
+/// The highest flash offset the layout may use. Only a 16 MB part reaches the
+/// E10 sector; every smaller flash ends below it and keeps its layout unchanged.
+fn usable_flash(flash_size: u32) -> u32 {
+    flash_size.min(E10_ABS_BLOCK_SECTOR)
+}
+
 // --- Board config (BOARD=<name> -> firmware/boards/<name>.toml) ---
 struct BoardConfig {
     vidpid: Option<String>,
@@ -297,7 +309,7 @@ fn main() {
 
     // memory.x: the checked-in script is the default 4 MB / 1408K-KVMAIN layout;
     // for any other FLASH_SIZE or KVMAIN we splice a recomputed MEMORY block
-    // (code = flash − KVMAIN − KVCNT) into it and keep the rest verbatim.
+    // (code = usable_flash − KVMAIN − KVCNT) into it and keep the rest verbatim.
     let flash_size = resolve_flash_size();
     let kvmain_len = resolve_kvmain_len();
     assert_layout_fits(flash_size, kvmain_len);
@@ -606,12 +618,13 @@ fn resolve_kvmain_len() -> u32 {
 /// linker does, with a message that names the fix. KVCNT is fixed at the top;
 /// KVMAIN and the code region share what is left below it.
 fn assert_layout_fits(flash_size: u32, kvmain_len: u32) {
+    let usable = usable_flash(flash_size);
     let kv = kvmain_len + KVCNT_LEN;
     assert!(
-        flash_size > kv,
+        usable > kv,
         "FLASH_SIZE={flash_size} too small for KVMAIN + KVCNT ({kv} bytes)"
     );
-    let code = flash_size - kv;
+    let code = usable - kv;
     assert!(
         code >= MIN_CODE,
         "this FLASH_SIZE / KVMAIN split leaves only {code} bytes for code (< {MIN_CODE}); \
@@ -642,7 +655,7 @@ fn parse_size(s: &str) -> Option<u32> {
 /// splice it into the template, keeping the rest (KV symbols, SECTIONS) verbatim.
 /// KVCNT stays fixed at the top; KVMAIN sits below it; the code region is the rest.
 fn splice_memory_block(template: &str, flash_size: u32, kvmain_len: u32) -> String {
-    let code = flash_size - kvmain_len - KVCNT_LEN;
+    let code = usable_flash(flash_size) - kvmain_len - KVCNT_LEN;
     let kvmain = 0x1000_0000 + code;
     let kvcnt = kvmain + kvmain_len;
     let block = format!(

--- a/firmware/memory.x
+++ b/firmware/memory.x
@@ -7,7 +7,8 @@
    `.end_block`.
 
    This is the default 4 MB / 1408K-KVMAIN MEMORY block; for any other FLASH_SIZE
-   or KVMAIN, build.rs splices in a recomputed one (code = flash − KVMAIN − KVCNT)
+   or KVMAIN, build.rs splices in a recomputed one (code = usable − KVMAIN − KVCNT,
+   where a 16 MB part stops one sector short of the RP2350-E10 absolute block)
    and keeps everything below it verbatim. KVMAIN is baked as PK_KVMAIN_LEN and read
    back by flash_storage.rs (MAIN_LEN), so build.rs keeps the two in step; KVCNT is
    fixed. Change these defaults here AND in build.rs (DEFAULT_KVMAIN) together. */

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -650,7 +650,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0872;
+    let device_release: u16 = 0x0873;
     config.device_release = device_release;
 
     let mut builder = Builder::new(

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -149,6 +149,12 @@ run "clippy (display strong-pin)" env LED_KIND=none cargo clippy -p firmware --f
 run "build firmware (release)" cargo build --release -p firmware
 run "firmware size budget"     firmware_size_budget
 run "partition table fences the store" partition_table_fences_the_store
+# The 16 MB geometry is the one that broke: the store used to end at the top of
+# the XIP window, where the bootrom's RP2350-E10 absolute block lives, and
+# `picotool partition create` refuses a table claiming it — a build the release
+# makes (display, 16mb) and the 4 MB gate above never exercised.
+run "build firmware (16M)"     env FLASH_SIZE=16M cargo build --release -p firmware
+run "partition table fences the store (16M)" partition_table_fences_the_store
 # The trusted-display flavor must keep building from the same tree. Built
 # `LED_KIND=none` (the panel replaces the addressable LED and its backlight uses
 # GPIO16 — the compile_error guard in main.rs enforces this), and before the

--- a/scripts/pt.sh
+++ b/scripts/pt.sh
@@ -101,6 +101,12 @@ cat > "$tmp/pt.json" <<EOF
 }
 EOF
 
-picotool partition create "$tmp/pt.json" "$out" "$in" -t elf >/dev/null
+# picotool reports its refusals on stdout, so a plain `>/dev/null` turned the one
+# thing worth reading — "the address 10ffff00 cannot be in a partition" — into a
+# bare exit code, and a failing release build printed nothing at all.
+if ! log=$(picotool partition create "$tmp/pt.json" "$out" "$in" -t elf 2>&1); then
+  printf '%s\n' "$log" >&2
+  exit 1
+fi
 printf 'pt.sh: store fenced at 0x%08x..0x%08x (%d KiB), NSBOOT denied\n' \
   "$start" "$end" $((size / 1024)) >&2


### PR DESCRIPTION
Re-cut of [#70](https://github.com/TheMaxMur/RS-Key/pull/70) with the fix for the reason it never shipped. The `v0.4.7` tag exists, its release build **failed**, and no release was published for it; the tag ruleset forbids moving a `v*` tag, so this is a new version — the same call as the burned `v0.2.1`.

## The blocker, and the fix

`nix build .#firmware-display` died in the release run with `exit 253` and no message. Reproduced locally: the partition table that landed in 0.4.7 covers the whole chip, and on a **16 MB** part the store's last sector holds `0x10FFFF00` — the absolute block the bootrom's **RP2350-E10** workaround owns. `picotool partition create` refuses a table claiming it (and separately requires unpartitioned space to accept the `absolute` family). It was silent because picotool reports refusals on **stdout**, which `pt.sh` sent to `/dev/null`.

- The layout ceiling is now `min(FLASH_SIZE, 0xFFF000)` — one rule, no per-size branch. 4 MB and 2 MB layouts are **byte-identical to 0.4.7**; a 16 MB store stops one sector short and leaves the E10 block outside every partition.
- `pt.sh` no longer swallows picotool's message.
- The gate now builds a **16 MB** image and runs the same partition-table assertion on it — the assertion previously ran on the 4 MB default only, and the display smoke build did not set `FLASH_SIZE=16M` either, so the one geometry with a special case was checked by nothing.

⚠️ **Upgrading a provisioned 16 MB key** (`display`, `16mb`, `abrobot-16m`, `waveshare-touch-lcd`) **moves its store 4 KB down, so the device comes up factory-empty — export the seed first.** A 4 MB key upgrades in place.

## Everything else

The whole 0.4.7 content: audit run-37 (fifteen LOW/INFO fixes, no MEDIUM+), the finished persistent `pcmr` grant, `CTAPHID_WINK` made real and then bounded, the allowList/excludeList truncation fix, the partition-table fence itself, `rsk identify`, `overlays.ccid-rs-key`, and the two host PRs from @mannp ([#68](https://github.com/TheMaxMur/RS-Key/pull/68), [#69](https://github.com/TheMaxMur/RS-Key/pull/69)).

`bcdDevice` `0x0871` → `0x0873`, `rsk` 0.3.30 → 0.3.32, `rsk-tui` 0.3.8 → 0.3.9.

## Pre-flight

- `nix develop -c ./scripts/check.sh` — ALL CHECKS PASSED (incl. the two new 16 MB steps; the emitted table reads `00e7f000->00fff000`, NSBOOT denied)
- `nix build .#firmware-display` and `nix build .#firmware-16mb` — **the two builds the release died on** — both produce their `.uf2`
- `nix develop .#fuzz -c cargo fuzz build` — clean
- `nix develop -c ./scripts/docs.sh check` — build + links OK

## What is *not* verified

The `0x0871` stack was hardware-verified when it landed. **The run-37 remediation (`0x0872`) and this E10 layout change (`0x0873`) are gate-green but have not been run on hardware** — and the layout change is the one that wants a real 16 MB board before you trust it. Also still open from run-37: whether power-on clears `WATCHDOG.scratch2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)