### PR TITLE
fix(ci): the daily proof row died on one crate and took sixteen with it

### DIFF
--- a/.github/workflows/deep-checks.yml
+++ b/.github/workflows/deep-checks.yml
@@ -11,12 +11,15 @@
 #   fuzz-coverage — per-target libFuzzer region/line coverage over that
 #          accumulated corpus (scripts/fuzz-coverage.sh): a summary table on the
 #          step page and the per-target HTML uploaded. Advisory, not a gate.
-#   kani — every #[kani::proof] harness: the `all` tier of scripts/kani.sh
+#   kani / kani-heavy — every #[kani::proof] harness, as the `light` and `heavy`
+#          tiers of scripts/kani.sh, which partition its `all` roster
 #          (docs/testing.md). The fast tier of that same script runs per-PR in
-#          ci.yml; this row is the one that owes the whole roster, including the
-#          phy round-trip — ~80 min on a hosted runner (2637a20), 27m42s locally,
-#          against a 30m per-harness cap. Kani is not in nixpkgs and its setup
-#          downloads a prebuilt CBMC bundle, so this job is rustup-based, not nix.
+#          ci.yml; these two owe the whole roster between them. They are two jobs
+#          because `rsk-rescue`'s phy round-trip peaks at 11.1 GB and takes the
+#          runner down with it (~80 min on a hosted runner, 2637a20; 55 min and
+#          that peak measured 2026-08-14), so its death costs its own crates only.
+#          Kani is not in nixpkgs and its setup downloads a prebuilt CBMC bundle,
+#          so these jobs are rustup-based, not nix.
 #   repro — `nix build .#firmware` twice (`--rebuild` diffs every output
 #          byte): proves the hermetic image is bit-reproducible and publishes
 #          the canonical sha256 for this flake.lock (docs/build.md).
@@ -34,6 +37,7 @@
 #   nix develop .#fuzz -c ./scripts/fuzz-all.sh   (FUZZ_SECONDS=30 to shorten)
 #   nix develop .#fuzz -c ./scripts/fuzz-coverage.sh
 #   ./scripts/kani.sh all   (needs `cargo install kani-verifier` first — not nix)
+#   ./scripts/kani.sh light   ./scripts/kani.sh heavy   # what the two rows run
 #   nix develop -c cargo llvm-cov --summary-only --fail-under-lines 80 --target <host> --workspace --exclude firmware --exclude rsk-wipe
 #   nix develop -c ./scripts/complexity_gate.sh
 
@@ -218,9 +222,14 @@ jobs:
           command -v cargo-kani >/dev/null || cargo install --locked kani-verifier --version "$KANI_VERSION"
           cargo kani setup
 
-      # The `all` tier: every crate carrying a harness, `rsk-bench` aside
-      # (scripts/kani_gate.py holds that exclusion and its measured reason). The
-      # script also floors the harness count and the `kani::cover!` count, because
+      # `light` + `heavy` = the `all` roster: every crate carrying a harness,
+      # `rsk-bench` aside (scripts/kani_gate.py holds that exclusion and its
+      # measured reason). They are two jobs because `rsk-rescue`'s phy round-trip
+      # peaks at 11.1 GB and takes the runner with it — twice, at 50-58 min,
+      # against this 6 h cap and with the run's other jobs still going. Split, a
+      # death there costs its own crates and not the other sixteen's verdicts.
+      #
+      # The script floors the harness count and the `kani::cover!` count, because
       # a roster that selects nothing exits 0 and so does a cover nothing reaches.
       # `--harness-timeout`, which it passes, is per harness and not per row —
       # Kani runs the rest and fails at the end. It is set to this job's own 6 h,
@@ -228,8 +237,36 @@ jobs:
       # to keep the flag from being unset: a cap that fires on this tier costs more
       # than it saves, because the non-zero exit ends the script at the `tee` and
       # the harness and cover floors below it are never read.
-      - name: prove every harness
-        run: ./scripts/kani.sh all
+      - name: prove every harness but the heavy crate
+        run: ./scripts/kani.sh light
+
+  # The half that can exhaust the runner. Its own job so its death is its own:
+  # see the `HEAVY` comment in `scripts/kani.sh` for the measurement that drew
+  # line, and `rsk-fido`'s 9.3 GiB on the other side of it.
+  kani-heavy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      KANI_VERSION: "0.67.0"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.kani
+            ~/.cargo/bin/cargo-kani
+            ~/.cargo/bin/kani
+            ~/.cargo/registry
+          key: kani-${{ runner.os }}-${{ env.KANI_VERSION }}
+
+      - name: install kani (rustup-based — not packaged in nixpkgs)
+        run: |
+          command -v cargo-kani >/dev/null || cargo install --locked kani-verifier --version "$KANI_VERSION"
+          cargo kani setup
+
+      - name: prove the heavy crate
+        run: ./scripts/kani.sh heavy
   repro:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -241,7 +241,9 @@ shell):
 cargo install --locked kani-verifier --version 0.67.0 && cargo kani setup
 ./scripts/kani.sh pr       # the fast tier — what every pull request runs
 ./scripts/kani.sh state    # rsk-fido + rsk-fs, the security-state sequences
-./scripts/kani.sh all      # every harness; what runs daily
+./scripts/kani.sh all      # every harness — the roster, and the local command
+./scripts/kani.sh light    # all but the heavy crate — one of the two daily rows
+./scripts/kani.sh heavy    # rsk-rescue alone — the other, in its own job
 ```
 
 `scripts/kani.sh` owns the tier → crate table and nothing else does, and it
@@ -286,6 +288,8 @@ run):
 | `pr` | 13 | 50 | 23 | 199 s | `rsk-piv::set_protected_total_and_invariant`, 47 s |
 | `state` | 2 | 8 | 9 | ~10 min | `rsk-fido::…_at_call_site`, ~7 min (9.3 GiB peak) |
 | `all` | 17 | 66 | 31 | ~1 h 45 | `rsk-rescue::serialize_parse_roundtrip`, 27 m 42 s |
+| `light` | 16 | 61 | 30 | ~1 h | `rsk-fido::…_at_call_site`, ~7 min (9.3 GiB peak) |
+| `heavy` | 1 | 5 | 1 | ~55 min | `rsk-rescue::serialize_parse_roundtrip`, 55 min (11.1 GB peak) |
 
 `pr` and `state` are measured runs. `all` has never been run end to end here:
 its cover count is the two measured tiers plus `rsk-rescue`'s one, so

--- a/scripts/kani.sh
+++ b/scripts/kani.sh
@@ -49,6 +49,18 @@ FAST="rsk-sdk rsk-fs rsk-crypto rsk-openpgp rsk-otp rsk-piv rsk-oath rsk-usb rsk
 # and one of them peaks at 9.3 GiB).
 SLOW="rsk-rescue rsk-rsa-asm rsk-mldsa rsk-fido"
 
+# HEAVY: the crates the daily row runs in a job of their own, because their peak
+# solver memory is near what a hosted runner has left over. Measured 2026-08-14:
+# `rsk-rescue`'s phy round-trip peaks at 11.1 GB and the runner dies under it
+# ("received a shutdown signal" at 50-58 min, twice, against a 6 h job cap and
+# with the run's other jobs still going, so neither a timeout nor a cancel);
+# `rsk-fido`'s 9.3 GiB fits, which the `state` row demonstrates on every run. The
+# ceiling therefore sits between the two, and the split is drawn by that number
+# rather than by how long a crate takes. `light` is the rest of `all`: together
+# they are `all`, so nothing stops being proved — one job can now die without
+# taking the other sixteen crates' verdicts with it.
+HEAVY="rsk-rescue"
+
 # STATEFUL: the crates whose proofs are about the security state a reset, a wipe
 # or a torn write can leave behind -- a cross-cut of the two tiers above
 # (rsk-fido is SLOW, rsk-fs is FAST), selected by subject, not by cost. A change
@@ -69,6 +81,10 @@ STATEFUL="rsk-fido rsk-fs"
 FLOOR_pr=50
 FLOOR_state=8
 FLOOR_all=66
+# `light` + `heavy` = `all`, so these two sum to FLOOR_all and the guard checks
+# each against the tree the same way. They are the numbers the daily rows read.
+FLOOR_light=61
+FLOOR_heavy=5
 
 # Source-level `kani::cover!`s each tier must report on. Kani 0.67.0 has no
 # `--fail-uncoverable`, so an unsatisfiable cover prints "N of M cover properties
@@ -80,6 +96,8 @@ FLOOR_all=66
 COVERS_pr=23
 COVERS_state=9
 COVERS_all=31
+COVERS_light=30
+COVERS_heavy=1
 
 # `kani::cover!` properties CBMC may report unsatisfied while their source-level
 # cover is still reached. One `cover!` becomes several properties wherever the
@@ -104,6 +122,21 @@ TIMEOUT_state=30m
 # runner (`2637a20` measured it there). The trade this makes is that one
 # non-convergent proof now consumes the whole 6 h job instead of its own slot.
 TIMEOUT_all=6h
+# Both daily halves inherit that reasoning: a cap that fires costs the row its
+# floors, and the job's own `timeout-minutes` is the real bound either way.
+TIMEOUT_light=6h
+TIMEOUT_heavy=6h
+
+# `all` less `HEAVY`, so the two daily tiers partition it by construction rather
+# than by a second hand-written list that could drift out of step with the first.
+without_heavy() {
+  for c in $FAST $SLOW; do
+    case " $HEAVY " in
+      *" $c "*) ;;
+      *) printf '%s ' "$c" ;;
+    esac
+  done
+}
 
 # The one owner of tier → crates. `--tiers` and the run path both come through
 # here, so a tier the guard is shown is a tier that would actually run.
@@ -112,11 +145,13 @@ crates_of() {
     pr) echo "$FAST" ;;
     state) echo "$STATEFUL" ;;
     all) echo "$FAST $SLOW" ;;
+    heavy) echo "$HEAVY" ;;
+    light) echo "$(without_heavy)" ;;
     *) return 1 ;;
   esac
 }
 
-TIERS="pr state all"
+TIERS="pr state all light heavy"
 
 usage() {
   echo "usage: $0 {${TIERS// /|}} [cargo-kani args…]" >&2

--- a/scripts/kani_gate.py
+++ b/scripts/kani_gate.py
@@ -368,8 +368,16 @@ def audit(root):  # noqa: C901 — one clause per failure mode, each named
             problems.append(
                 f"{use.path} runs `scripts/kani.sh {use.tier}`, which is not a tier"
             )
+    run_by_ci = {u.tier for u in seen if u.executed and u.tier in table}
+    covered = frozenset().union(frozenset(), *(table[t] for t in run_by_ci))
     for tier in sorted(table):
-        if not [u for u in seen if u.tier == tier and u.executed]:
+        # FULL is the roster anchor, not a row of its own: the daily run splits it
+        # into halves so the one that can exhaust the runner's memory takes only
+        # its own crates down. It is satisfied when the rows that DO run prove
+        # every crate it names — and only then. Every other tier still owes a row,
+        # which is what keeps this from becoming a way to retire one quietly.
+        split = tier == FULL and table[tier] <= covered
+        if tier not in run_by_ci and not split:
             problems.append(
                 f"no CI row runs the `{tier}` tier: it is in no step's `run:`, or"
                 " that line is commented out — a tier nobody runs proves nothing"

--- a/scripts/test_kani_gate.py
+++ b/scripts/test_kani_gate.py
@@ -506,3 +506,78 @@ def test_a_reformatted_floor_is_still_read(tree, spelling):
     the number was `None` over a file that plainly prints it."""
     tree.edit(kani_gate.RUNNER, "FLOOR_all=3", spelling)
     assert tree.problems() == []
+
+
+def test_the_full_tier_may_be_split_across_two_rows(tree):
+    """`all` is the anchor, not a row: two halves that partition it satisfy it.
+
+    The daily run splits it because one half can exhaust a hosted runner's
+    memory, and a job that dies should cost only its own crates.
+    """
+    tree.edit(
+        kani_gate.RUNNER,
+        '    all) echo "$FAST $SLOW" ;;',
+        '    all) echo "$FAST $SLOW" ;;\n'
+        '    light) echo "$FAST" ;;\n'
+        '    heavy) echo "$SLOW" ;;',
+    )
+    tree.edit(kani_gate.RUNNER, 'TIERS="pr state all"', 'TIERS="pr state all light heavy"')
+    tree.edit(
+        kani_gate.RUNNER,
+        "FLOOR_all=3\n",
+        "FLOOR_all=3\nFLOOR_light=2\nFLOOR_heavy=1\n",
+    )
+    tree.edit(
+        kani_gate.RUNNER,
+        "COVERS_all=4\n",
+        "COVERS_all=4\nCOVERS_light=3\nCOVERS_heavy=1\n",
+    )
+    tree.edit(
+        kani_gate.PINNED_IN,
+        "        run: ./scripts/kani.sh all",
+        "        run: ./scripts/kani.sh light\n"
+        "      - name: prove the heavy half\n"
+        "        run: ./scripts/kani.sh heavy",
+    )
+    tree.edit(
+        kani_gate.DOCS,
+        "./scripts/kani.sh all\n",
+        "./scripts/kani.sh all\n./scripts/kani.sh light\n./scripts/kani.sh heavy\n",
+    )
+    tree.edit(
+        kani_gate.DOCS,
+        "| `all` | 3 | 3 | 4 | 2 s | `rsk-c::p`, 2 s |\n",
+        "| `all` | 3 | 3 | 4 | 2 s | `rsk-c::p`, 2 s |\n"
+        "| `light` | 2 | 2 | 3 | 1 s | `rsk-a::p`, 1 s |\n"
+        "| `heavy` | 1 | 1 | 1 | 2 s | `rsk-c::p`, 2 s |\n",
+    )
+    assert tree.problems() == []
+
+
+def test_a_split_that_leaves_a_crate_behind_still_fails(tree):
+    """The exemption is exact: halves that do not cover `all` are not a split."""
+    tree.edit(
+        kani_gate.RUNNER,
+        '    all) echo "$FAST $SLOW" ;;',
+        '    all) echo "$FAST $SLOW" ;;\n    light) echo "$FAST" ;;',
+    )
+    tree.edit(kani_gate.RUNNER, 'TIERS="pr state all"', 'TIERS="pr state all light"')
+    tree.edit(kani_gate.RUNNER, "FLOOR_all=3\n", "FLOOR_all=3\nFLOOR_light=2\n")
+    tree.edit(kani_gate.RUNNER, "COVERS_all=4\n", "COVERS_all=4\nCOVERS_light=3\n")
+    tree.edit(
+        kani_gate.PINNED_IN,
+        "        run: ./scripts/kani.sh all",
+        "        run: ./scripts/kani.sh light",
+    )
+    tree.edit(
+        kani_gate.DOCS,
+        "./scripts/kani.sh all\n",
+        "./scripts/kani.sh all\n./scripts/kani.sh light\n",
+    )
+    tree.edit(
+        kani_gate.DOCS,
+        "| `all` | 3 | 3 | 4 | 2 s | `rsk-c::p`, 2 s |\n",
+        "| `all` | 3 | 3 | 4 | 2 s | `rsk-c::p`, 2 s |\n"
+        "| `light` | 2 | 2 | 3 | 1 s | `rsk-a::p`, 1 s |\n",
+    )
+    assert only(tree.problems(), "no CI row runs the `all` tier")


### PR DESCRIPTION
`rsk-rescue`'s phy round-trip peaks at **11.1 GB** of solver memory and a hosted
runner does not have it to spare: the `kani` job was killed twice — at 50 and 58
minutes, "the runner has received a shutdown signal". Not a timeout (6 h cap) and
not a concurrency cancel (the run's other jobs kept going). `rsk-fido`'s 9.3 GiB
fits, which the `state` row shows on every PR, so the ceiling is between them.

The daily roster now runs as two jobs — `light` (every crate but that one) and
`heavy` (that one alone). Their union is `all` by construction: `light` is
computed as `all` less `HEAVY`, not written out twice. Nothing stops being
proved; the half that can die costs its own 5 harnesses instead of the other 61.

The proof stays whole — given a 6 h cap it verifies SUCCESSFUL in 55 min.

`kani_gate.py` demanded a CI row per tier. `all` is the roster anchor and is now
satisfied when the rows that do run cover every crate it names; every other tier
still owes a row. Two mistakes in my own rule were caught by the guard's existing
tests, and both cases are pinned by new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)