### PR TITLE
fix(piv): an RSA key must answer to the only id a standard host can name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,34 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **An RSA-3072 or RSA-4096 PIV key is usable again under Windows' own smart-card
+  minidriver.** 0.4.10 began requiring GENERAL AUTHENTICATE's algorithm byte to
+  equal the one the slot's key was stored under — the reference behaviour, and
+  the fix for a slot whose key the request never named. But SP 800-73 has no id
+  for RSA-3072 or RSA-4096: `0x05` and `0x16` are Yubico's, so a host holding
+  only the standard table cannot name such a key with any byte the card would
+  take. `msclmd.dll`, the PIV minidriver Windows uses when Yubico's is not
+  installed, is exactly that host, and BitLocker unlock through it stopped
+  working ([#79](https://github.com/TheMaxMur/RS-Key/issues/79)).
+
+  Inside the RSA family the byte may now differ. It still chooses neither the key
+  nor its size — both come from the slot — so the body is pinned to the *slot's*
+  modulus, before the touch and before the load: a request naming the family
+  reaches the key, one naming a different key is refused without prompting or
+  spending the PIN freshness. Across families, and between the two EC curves
+  (both of which the standard does name), the exact byte is still required.
+
+  A deliberate divergence, measured on both sides rather than argued: a YubiKey
+  5.7.4 insists on the exact byte — nine P1 values at a provisioned slot, only
+  its own is `9000` — and is itself unusable for an RSA-4096 key under that
+  minidriver, failing with the same `SCARD_E_INVALID_PARAMETER` on the same test.
+  So this is RS-Key working where the reference does not. Found by bisecting six
+  firmware builds against `certutil -scinfo` on real hardware.
+  **bcdDevice → 0x095A.**
+
+
 ## [0.4.10] - 2026-08-14
 
 The conformance release: every applet swept against a real YubiKey 5.7.4, three

--- a/crates/rsk-piv/src/auth.rs
+++ b/crates/rsk-piv/src/auth.rs
@@ -143,11 +143,33 @@ impl<S: Storage> GenAuth<'_, S> {
     /// `6A86`, and `6581` for the RSA arm, whose seal read ran first. Without it
     /// the RSA arm also had no algorithm check at all: an RSA-2048 request at an
     /// RSA-3072 slot loaded the 3072 key and spent before refusing on length.
-    fn algo_is_the_keys(&self) -> Result<(), Sw> {
+    ///
+    /// Inside the RSA family the byte may differ, and has to. SP 800-73 has no id
+    /// for RSA-3072 or RSA-4096 — `0x05`/`0x16` are Yubico's — so a host holding
+    /// only the standard table can name such a key by no byte the card would
+    /// accept, and Windows' own PIV minidriver is exactly that host: it answers
+    /// `SCARD_E_INVALID_PARAMETER` and the key is unusable, which is what issue
+    /// #79 turned out to be. A YubiKey 5.7.4 insists on the exact byte (measured,
+    /// nine cells at a provisioned slot: only its own id is `9000`) and is itself
+    /// unusable for an RSA-4096 key under that minidriver — measured on one, same
+    /// error. So this diverges from the reference deliberately, in the direction
+    /// of the key working.
+    ///
+    /// What the byte still never chooses is the key or its size: both come from
+    /// the slot. That is why the body is pinned to the SLOT's modulus here — the
+    /// relaxation admits a host that names the family, not one that names a
+    /// different key — and why it is judged here rather than at the load, so a
+    /// mismatch still neither prompts for a touch nor spends the freshness.
+    fn algo_is_the_keys(&self, body: &[u8]) -> Result<(), Sw> {
         if self.algo == self.slot_algo {
-            Ok(())
-        } else {
-            Err(Sw::WRONG_DATA)
+            return Ok(());
+        }
+        match (
+            keygen::rsa_size_from_algo(self.algo),
+            keygen::rsa_size_from_algo(self.slot_algo),
+        ) {
+            (Some(_), Some(want)) if body.len() == want => Ok(()),
+            _ => Err(Sw::WRONG_DATA),
         }
     }
 
@@ -234,7 +256,7 @@ impl<S: Storage> GenAuth<'_, S> {
     /// RSA (blinded, CRT-fault-checked), ECDSA over the digest, or PureEdDSA over
     /// the message. Symmetric algos are refused — see the arm's oracle note.
     fn slot_key_op(&mut self, c: &[u8], res: &mut ResBuf) -> Result<(), Sw> {
-        self.algo_is_the_keys()?;
+        self.algo_is_the_keys(c)?;
         match self.algo {
             ALGO_RSA1024 | ALGO_RSA2048 | ALGO_RSA3072 | ALGO_RSA4096 => {
                 check_touch(self.touch_policy, self.presence)?;
@@ -315,7 +337,7 @@ impl<S: Storage> GenAuth<'_, S> {
         if !is_key(self.key_ref) {
             return Err(Sw::WRONG_DATA);
         }
-        self.algo_is_the_keys()?;
+        self.algo_is_the_keys(pp)?;
         if !matches!(self.algo, ALGO_ECCP256 | ALGO_ECCP384 | ALGO_X25519) {
             return Err(Sw::WRONG_DATA);
         }

--- a/crates/rsk-piv/src/tests.rs
+++ b/crates/rsk-piv/src/tests.rs
@@ -7357,3 +7357,216 @@ fn a_one_byte_body_is_the_same_refusal_on_every_command() {
         "MOVE KEY authorised: a destination naming no slot"
     );
 }
+
+/// A GENERAL AUTHENTICATE body: `7C { 82 00, 81 <cryptogram> }`, with whichever
+/// length form the size needs — the RSA cases below straddle the 128-byte
+/// boundary where BER stops using the short form.
+fn rsa_ga_body(cryptogram: &[u8]) -> Vec<u8> {
+    let mut inner = vec![0x82, 0x00, 0x81];
+    if cryptogram.len() < 0x80 {
+        inner.push(cryptogram.len() as u8);
+    } else if cryptogram.len() < 0x100 {
+        inner.extend_from_slice(&[0x81, cryptogram.len() as u8]);
+    } else {
+        inner.extend_from_slice(&[0x82, (cryptogram.len() >> 8) as u8, cryptogram.len() as u8]);
+    }
+    inner.extend_from_slice(cryptogram);
+    let mut out = vec![0x7C];
+    if inner.len() < 0x80 {
+        out.push(inner.len() as u8);
+    } else if inner.len() < 0x100 {
+        out.extend_from_slice(&[0x81, inner.len() as u8]);
+    } else {
+        out.extend_from_slice(&[0x82, (inner.len() >> 8) as u8, inner.len() as u8]);
+    }
+    out.extend_from_slice(&inner);
+    out
+}
+
+/// Naming an RSA key by another RSA algorithm id is accepted; the key and its
+/// size still come from the slot.
+///
+/// SP 800-73 has no id for RSA-3072 or RSA-4096, so a host with only the standard
+/// table cannot name such a key at all — Windows' own PIV minidriver could not,
+/// and answered SCARD_E_INVALID_PARAMETER (issue #79). A YubiKey 5.7.4 insists on
+/// the exact byte and is unusable there for the same reason; this is the
+/// deliberate divergence. The pairing is exercised at RSA-1024 rather than 4096
+/// because the rule is about the family, and a 4096 keygen would put a minute
+/// into every run of this suite.
+#[test]
+fn an_rsa_key_answers_to_another_rsa_algorithm_id() {
+    let rng = RefCell::new(TestRng(11));
+    let pres = RefCell::new(AlwaysConfirm);
+    let mut app = PivApplet::new(SERIAL, HASH, None, &rng, &pres);
+    let mut fs = new_fs();
+    select(&mut app, &mut fs);
+    auth_mgm(&mut app, &mut fs);
+    verify_pin(&mut app, &mut fs);
+    for (slot, algo) in [
+        (SLOT_AUTHENTICATION, ALGO_RSA1024),
+        // 9C is PIN-policy ALWAYS, so whether it still signs is how the
+        // freshness is read back below.
+        (SLOT_SIGNATURE, ALGO_ECCP256),
+    ] {
+        assert_eq!(
+            run(
+                &mut app,
+                &mut fs,
+                INS_ASYM_KEYGEN,
+                0,
+                slot,
+                &gen_template(algo)
+            )
+            .0,
+            Sw::OK
+        );
+    }
+
+    // The slot's own id: unchanged, and the control for the two below.
+    verify_pin(&mut app, &mut fs);
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_AUTHENTICATE,
+        ALGO_RSA1024,
+        SLOT_AUTHENTICATION,
+        &rsa_ga_body(&[0x42u8; 128]),
+    );
+    assert_eq!(sw, Sw::OK, "the slot's own algorithm id still works");
+
+    // Another RSA id, and a cryptogram the size of THIS slot's key: accepted.
+    verify_pin(&mut app, &mut fs);
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_AUTHENTICATE,
+        ALGO_RSA2048,
+        SLOT_AUTHENTICATION,
+        &rsa_ga_body(&[0x42u8; 128]),
+    );
+    assert_eq!(
+        sw,
+        Sw::OK,
+        "an RSA id from the same family must reach the slot's key"
+    );
+
+    // Another RSA id with that id's OWN size: refused. The relaxation admits a
+    // host that names the family, not one that names a different key — the body
+    // is pinned to the slot's modulus, not to the byte.
+    verify_pin(&mut app, &mut fs);
+    let (sw, _) = run(
+        &mut app,
+        &mut fs,
+        INS_AUTHENTICATE,
+        ALGO_RSA2048,
+        SLOT_AUTHENTICATION,
+        &rsa_ga_body(&[0x42u8; 256]),
+    );
+    assert_eq!(
+        sw,
+        Sw::WRONG_DATA,
+        "a cryptogram sized for the named algorithm rather than the slot's key"
+    );
+    // The status word alone does not pin this: without the length check the
+    // request passes the algorithm gate, loads the slot's key and refuses on the
+    // length one line later — same `6A80`, but it has reached the key by then and
+    // spent the freshness (and prompted for a touch). That is what the check buys
+    // and what this reads back. Mutating the pin away turns this line red and
+    // nothing else does.
+    assert_eq!(
+        sign_p256(&mut app, &mut fs, SLOT_SIGNATURE),
+        Sw::OK,
+        "a body refused on length must not have reached the key"
+    );
+}
+
+/// The relaxation is inside the RSA family and nowhere else: it must not let an
+/// RSA request reach an EC key, an EC request reach an RSA key, or one curve
+/// answer for another — and a refusal must still cost neither a touch nor the
+/// PIN freshness, which is the property the exact check was added for.
+#[test]
+fn the_rsa_relaxation_does_not_cross_a_family_or_a_curve() {
+    let rng = RefCell::new(TestRng(13));
+    let pres = RefCell::new(AlwaysConfirm);
+    let mut app = PivApplet::new(SERIAL, HASH, None, &rng, &pres);
+    let mut fs = new_fs();
+    select(&mut app, &mut fs);
+    auth_mgm(&mut app, &mut fs);
+    verify_pin(&mut app, &mut fs);
+    for (slot, algo) in [
+        (SLOT_AUTHENTICATION, ALGO_RSA1024),
+        (SLOT_SIGNATURE, ALGO_ECCP256),
+        (SLOT_KEYMGM, ALGO_ECCP384),
+    ] {
+        assert_eq!(
+            run(
+                &mut app,
+                &mut fs,
+                INS_ASYM_KEYGEN,
+                0,
+                slot,
+                &gen_template(algo)
+            )
+            .0,
+            Sw::OK
+        );
+    }
+
+    // An RSA id at an EC slot, with the EC slot's own digest length.
+    verify_pin(&mut app, &mut fs);
+    let mut ec_body = vec![0x7C, 0x24, 0x82, 0x00, 0x81, 0x20];
+    ec_body.extend_from_slice(&[0x42u8; 32]);
+    assert_eq!(
+        run(
+            &mut app,
+            &mut fs,
+            INS_AUTHENTICATE,
+            ALGO_RSA2048,
+            SLOT_SIGNATURE,
+            &ec_body
+        )
+        .0,
+        Sw::WRONG_DATA,
+        "an RSA id must not reach an EC key"
+    );
+
+    // An EC id at the RSA slot, with that slot's modulus length — the length
+    // agreeing must not carry a request across the family boundary.
+    assert_eq!(
+        run(
+            &mut app,
+            &mut fs,
+            INS_AUTHENTICATE,
+            ALGO_ECCP256,
+            SLOT_AUTHENTICATION,
+            &rsa_ga_body(&[0x42u8; 128])
+        )
+        .0,
+        Sw::WRONG_DATA,
+        "an EC id must not reach an RSA key"
+    );
+
+    // One curve for another stays exact: both ids are in SP 800-73, so no host
+    // needs the leniency and the reference's strictness costs nothing.
+    assert_eq!(
+        run(
+            &mut app,
+            &mut fs,
+            INS_AUTHENTICATE,
+            ALGO_ECCP256,
+            SLOT_KEYMGM,
+            &ec_body
+        )
+        .0,
+        Sw::WRONG_DATA,
+        "P-256 must not answer for a P-384 slot"
+    );
+
+    // None of the three reached a key, so the freshness an ALWAYS slot reads is
+    // still standing.
+    assert_eq!(
+        sign_p256(&mut app, &mut fs, SLOT_SIGNATURE),
+        Sw::OK,
+        "a refused algorithm must not spend the freshness"
+    );
+}

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -690,7 +690,7 @@ async fn main(spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
     // bcdDevice build counter; also surfaced on the trusted-display Firmware screen.
-    let device_release: u16 = 0x0959;
+    let device_release: u16 = 0x095A;
     config.device_release = device_release;
 
     let mut builder = Builder::new(


### PR DESCRIPTION
Fixes #79.

0.4.10 began requiring GENERAL AUTHENTICATE's algorithm byte to equal the slot's
stored one — the reference behaviour, and it closed a real hole. But SP 800-73 has
no id for RSA-3072/4096 (`0x05`/`0x16` are Yubico's), so a host with only the
standard table cannot name such a key at all. `msclmd.dll` — the PIV minidriver
Windows uses when Yubico's is not installed — is that host, and BitLocker unlock
through it broke.

Inside the RSA family the byte may now differ; it still chooses neither the key nor
its size, so the body is pinned to the **slot's** modulus, before the touch and
before the load. Across families and between the two EC curves, exact is still
required.

**Measured on both sides.** A YubiKey 5.7.4 insists on the exact byte (nine P1
values, only its own is `9000`) and is itself unusable for an RSA-4096 key under
that minidriver — same test, same `SCARD_E_INVALID_PARAMETER`. A deliberate
divergence: RS-Key works where the reference does not.

Found by bisecting six firmware builds against `certutil -scinfo` on hardware.
Verified where it broke: OAEP test FAILED → passed, matching 0.4.9 line for line.
Three mutations, each red on exactly one test.

bcdDevice 0x0959 → 0x095A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)