### PR TITLE
fix(ci): the fuzz row lost the dev shell to its own nested bash

### DIFF
--- a/.github/workflows/deep-checks.yml
+++ b/.github/workflows/deep-checks.yml
@@ -31,7 +31,7 @@
 # Runs daily, on demand (workflow_dispatch, with a per-target time knob),
 # and self-tests on any push that edits this file. Local equivalents:
 #   nix develop .#fuzz -c cargo miri test --manifest-path fuzz/Cargo.toml
-#   nix develop .#fuzz -c cargo fuzz run <target> -- -max_total_time=120
+#   nix develop .#fuzz -c ./scripts/fuzz-all.sh   (FUZZ_SECONDS=30 to shorten)
 #   nix develop .#fuzz -c ./scripts/fuzz-coverage.sh
 #   ./scripts/kani.sh all   (needs `cargo install kani-verifier` first — not nix)
 #   nix develop -c cargo llvm-cov --summary-only --fail-under-lines 80 --target <host> --workspace --exclude firmware --exclude rsk-wipe
@@ -55,6 +55,7 @@ on:
         "nix/devshells.nix",
         "nix/firmware.nix",
         "scripts/fuzz-coverage.sh",
+        "scripts/fuzz-all.sh",
       ]
 
 permissions:
@@ -125,40 +126,16 @@ jobs:
       - name: build every fuzz target
         run: nix develop .#fuzz -c cargo fuzz build
 
+      # A script, not an inline `-c bash -c '…'`: that form loses the dev shell's
+      # PATH here and `cargo` falls through to the image's rustup shim, which
+      # syncs stable and answers "no such command: fuzz". Measured in one run,
+      # same image, same minute — the `fuzz-coverage` row below, which already
+      # calls its script this way, listed 53 targets while this one listed 0 and
+      # tripped its own roster floor. The floor did its job; the shape was wrong.
       - name: fuzz every target
-        run: |
-          nix develop .#fuzz -c bash -euo pipefail -c '
-            # `set -e` does not fire on an empty or failing $( ) used as a `for`
-            # word list, so a broken `cargo fuzz list` fuzzed zero targets and
-            # this job reported green — measured, rc=0. Floor the roster at today's
-            # count: unlike the firmware-size ratchet it needs no margin, because a
-            # target count has no build noise. Lower FUZZ_TARGET_FLOOR, and its two
-            # copies in scripts/fuzz-coverage.sh and scripts/check.sh, in the commit
-            # that removes a target.
-            mapfile -t targets < <(cargo fuzz list)
-            # The corpus lives in one LRU-evictable cache entry; on a restore
-            # miss every target starts from empty and the run still says DONE.
-            echo "roster: ${#targets[@]} targets (floor ${FUZZ_TARGET_FLOOR}), corpus: $(find fuzz/corpus -type f 2>/dev/null | wc -l) inputs restored"
-            if [ "${#targets[@]}" -lt "$FUZZ_TARGET_FLOOR" ]; then
-              echo "::error::cargo fuzz list yielded ${#targets[@]} targets, under the ${FUZZ_TARGET_FLOOR} floor — the roster shrank or the list failed"
-              exit 1
-            fi
-            failed=""
-            for t in "${targets[@]}"; do
-              echo "::group::${t} (${FUZZ_SECONDS}s)"
-              if ! cargo fuzz run "$t" -- -max_total_time="$FUZZ_SECONDS" -print_final_stats=1; then
-                failed="$failed $t"
-              fi
-              echo "::endgroup::"
-            done
-            if [ -n "$failed" ]; then
-              echo "::error::crashing targets:$failed"
-              exit 1
-            fi
-          '
+        run: nix develop .#fuzz -c ./scripts/fuzz-all.sh
         env:
           FUZZ_SECONDS: ${{ inputs.fuzz_seconds || '120' }}
-          FUZZ_TARGET_FLOOR: "53"
 
       - name: upload crash artifacts
         if: failure()

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -225,8 +225,8 @@ release_image_retires_its_unsigned_image_def() {
 # target on the empty file. Liveness only — no sanitizer, no coverage, no
 # fuzzing; those stay in deep-checks.
 #
-# Same floor, and the same reason, as scripts/fuzz-coverage.sh and the
-# deep-checks fuzz loop: a `for` over an empty word list runs nothing and exits
+# Same floor, and the same reason, as scripts/fuzz-coverage.sh and
+# scripts/fuzz-all.sh: a `for` over an empty word list runs nothing and exits
 # 0. Lower all three in the commit that removes a target.
 FUZZ_TARGET_FLOOR=53
 fuzz_targets_are_alive() {

--- a/scripts/fuzz-all.sh
+++ b/scripts/fuzz-all.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+# Fuzz every target for FUZZ_SECONDS each — the deep-checks `fuzz` row.
+#
+#   nix develop .#fuzz -c ./scripts/fuzz-all.sh
+#   FUZZ_SECONDS=30 nix develop .#fuzz -c ./scripts/fuzz-all.sh
+#
+# A FILE, not an inline `nix develop .#fuzz -c bash -euo pipefail -c '…'`, which
+# is what the workflow used to carry. That form loses the dev shell's PATH on a
+# GitHub runner: `cargo` falls through to the image's rustup shim, which syncs
+# *stable* and answers "no such command: fuzz". Measured in one run, same image,
+# same minute — the sibling row `nix develop .#fuzz -c ./scripts/fuzz-coverage.sh`
+# listed 53 targets while the inline one listed 0. Not reproducible in a local
+# Linux VM, which is why the shape is the fix and the check below is the proof.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# The row's own toolchain, asserted before anything depends on it. Without this a
+# `cargo` that is not the dev shell's reads as "the roster shrank" — the failure
+# that sent a maintainer looking for a deleted fuzz target.
+if ! command -v cargo-fuzz >/dev/null; then
+  echo "FAIL: cargo-fuzz is not on PATH — this is not the .#fuzz dev shell." >&2
+  echo "      cargo:      $(command -v cargo || echo '(none)')" >&2
+  echo "      rustc:      $(command -v rustc || echo '(none)')" >&2
+  echo "      run it as:  nix develop .#fuzz -c $0" >&2
+  exit 1
+fi
+
+FUZZ_SECONDS="${FUZZ_SECONDS:-120}"
+# Same floor and same reason as `scripts/fuzz-coverage.sh` and the `fuzz targets
+# alive` row in `scripts/check.sh`: `set -e` does not fire on an empty or failing
+# $( ) in a `for` word list, so a broken `cargo fuzz list` fuzzed zero targets and
+# the row reported green — measured, rc=0. It needs no margin, unlike the
+# firmware-size ratchet: a target count has no build noise. A literal, not
+# `${FUZZ_TARGET_FLOOR:-53}`, because a floor the environment can lower is not a
+# floor. Lower all three copies in the commit that removes a target.
+FUZZ_TARGET_FLOOR=53
+
+mapfile -t targets < <(cargo fuzz list)
+# The corpus lives in one LRU-evictable cache entry; on a restore miss every
+# target starts from empty and the run still says DONE.
+echo "roster: ${#targets[@]} targets (floor ${FUZZ_TARGET_FLOOR}), corpus: $(find fuzz/corpus -type f 2>/dev/null | wc -l) inputs restored"
+if [ "${#targets[@]}" -lt "$FUZZ_TARGET_FLOOR" ]; then
+  echo "::error::cargo fuzz list yielded ${#targets[@]} targets, under the ${FUZZ_TARGET_FLOOR} floor — the roster shrank or the list failed"
+  exit 1
+fi
+
+failed=""
+for t in "${targets[@]}"; do
+  echo "::group::${t} (${FUZZ_SECONDS}s)"
+  if ! cargo fuzz run "$t" -- -max_total_time="$FUZZ_SECONDS" -print_final_stats=1; then
+    failed="$failed $t"
+  fi
+  echo "::endgroup::"
+done
+
+if [ -n "$failed" ]; then
+  echo "::error::crashing targets:$failed"
+  exit 1
+fi
+echo "fuzz: ${#targets[@]} targets, ${FUZZ_SECONDS}s each, no crashes"

--- a/scripts/fuzz-coverage.sh
+++ b/scripts/fuzz-coverage.sh
@@ -32,7 +32,7 @@ covbuild="fuzz/coverage/.build"
 # report — we measure OUR parser/dispatch surface, not the glue around it.
 ign='(fuzz/fuzz_targets/|/\.cargo/registry/|/rustc/|/library/|/rustlib/)'
 
-# Same floor and same reason as the deep-checks fuzz loop: `set -e` does not fire
+# Same floor and same reason as `scripts/fuzz-all.sh`: `set -e` does not fire
 # on an empty or failing $( ) in a `for` word list, so a broken `cargo fuzz list`
 # printed an empty table and exited 0. The third copy is the `fuzz targets alive`
 # row in scripts/check.sh; lower all three in the same commit.


### PR DESCRIPTION
The `deep-checks` `fuzz` row went red with `cargo fuzz list` yielding 0 targets
against its floor of 53, because `nix develop .#fuzz -c bash -c '…'` does not
keep the dev shell's PATH on a GitHub runner — `cargo` falls through to the
image's rustup shim.

The control was in the same run: `fuzz-coverage`, which already calls its script
as `nix develop .#fuzz -c ./scripts/fuzz-coverage.sh`, listed 53 targets a minute
earlier. So the loop moves into `scripts/fuzz-all.sh` and is called the same way,
and the script asserts its own toolchain first so a foreign `cargo` can no longer
read as "the roster shrank".

Gate green locally; the script verified from both sides (refuses outside the
shell naming what it found, 53/53 targets and no crashes inside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)