### PR TITLE
ci: deep-checks on two cadences, with matrices for fuzz, miri, kani and mutants

### DIFF
--- a/.github/workflows/deep-checks.yml
+++ b/.github/workflows/deep-checks.yml
@@ -2,24 +2,24 @@
 # Copyright (C) 2026 RS-Key contributors
 
 # Scheduled deep checks — the slow adversarial suites that are deliberately
-# not part of the merge gate (docs/testing.md):
+# not part of the merge gate (docs/testing.md).
+#
+# Two cadences, because the suites no longer fit one. Every row that answers
+# "did today's tree break something" runs daily; the two that answer "how well is
+# this tree tested at all" are weeks-scale questions and run on Sunday, where
+# their runners do not compete with the daily rows.
+#
+# DAILY
 #   miri — fuzz/tests/miri.rs: every fuzz target's logic under Miri's UB
-#          checker. MIRIFLAGS policy comes from the .#fuzz dev shell.
-#   fuzz — a timed libFuzzer pass over every cargo-fuzz target. The corpus
-#          is carried between runs via the actions cache, so its coverage
-#          accumulates day over day; crash artifacts are uploaded.
+#          checker, sharded (scripts/miri-all.sh). MIRIFLAGS policy comes from
+#          the .#fuzz dev shell.
+#   fuzz — a timed libFuzzer pass over every cargo-fuzz target, sharded
+#          (scripts/fuzz-all.sh). The corpus is carried between runs via the
+#          actions cache, so its coverage accumulates day over day; crash
+#          artifacts are uploaded.
 #   fuzz-coverage — per-target libFuzzer region/line coverage over that
 #          accumulated corpus (scripts/fuzz-coverage.sh): a summary table on the
 #          step page and the per-target HTML uploaded. Advisory, not a gate.
-#   kani / kani-heavy — every #[kani::proof] harness, as the `light` and `heavy`
-#          tiers of scripts/kani.sh, which partition its `all` roster
-#          (docs/testing.md). The fast tier of that same script runs per-PR in
-#          ci.yml; these two owe the whole roster between them. They are two jobs
-#          because `rsk-rescue`'s phy round-trip peaks at 11.1 GB and takes the
-#          runner down with it (~80 min on a hosted runner, 2637a20; 55 min and
-#          that peak measured 2026-08-14), so its death costs its own crates only.
-#          Kani is not in nixpkgs and its setup downloads a prebuilt CBMC bundle,
-#          so these jobs are rustup-based, not nix.
 #   repro — `nix build .#firmware` twice (`--rebuild` diffs every output
 #          byte): proves the hermetic image is bit-reproducible and publishes
 #          the canonical sha256 for this flake.lock (docs/build.md).
@@ -27,25 +27,46 @@
 #          a regression alarm on the host-testable surface (the embedded
 #          firmware image is not host-measurable). scripts/metrics.sh is the
 #          separate, un-gated refactor-reconnaissance tool.
-#   complexity — scripts/complexity_gate.sh: cognitive-complexity ceiling over
-#          the crate libraries (rust-code-analysis). A ratchet that catches a
-#          new hotspot the day it lands; the coverage floor's sibling.
 #
-# Runs daily, on demand (workflow_dispatch, with a per-target time knob),
-# and self-tests on any push that edits this file. Local equivalents:
-#   nix develop .#fuzz -c cargo miri test --manifest-path fuzz/Cargo.toml
+# WEEKLY (Sunday)
+#   kani — every #[kani::proof] harness, one runner per tier: the three `light*`
+#          shards and `heavy`, which together are the `all` roster of
+#          `scripts/kani.sh` (docs/testing.md). The fast tier of that same script runs
+#          per-PR in ci.yml; these four owe the whole roster between them. They
+#          are separate jobs for two measured reasons — `rsk-rescue`'s phy
+#          round-trip peaks at 11.1 GB and takes the runner down with it, so its
+#          death costs its own crate only; and the rest, run in one job, cost the
+#          sum of every crate's solving rather than the slowest shard's. Kani is
+#          not in nixpkgs and its setup downloads a prebuilt CBMC bundle, so
+#          these jobs are rustup-based, not nix.
+#   mutants — cargo-mutants over the host crates, sharded
+#          (scripts/mutants-all.sh). Coverage says a line ran; this says a test
+#          would notice if it changed. **Advisory**, for the reason that script
+#          states at length: most survivors are not defects, so a gating row
+#          would be red every week.
+#
+# `complexity` used to be here and is gone: scripts/check.sh already runs
+# scripts/complexity_gate.sh on every pull request, so the row re-proved a merge
+# gate a day later.
+#
+# Runs on both schedules, on demand (workflow_dispatch, with a per-target time
+# knob), and self-tests on any push that edits this file — a dispatch or a push
+# runs BOTH cadences, which is what makes an edit here self-testing. Local
+# equivalents:
+#   nix develop .#fuzz -c ./scripts/miri-all.sh   (MIRI_SHARD=2/3 for one shard)
 #   nix develop .#fuzz -c ./scripts/fuzz-all.sh   (FUZZ_SECONDS=30 to shorten)
 #   nix develop .#fuzz -c ./scripts/fuzz-coverage.sh
 #   ./scripts/kani.sh all   (needs `cargo install kani-verifier` first — not nix)
-#   ./scripts/kani.sh light   ./scripts/kani.sh heavy   # what the two rows run
+#   ./scripts/kani.sh light1   ./scripts/kani.sh heavy   # what the weekly rows run
+#   nix develop -c ./scripts/mutants-all.sh   (MUTANTS_SHARD=2/8 for one shard)
 #   nix develop -c cargo llvm-cov --summary-only --fail-under-lines 80 --target <host> --workspace --exclude firmware --exclude rsk-wipe
-#   nix develop -c ./scripts/complexity_gate.sh
 
 name: deep-checks
 
 on:
   schedule:
     - cron: "17 5 * * *" # 05:17 UTC daily
+    - cron: "41 5 * * 0" # 05:41 UTC Sunday — the weeks-scale rows
   workflow_dispatch:
     inputs:
       fuzz_seconds:
@@ -60,6 +81,9 @@ on:
         "nix/firmware.nix",
         "scripts/fuzz-coverage.sh",
         "scripts/fuzz-all.sh",
+        "scripts/miri-all.sh",
+        "scripts/mutants-all.sh",
+        "scripts/kani.sh",
       ]
 
 permissions:
@@ -69,10 +93,18 @@ concurrency:
   group: deep-checks
   cancel-in-progress: true
 
+# Each job names the cadence it is NOT, rather than the one it is: a scheduled run
+# carries the cron that started it, and a dispatch or a push carries none, so
+# "not the other one" runs everything by hand and everything on an edit.
 jobs:
   miri:
+    if: github.event.schedule != '41 5 * * 0'
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -95,11 +127,18 @@ jobs:
           restore-keys: miri-${{ runner.os }}-
 
       - name: miri — every fuzz target's logic under the UB checker
-        run: nix develop .#fuzz -c cargo miri test --manifest-path fuzz/Cargo.toml
+        run: nix develop .#fuzz -c ./scripts/miri-all.sh
+        env:
+          MIRI_SHARD: ${{ matrix.shard }}/3
 
   fuzz:
+    if: github.event.schedule != '41 5 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -121,11 +160,16 @@ jobs:
           key: fuzz-${{ runner.os }}-${{ hashFiles('fuzz/Cargo.lock', 'flake.lock') }}
           restore-keys: fuzz-${{ runner.os }}-
 
+      # One corpus entry per shard: four jobs cannot write one key, and a shard
+      # only ever fuzzes its own slice of the roster. The slice is positional, so
+      # adding a target shifts the ones after it into a neighbouring shard and
+      # costs them their accumulated inputs once — see the comment in
+      # scripts/fuzz-all.sh for why balance won that trade.
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fuzz/corpus
-          key: fuzz-corpus-${{ github.run_id }}
-          restore-keys: fuzz-corpus-
+          key: fuzz-corpus-s${{ matrix.shard }}-${{ github.run_id }}
+          restore-keys: fuzz-corpus-s${{ matrix.shard }}-
 
       - name: build every fuzz target
         run: nix develop .#fuzz -c cargo fuzz build
@@ -136,16 +180,17 @@ jobs:
       # same image, same minute — the `fuzz-coverage` row below, which already
       # calls its script this way, listed 53 targets while this one listed 0 and
       # tripped its own roster floor. The floor did its job; the shape was wrong.
-      - name: fuzz every target
+      - name: fuzz this shard's targets
         run: nix develop .#fuzz -c ./scripts/fuzz-all.sh
         env:
           FUZZ_SECONDS: ${{ inputs.fuzz_seconds || '120' }}
+          FUZZ_SHARD: ${{ matrix.shard }}/4
 
       - name: upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: fuzz-artifacts-${{ github.run_id }}
+          name: fuzz-artifacts-${{ github.run_id }}-s${{ matrix.shard }}
           path: fuzz/artifacts/
           if-no-files-found: ignore
 
@@ -153,9 +198,10 @@ jobs:
         if: always()
         with:
           path: fuzz/corpus
-          key: fuzz-corpus-${{ github.run_id }}
+          key: fuzz-corpus-s${{ matrix.shard }}-${{ github.run_id }}
 
   fuzz-coverage:
+    if: github.event.schedule != '41 5 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -181,13 +227,32 @@ jobs:
           key: fuzz-cov-${{ runner.os }}-${{ hashFiles('fuzz/Cargo.lock', 'flake.lock') }}
           restore-keys: fuzz-cov-${{ runner.os }}-
 
-      # Read (never write) the corpus the `fuzz` job accumulated on the previous
-      # run: coverage measures those saved inputs, not a fresh fuzzing pass.
+      # Read (never write) the corpora the `fuzz` shards accumulated on the
+      # previous run: coverage measures those saved inputs, not a fresh fuzzing
+      # pass. One restore per shard, because that is how they are stored; they
+      # extract into the same tree and the per-target directories are disjoint.
+      # Restoring only one would measure a quarter of the roster against a floor
+      # written for all of it.
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fuzz/corpus
-          key: fuzz-corpus-${{ github.run_id }}
-          restore-keys: fuzz-corpus-
+          key: fuzz-corpus-s1-${{ github.run_id }}
+          restore-keys: fuzz-corpus-s1-
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: fuzz/corpus
+          key: fuzz-corpus-s2-${{ github.run_id }}
+          restore-keys: fuzz-corpus-s2-
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: fuzz/corpus
+          key: fuzz-corpus-s3-${{ github.run_id }}
+          restore-keys: fuzz-corpus-s3-
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: fuzz/corpus
+          key: fuzz-corpus-s4-${{ github.run_id }}
+          restore-keys: fuzz-corpus-s4-
 
       - name: per-target libFuzzer coverage over the accumulated corpus
         run: nix develop .#fuzz -c ./scripts/fuzz-coverage.sh
@@ -200,74 +265,8 @@ jobs:
           path: fuzz/coverage/*/html
           if-no-files-found: ignore
 
-  kani:
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
-    env:
-      KANI_VERSION: "0.67.0"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.kani
-            ~/.cargo/bin/cargo-kani
-            ~/.cargo/bin/kani
-            ~/.cargo/registry
-          key: kani-${{ runner.os }}-${{ env.KANI_VERSION }}
-
-      - name: install kani (rustup-based — not packaged in nixpkgs)
-        run: |
-          command -v cargo-kani >/dev/null || cargo install --locked kani-verifier --version "$KANI_VERSION"
-          cargo kani setup
-
-      # `light` + `heavy` = the `all` roster: every crate carrying a harness,
-      # `rsk-bench` aside (scripts/kani_gate.py holds that exclusion and its
-      # measured reason). They are two jobs because `rsk-rescue`'s phy round-trip
-      # peaks at 11.1 GB and takes the runner with it — twice, at 50-58 min,
-      # against this 6 h cap and with the run's other jobs still going. Split, a
-      # death there costs its own crates and not the other sixteen's verdicts.
-      #
-      # The script floors the harness count and the `kani::cover!` count, because
-      # a roster that selects nothing exits 0 and so does a cover nothing reaches.
-      # `--harness-timeout`, which it passes, is per harness and not per row —
-      # Kani runs the rest and fails at the end. It is set to this job's own 6 h,
-      # so `timeout-minutes` is the real bound and the per-harness cap exists only
-      # to keep the flag from being unset: a cap that fires on this tier costs more
-      # than it saves, because the non-zero exit ends the script at the `tee` and
-      # the harness and cover floors below it are never read.
-      - name: prove every harness but the heavy crate
-        run: ./scripts/kani.sh light
-
-  # The half that can exhaust the runner. Its own job so its death is its own:
-  # see the `HEAVY` comment in `scripts/kani.sh` for the measurement that drew
-  # line, and `rsk-fido`'s 9.3 GiB on the other side of it.
-  kani-heavy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
-    env:
-      KANI_VERSION: "0.67.0"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.kani
-            ~/.cargo/bin/cargo-kani
-            ~/.cargo/bin/kani
-            ~/.cargo/registry
-          key: kani-${{ runner.os }}-${{ env.KANI_VERSION }}
-
-      - name: install kani (rustup-based — not packaged in nixpkgs)
-        run: |
-          command -v cargo-kani >/dev/null || cargo install --locked kani-verifier --version "$KANI_VERSION"
-          cargo kani setup
-
-      - name: prove the heavy crate
-        run: ./scripts/kani.sh heavy
   repro:
+    if: github.event.schedule != '41 5 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -296,6 +295,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   coverage:
+    if: github.event.schedule != '41 5 * * 0'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -330,9 +330,56 @@ jobs:
             --target x86_64-unknown-linux-gnu \
             --workspace --exclude firmware --exclude rsk-wipe
 
-  complexity:
+  kani:
+    if: github.event.schedule != '17 5 * * *'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 360
+    env:
+      KANI_VERSION: "0.67.0"
+    strategy:
+      fail-fast: false
+      matrix:
+        tier: [light1, light2, light3, heavy]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.kani
+            ~/.cargo/bin/cargo-kani
+            ~/.cargo/bin/kani
+            ~/.cargo/registry
+          key: kani-${{ runner.os }}-${{ env.KANI_VERSION }}
+
+      - name: install kani (rustup-based — not packaged in nixpkgs)
+        run: |
+          command -v cargo-kani >/dev/null || cargo install --locked kani-verifier --version "$KANI_VERSION"
+          cargo kani setup
+
+      # The tier names come from the matrix and the crates from `scripts/kani.sh`;
+      # scripts/kani_gate.py resolves the one to reach the other, and refuses a
+      # `-p` roster written anywhere but that script.
+      #
+      # The script floors the harness count and the `kani::cover!` count, because
+      # a roster that selects nothing exits 0 and so does a cover nothing reaches.
+      # `--harness-timeout`, which it passes, is per harness and not per row —
+      # Kani runs the rest and fails at the end. It is set to this job's own 6 h,
+      # so `timeout-minutes` is the real bound and the per-harness cap exists only
+      # to keep the flag from being unset: a cap that fires on these tiers costs
+      # more than it saves, because the non-zero exit ends the script at the `tee`
+      # and the harness and cover floors below it are never read.
+      - name: prove this tier's harnesses
+        run: ./scripts/kani.sh ${{ matrix.tier }}
+
+  mutants:
+    if: github.event.schedule != '17 5 * * *'
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -343,8 +390,22 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
 
-      # Cognitive-complexity ratchet over the crate libraries — fails on a new
-      # hotspot above the ceiling in scripts/complexity_gate.sh. rust-code-analysis
-      # is pulled ad-hoc (nix shell) and never joins the pinned shell / SBOM.
-      - name: complexity — crate-library cognitive ceiling
-        run: nix develop -c ./scripts/complexity_gate.sh
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: mutants-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: mutants-${{ runner.os }}-
+
+      # 8 shards and 3 jobs each is a first estimate, not a measurement: the sweep
+      # that produced these numbers took 3 h over 13 232 mutants on 18 cores, and
+      # a hosted runner has a small fraction of that. Re-tune both from the first
+      # run's wall time rather than trusting the arithmetic.
+      - name: mutants — would a test notice if this line changed?
+        run: nix develop -c ./scripts/mutants-all.sh
+        env:
+          MUTANTS_SHARD: ${{ matrix.shard }}/8
+          MUTANTS_JOBS: "3"
+          HOST_TARGET: x86_64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,27 @@ tag: the USB `bcdDevice` build counter (bumped on every behavior change), and
 
 ## [Unreleased]
 
+### Changed
+
+- **`deep-checks` runs on two cadences and across matrices.** Miri (3 shards) and
+  the libFuzzer pass (4 shards) stay daily; Kani moves to Sunday as four jobs —
+  the three `light*` shards of `scripts/kani.sh` plus `heavy` — so the roster's
+  wall time is the slowest shard's rather than the sum of seventeen crates'. The
+  `complexity` row is gone: `scripts/check.sh` already runs
+  `scripts/complexity_gate.sh` on every pull request, so it re-proved a merge
+  gate a day later.
+
+- **A weekly `cargo-mutants` sweep, advisory.** Line coverage says a line ran;
+  this says a test would notice if it changed. The first full sweep — 13 232
+  mutants over `crates/` — found `rsk-fido`'s `require_pin_inputs` replaceable by
+  `Ok(())` with the gate green (its removal turns a missing parameter into a
+  panic, and no host test drives that path), and the trusted display's four
+  applet loaders exercised by no test at all. It reports rather than gates:
+  most survivors are not defects — code behind an off `cfg`, a guard a deeper
+  guard masks, a coordinate no test pins on purpose — so a gating row would be
+  red every week. `scripts/mutants-all.sh` fails on its own apparatus instead: a
+  shard that tested nothing, or a run that produced no summary.
+
 ### Fixed
 
 - **An RSA-3072 or RSA-4096 PIV key is usable again under Windows' own smart-card

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -242,8 +242,10 @@ cargo install --locked kani-verifier --version 0.67.0 && cargo kani setup
 ./scripts/kani.sh pr       # the fast tier — what every pull request runs
 ./scripts/kani.sh state    # rsk-fido + rsk-fs, the security-state sequences
 ./scripts/kani.sh all      # every harness — the roster, and the local command
-./scripts/kani.sh light    # all but the heavy crate — one of the two daily rows
-./scripts/kani.sh heavy    # rsk-rescue alone — the other, in its own job
+./scripts/kani.sh light1   # one of the three weekly shards of "all but heavy"
+./scripts/kani.sh light2
+./scripts/kani.sh light3
+./scripts/kani.sh heavy    # rsk-rescue alone, in its own job
 ```
 
 `scripts/kani.sh` owns the tier → crate table and nothing else does, and it
@@ -288,7 +290,9 @@ run):
 | `pr` | 13 | 50 | 23 | 199 s | `rsk-piv::set_protected_total_and_invariant`, 47 s |
 | `state` | 2 | 8 | 9 | ~10 min | `rsk-fido::…_at_call_site`, ~7 min (9.3 GiB peak) |
 | `all` | 17 | 66 | 31 | ~1 h 45 | `rsk-rescue::serialize_parse_roundtrip`, 27 m 42 s |
-| `light` | 16 | 61 | 30 | ~1 h | `rsk-fido::…_at_call_site`, ~7 min (9.3 GiB peak) |
+| `light1` | 4 | 17 | 11 | not yet run | `rsk-fido::…_at_call_site`, ~7 min (9.3 GiB peak) |
+| `light2` | 5 | 21 | 3 | not yet run | `rsk-rsa-asm`'s division spec and sieve |
+| `light3` | 7 | 23 | 16 | not yet run | `rsk-mldsa`'s rounding round-trips |
 | `heavy` | 1 | 5 | 1 | ~55 min | `rsk-rescue::serialize_parse_roundtrip`, 55 min (11.1 GB peak) |
 
 `pr` and `state` are measured runs. `all` has never been run end to end here:
@@ -379,8 +383,8 @@ CI runs the tiers above, from this same script (rustup-based, version pinned,
 `proofs` job runs `pr` on any change under `crates/`, and adds `state` when the
 diff reaches `rsk-fido`, `rsk-fs`, `rsk-store` or `rsk-wipe` — the surface those
 sequence proofs are about (`scripts/ci-scope.sh`, `PROOFS` / `PROOFS_STATE`,
-both covered by its `--self-test`). `deep-checks.yml`'s daily `kani` job runs
-`all`.
+both covered by its `--self-test`). `deep-checks.yml`'s weekly `kani` job runs the
+three `light*` shards and `heavy`, one runner each, which together are `all`.
 
 `scripts/kani_gate.py` is in the merge gate and holds the tiers to their word:
 the `all` tier must be exactly the crates carrying a `#[kani::proof]` less the
@@ -731,18 +735,19 @@ third reader of our CTAP replies, and the only one that claims 2.3.
 `nix develop -c ./scripts/check.sh` plus the `proofs` job — `scripts/kani.sh`,
 which cannot join `check.sh` because Kani is not in the dev shell — plus, on a
 runner with the board attached, the `tests/` scripts. The scheduled
-`deep-checks` workflow is the Miri, fuzz and full-tier Kani commands from this
-page, daily, plus a `repro` job that builds the hermetic firmware twice and
-requires bit-identical outputs
-([build.md](build.md#nix-build-hermetic-no-dev-shell)), an `llvm-cov` job that
-floors host-crate line coverage, and a `complexity` job that ratchets
-crate-library cognitive complexity. No hidden state.
+`deep-checks` workflow runs on two cadences. Daily: the Miri and fuzz commands
+from this page, both sharded across runners, a `repro` job that builds the
+hermetic firmware twice and requires bit-identical outputs
+([build.md](build.md#nix-build-hermetic-no-dev-shell)), and an `llvm-cov` job
+that floors host-crate line coverage. Weekly, on Sunday: the full Kani roster,
+one runner per tier, and an advisory `cargo-mutants` sweep. No hidden state.
 
 ```mermaid
 flowchart TB
     a["Merge gate — every commit / PR<br/>check.sh: fmt · clippy · host tests · firmware builds · size ratchet · audit · deny · vet · gitleaks<br/>proofs: Kani pr tier (+ state tier when the diff reaches it)"]
-    b["Daily — deep-checks<br/>Miri · timed libFuzzer · Kani (all tiers) · repro (bit-identical build) · llvm-cov (coverage floor) · complexity (cognitive ratchet)"]
-    a ~~~ b
+    b["Daily — deep-checks<br/>Miri (3 shards) · timed libFuzzer (4 shards) · repro (bit-identical build) · llvm-cov (coverage floor)"]
+    c["Weekly — deep-checks<br/>Kani: light1 · light2 · light3 · heavy — together the all roster<br/>cargo-mutants (8 shards, advisory)"]
+    a ~~~ b ~~~ c
 ```
 
 ## Refactor metrics (advisory)
@@ -764,7 +769,8 @@ cognitive is a flat serializer (a long `match` that just encodes), not a
 refactor target.
 
 The same signal has a ratcheted, automated sibling. `scripts/complexity_gate.sh`
-runs in `deep-checks` and fails if any crate-library function crosses a
+runs inside `check.sh`, on every pull request, and fails if any crate-library
+function crosses a
 cognitive-complexity ceiling (`COGNITIVE_CEILING`), catching a new hotspot the
 day it lands. Lower the ceiling as the peak falls; raise it only for a justified
 growth, in the same commit. `firmware/` is out of scope: it is embedded glue plus

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -35,6 +35,10 @@
       pkgs.cargo-cyclonedx # CycloneDX SBOM generation (release provenance)
       pkgs.cargo-vet # supply-chain: provenance-of-review (audited dependency set)
       pkgs.cargo-llvm-cov # host-crate line-coverage floor for the daily deep-checks
+      # Mutation testing (scripts/mutants-all.sh, weekly + `--in-diff` by hand).
+      # Coverage says a line ran; this says a test would notice if it changed —
+      # which is the property the `require_pin_inputs` gap was invisible to.
+      pkgs.cargo-mutants
 
       # Documentation site (see scripts/docs.sh): the GitHub Pages source is the
       # docs/ tree rendered by mdBook; mdbook-mermaid renders the diagrams; lychee

--- a/scripts/fuzz-all.sh
+++ b/scripts/fuzz-all.sh
@@ -47,8 +47,43 @@ if [ "${#targets[@]}" -lt "$FUZZ_TARGET_FLOOR" ]; then
   exit 1
 fi
 
+# FUZZ_SHARD=i/k — this runner's slice of the roster, so the row's wall time is
+# the slowest shard's rather than the sum of every target's. Sliced only AFTER the
+# floor above has been checked against the whole list: a per-shard floor would be
+# a second number to re-balance, and the guard it replaced is the one that catches
+# `cargo fuzz list` failing outright.
+FUZZ_SHARD="${FUZZ_SHARD:-1/1}"
+shard_i="${FUZZ_SHARD%%/*}"
+shard_n="${FUZZ_SHARD##*/}"
+if ! [ "$shard_i" -ge 1 ] 2>/dev/null || ! [ "$shard_i" -le "$shard_n" ] 2>/dev/null; then
+  echo "::error::FUZZ_SHARD=$FUZZ_SHARD is not i/k with 1 <= i <= k"
+  exit 1
+fi
+
+# Round-robin over the list, which is balanced by construction. Hashing the name
+# would keep a target on the same shard when the roster changes — the corpus is
+# cached per shard, so a reshuffle costs the moved targets their accumulated
+# inputs — but no cheap hash divides 54 names evenly into both 3 and 4 buckets:
+# `cksum` low bits track the shared prefixes (7/12/10/25 measured), and the safe
+# mixes traded one bad split for another (15/14/20/5). Balance is what this row is
+# sharded for; the corpus is best-effort anyway, living in one LRU-evictable cache
+# entry that has already been dropped once.
+mine=()
+for i in "${!targets[@]}"; do
+  if [ $((i % shard_n)) -eq $((shard_i - 1)) ]; then
+    mine+=("${targets[$i]}")
+  fi
+done
+# A shard with nothing in it exits 0 having fuzzed nothing — the same green-on-zero
+# this script exists to refuse, just one runner at a time.
+if [ "${#mine[@]}" -eq 0 ]; then
+  echo "::error::shard ${FUZZ_SHARD} selected no targets from ${#targets[@]}"
+  exit 1
+fi
+echo "shard ${FUZZ_SHARD}: ${#mine[@]} of ${#targets[@]} targets"
+
 failed=""
-for t in "${targets[@]}"; do
+for t in "${mine[@]}"; do
   echo "::group::${t} (${FUZZ_SECONDS}s)"
   if ! cargo fuzz run "$t" -- -max_total_time="$FUZZ_SECONDS" -print_final_stats=1; then
     failed="$failed $t"
@@ -60,4 +95,4 @@ if [ -n "$failed" ]; then
   echo "::error::crashing targets:$failed"
   exit 1
 fi
-echo "fuzz: ${#targets[@]} targets, ${FUZZ_SECONDS}s each, no crashes"
+echo "fuzz: shard ${FUZZ_SHARD}, ${#mine[@]} of ${#targets[@]} targets, ${FUZZ_SECONDS}s each, no crashes"

--- a/scripts/kani.sh
+++ b/scripts/kani.sh
@@ -13,7 +13,7 @@
 #
 # So: `pr` on every pull request that touches the crates, `state` additionally
 # when the change reaches the security-state surface those proofs are about, and
-# `all` — the union, nothing dropped — daily.
+# `all` — the union, nothing dropped — weekly, as the four shards below.
 #
 # The tier membership lives here and nowhere else. It used to be a hand-written
 # `-p` list repeated in the workflow, in the workflow's own header comment and in
@@ -49,17 +49,55 @@ FAST="rsk-sdk rsk-fs rsk-crypto rsk-openpgp rsk-otp rsk-piv rsk-oath rsk-usb rsk
 # and one of them peaks at 9.3 GiB).
 SLOW="rsk-rescue rsk-rsa-asm rsk-mldsa rsk-fido"
 
-# HEAVY: the crates the daily row runs in a job of their own, because their peak
+# HEAVY: the crates that get a job of their own, because their peak
 # solver memory is near what a hosted runner has left over. Measured 2026-08-14:
 # `rsk-rescue`'s phy round-trip peaks at 11.1 GB and the runner dies under it
 # ("received a shutdown signal" at 50-58 min, twice, against a 6 h job cap and
 # with the run's other jobs still going, so neither a timeout nor a cancel);
 # `rsk-fido`'s 9.3 GiB fits, which the `state` row demonstrates on every run. The
 # ceiling therefore sits between the two, and the split is drawn by that number
-# rather than by how long a crate takes. `light` is the rest of `all`: together
-# they are `all`, so nothing stops being proved — one job can now die without
-# taking the other sixteen crates' verdicts with it.
+# rather than by how long a crate takes. The LIGHT shards below are the rest of
+# `all`, so nothing stops being proved — this job can die without taking the other
+# sixteen crates' verdicts with it.
 HEAVY="rsk-rescue"
+
+# `all` less HEAVY, split three ways, one runner each. It used to be a single row
+# whose wall time was the sum of every crate's solving; three make it the slowest
+# shard's instead, and a shard that dies costs its own crates only — the reasoning
+# that drew HEAVY, applied to time rather than to memory.
+#
+# Balanced by cost, not by crate count: the three expensive crates left after
+# HEAVY (`rsk-fido`'s sequence proofs ~12 min, `rsk-rsa-asm`'s division spec and
+# sieve, `rsk-mldsa`'s rounding round-trips) go one per shard, and the fast crates
+# fill in around them.
+LIGHT1="rsk-fido rsk-ui rsk-piv rsk-oath"
+LIGHT2="rsk-rsa-asm rsk-device rsk-fs rsk-crypto rsk-bip39"
+LIGHT3="rsk-mldsa rsk-led rsk-sdk rsk-openpgp rsk-usb rsk-otp rsk-slip39"
+
+# Three hand-written lists can drift the way `without_heavy()`'s one could not: a
+# crate that gains its first harness joins FAST, and `all`, and no shard at all —
+# proved by nothing, while every floor still adds up because the floors are the
+# shards' own. Refuse to run rather than trust that arithmetic.
+assert_light_partition() {
+  local want got
+  # `sort -u` on the shards, so this compares sets and leaves the duplicate case
+  # to the count below. Without it a repeated crate makes the strings differ here
+  # and that check never runs — it was dead code the first time this was written.
+  want="$(without_heavy | tr ' ' '\n' | grep -v '^$' | sort)"
+  got="$(echo "$LIGHT1 $LIGHT2 $LIGHT3" | tr ' ' '\n' | grep -v '^$' | sort -u)"
+  if [ "$want" != "$got" ]; then
+    echo "FAIL: LIGHT1+LIGHT2+LIGHT3 is not \`all\` less HEAVY." >&2
+    echo "      only in all-less-heavy: $(comm -23 <(echo "$want") <(echo "$got") | xargs)" >&2
+    echo "      only in shards:        $(comm -13 <(echo "$want") <(echo "$got") | xargs)" >&2
+    exit 2
+  fi
+  # `comm` above is blind to a crate listed in two shards: the sorted sets still
+  # match while one shard proves it twice and its sibling's floor comes up short.
+  if [ "$(echo "$LIGHT1 $LIGHT2 $LIGHT3" | wc -w)" -ne "$(echo "$want" | wc -w)" ]; then
+    echo "FAIL: a crate appears in more than one LIGHT shard." >&2
+    exit 2
+  fi
+}
 
 # STATEFUL: the crates whose proofs are about the security state a reset, a wipe
 # or a torn write can leave behind -- a cross-cut of the two tiers above
@@ -81,10 +119,13 @@ STATEFUL="rsk-fido rsk-fs"
 FLOOR_pr=50
 FLOOR_state=8
 FLOOR_all=66
-# `light` + `heavy` = `all`, so these two sum to FLOOR_all and the guard checks
-# each against the tree the same way. They are the numbers the daily rows read.
-FLOOR_light=61
+# The four weekly rows partition `all`, so these sum to FLOOR_all and the guard
+# checks each against the tree the same way. A harness that moves between shards
+# has to move a number with it.
 FLOOR_heavy=5
+FLOOR_light1=17
+FLOOR_light2=21
+FLOOR_light3=23
 
 # Source-level `kani::cover!`s each tier must report on. Kani 0.67.0 has no
 # `--fail-uncoverable`, so an unsatisfiable cover prints "N of M cover properties
@@ -96,8 +137,10 @@ FLOOR_heavy=5
 COVERS_pr=23
 COVERS_state=9
 COVERS_all=31
-COVERS_light=30
 COVERS_heavy=1
+COVERS_light1=11
+COVERS_light2=3
+COVERS_light3=16
 
 # `kani::cover!` properties CBMC may report unsatisfied while their source-level
 # cover is still reached. One `cover!` becomes several properties wherever the
@@ -122,10 +165,12 @@ TIMEOUT_state=30m
 # runner (`2637a20` measured it there). The trade this makes is that one
 # non-convergent proof now consumes the whole 6 h job instead of its own slot.
 TIMEOUT_all=6h
-# Both daily halves inherit that reasoning: a cap that fires costs the row its
+# Every weekly row inherits that reasoning: a cap that fires costs the row its
 # floors, and the job's own `timeout-minutes` is the real bound either way.
-TIMEOUT_light=6h
 TIMEOUT_heavy=6h
+TIMEOUT_light1=6h
+TIMEOUT_light2=6h
+TIMEOUT_light3=6h
 
 # `all` less `HEAVY`, so the two daily tiers partition it by construction rather
 # than by a second hand-written list that could drift out of step with the first.
@@ -146,12 +191,19 @@ crates_of() {
     state) echo "$STATEFUL" ;;
     all) echo "$FAST $SLOW" ;;
     heavy) echo "$HEAVY" ;;
-    light) echo "$(without_heavy)" ;;
+    light1) echo "$LIGHT1" ;;
+    light2) echo "$LIGHT2" ;;
+    light3) echo "$LIGHT3" ;;
     *) return 1 ;;
   esac
 }
 
-TIERS="pr state all light heavy"
+# Unconditionally, not from inside `crates_of`: there it would run in the `$( )`
+# of the `--tiers` loop, whose exit status that line discards — the guard reads
+# `--tiers`, so a broken partition has to fail it too.
+assert_light_partition
+
+TIERS="pr state all light1 light2 light3 heavy"
 
 usage() {
   echo "usage: $0 {${TIERS// /|}} [cargo-kani args…]" >&2

--- a/scripts/kani_gate.py
+++ b/scripts/kani_gate.py
@@ -96,7 +96,16 @@ PINNED = re.compile(r'KANI_VERSION:\s*"([\d.]+)"')
 DOC_PIN = re.compile(r"kani-verifier --version ([\d.]+)")
 
 #: An invocation of the tier runner, with or without a `./` and whatever drives it.
-INVOKED = re.compile(r"(?<![\w/-])(?:\./)?scripts/kani\.sh\s+(\S+)")
+#: The tier may be spelled out or come from a matrix — `${{ … }}` is captured
+#: whole so it can be resolved below rather than read as a tier named `${{`.
+INVOKED = re.compile(r"(?<![\w/-])(?:\./)?scripts/kani\.sh\s+(\$\{\{[^}]*\}\}|\S+)")
+
+#: The matrix reference the weekly row names its tier with.
+MATRIX_REF = re.compile(r"\$\{\{\s*matrix\.(\w+)\s*\}\}\Z")
+#: `key: [a, b]`, and the `key:` / `- a` block form, inside a `matrix:` block.
+MATRIX_INLINE = re.compile(r"^(\w+):\s*\[([^\]]*)\]\s*$")
+MATRIX_KEY = re.compile(r"^(\w+):\s*$")
+MATRIX_ITEM = re.compile(r"^-\s*[\"']?([\w.-]+)[\"']?\s*$")
 
 #: The two shapes the floors are counts of. Every one in this tree is written
 #: exactly like this, `#[kani::proof]` alone on its line.
@@ -155,18 +164,86 @@ def statements(text, yaml):
             yield body, False
 
 
+def matrices(text):
+    """(key → the values a `strategy.matrix` gives it, keys declared twice over).
+
+    Syntactic, like the rest of this guard: the dev shell has no YAML parser, and
+    a second way of reading a workflow would be a second answer to what CI runs.
+    A key declared twice with different values is reported rather than merged —
+    the wrong guess is a tier counted as proved by a job that does not prove it.
+
+    `include:` entries (`- tier: light1`) are deliberately not read: they carry a
+    colon, no rule below matches them, and the tier then reads as run by nobody.
+    That is the safe direction — it fails loudly instead of passing quietly.
+    """
+    table, conflicts = {}, set()
+    block, matrix_indent, key = {}, None, None
+
+    def close():
+        # One `matrix:` block at a time, merged only when it ends: reading the
+        # accumulating `- item` form straight into `table` would make a second
+        # job's differing matrix look like a continuation of the first's.
+        for name, values in block.items():
+            if name in table and table[name] != values:
+                conflicts.add(name)
+            table[name] = values
+        block.clear()
+
+    for indent, body in gate_lines.logical_lines(text):
+        if not body or body.startswith("#"):
+            continue
+        if matrix_indent is not None and indent <= matrix_indent:
+            close()
+            matrix_indent, key = None, None
+        if body.rstrip() == "matrix:":
+            matrix_indent, key = indent, None
+            continue
+        if matrix_indent is None:
+            continue
+        if found := MATRIX_INLINE.match(body):
+            key = found.group(1)
+            block[key] = tuple(
+                v.strip().strip("\"'") for v in found.group(2).split(",") if v.strip()
+            )
+        elif found := MATRIX_KEY.match(body):
+            key = found.group(1)
+        elif (found := MATRIX_ITEM.match(body)) and key:
+            block[key] = block.get(key, ()) + (found.group(1),)
+    close()
+    return table, conflicts
+
+
+def referenced_keys(text):
+    """The `matrix.<key>` names a tier runner on `text` takes its tier from."""
+    return {
+        ref.group(1)
+        for found in INVOKED.finditer(text)
+        if (ref := MATRIX_REF.match(found.group(1)))
+    }
+
+
 def uses(rel, text, yaml):
     """Every `scripts/kani.sh <tier>` on `text`, flagged executed or not.
 
     Executed means inside a step's `run:` scalar *and* left of the `#` — the only
     copy a job runs. A prose or comment copy is a quotation of it. Documentation
     is never executed, whatever it looks like.
+
+    A tier named `${{ matrix.<key> }}` expands to that key's values: the weekly
+    row proves one tier per runner, and which tiers those are is in the matrix,
+    not on the `run:` line.
     """
+    table = matrices(text)[0] if yaml else {}
     for body, in_run in statements(text, yaml):
         live, quoted = gate_lines.split_at_comment(body)
         for segment, executed in ((live, in_run), (quoted, False)):
             for found in INVOKED.finditer(segment):
-                yield Use(rel, found.group(1), executed)
+                ref = MATRIX_REF.match(found.group(1))
+                if ref is None:
+                    yield Use(rel, found.group(1), executed)
+                    continue
+                for value in table.get(ref.group(1), ()):
+                    yield Use(rel, value, executed)
 
 
 def handwritten(rel, text, yaml):
@@ -350,6 +427,17 @@ def audit(root):  # noqa: C901 — one clause per failure mode, each named
     harnesses, covers, orphans, unseen = crates_with_proofs(root)
     proven = set(harnesses)
     problems = []
+    # Only for a key a `scripts/kani.sh ${{ matrix.… }}` actually names: the fuzz,
+    # miri and mutants rows all shard on a `matrix.shard` of their own, and their
+    # differing lists say nothing about what Kani proves.
+    for rel, text, yaml in found:
+        if yaml:
+            conflicts = matrices(text)[1] & referenced_keys(text)
+            for key in sorted(conflicts):
+                problems.append(
+                    f"{rel} declares `matrix.{key}` twice with different values; "
+                    "which tiers a row proves would be a guess"
+                )
 
     for line in unseen:
         problems.append(

--- a/scripts/miri-all.sh
+++ b/scripts/miri-all.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+# Every fuzz target's logic under Miri's UB checker — the deep-checks `miri` row.
+#
+#   nix develop .#fuzz -c ./scripts/miri-all.sh
+#   MIRI_SHARD=2/4 nix develop .#fuzz -c ./scripts/miri-all.sh
+#
+# A file rather than an inline `run:`, for the reason `scripts/fuzz-all.sh` states
+# at length: that form loses the dev shell's PATH on a GitHub runner and `cargo`
+# falls through to the image's rustup shim.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MANIFEST=fuzz/Cargo.toml
+
+# The roster floor, same shape and same reason as `scripts/fuzz-all.sh`: a filter
+# that matches nothing prints "0 passed" and exits 0. Measured on this tree's own
+# harness — `cargo test -- --exact a b` with two names selects **zero** tests and
+# returns 0, which is why the shard below is expressed as `--skip` (repeatable,
+# and verified to subtract) and not as a list of names to run.
+#
+# 49 distinct tests over the workspace's three test targets — `tests/miri.rs` (43),
+# `tests/apdu_frame.rs` and `tests/churn_compaction.rs` — measured 2026-08-15.
+# A literal, not `${MIRI_TEST_FLOOR:-49}`: a floor the environment can lower is
+# not a floor. Raise it in the commit that adds a test.
+MIRI_TEST_FLOOR=49
+
+if ! cargo miri --version >/dev/null 2>&1; then
+  echo "FAIL: cargo-miri is not on PATH — this is not the .#fuzz dev shell." >&2
+  echo "      cargo:     $(command -v cargo || echo '(none)')" >&2
+  echo "      run it as: nix develop .#fuzz -c $0" >&2
+  exit 1
+fi
+
+# Listed by Miri's own build, not by a native `cargo test --list`: a `cfg(miri)`
+# test exists in one and not the other, and the roster has to be the one that runs.
+#
+# `sort -u` is load-bearing. The dev shell sets `-Zmiri-many-seeds=0..8`, so Miri
+# re-executes each test binary once per seed and `--list` prints the whole roster
+# eight times over — 392 lines for 49 tests, measured. Without the dedup the shards
+# would be slices of a list with eight copies of everything.
+mapfile -t tests < <(cargo miri test --manifest-path "$MANIFEST" -- --list 2>/dev/null | sed -n 's/: test$//p' | sort -u)
+
+echo "roster: ${#tests[@]} tests (floor ${MIRI_TEST_FLOOR})"
+if [ "${#tests[@]}" -lt "$MIRI_TEST_FLOOR" ]; then
+  echo "::error::--list yielded ${#tests[@]} tests, under the ${MIRI_TEST_FLOOR} floor — the roster shrank or the list failed"
+  exit 1
+fi
+
+MIRI_SHARD="${MIRI_SHARD:-1/1}"
+shard_i="${MIRI_SHARD%%/*}"
+shard_n="${MIRI_SHARD##*/}"
+if ! [ "$shard_i" -ge 1 ] 2>/dev/null || ! [ "$shard_i" -le "$shard_n" ] 2>/dev/null; then
+  echo "::error::MIRI_SHARD=$MIRI_SHARD is not i/k with 1 <= i <= k"
+  exit 1
+fi
+
+# Round-robin, and expressed as everything-but-mine: one Miri process per shard
+# instead of one per test, because Miri re-interprets std's startup on every
+# process and that cost would dwarf the tests on a shard this size.
+skip=()
+mine=0
+for i in "${!tests[@]}"; do
+  if [ $((i % shard_n)) -eq $((shard_i - 1)) ]; then
+    mine=$((mine + 1))
+  else
+    skip+=(--skip "${tests[$i]}")
+  fi
+done
+if [ "$mine" -eq 0 ]; then
+  echo "::error::shard ${MIRI_SHARD} selected no tests from ${#tests[@]}"
+  exit 1
+fi
+echo "shard ${MIRI_SHARD}: ${mine} of ${#tests[@]} tests"
+
+# What the shard will actually run, asked of the same lister that built the
+# roster. `--list` honours `--skip` (25 -> 23 on a scratch crate, measured), so a
+# skip name that stopped matching shows up HERE, before the run is spent, and a
+# stale list can no longer quietly widen or narrow a shard.
+#
+# This replaces counting what the run reported, which cannot be done: the eight
+# seed processes write to one stdout concurrently and shred each other's lines —
+# `test result: test result: okokokok. 0 passed;` is verbatim from a run that
+# passed. `scripts/kani.sh` refuses `--jobs` over the same hazard.
+selected="$(cargo miri test --manifest-path "$MANIFEST" -- --list ${skip[@]+"${skip[@]}"} 2>/dev/null | sed -n 's/: test$//p' | sort -u | wc -l | tr -d ' ')"
+if [ "${selected:-0}" -ne "$mine" ]; then
+  echo "::error::shard ${MIRI_SHARD} selects ${selected:-0} tests, expected ${mine} — a --skip name no longer matches"
+  exit 1
+fi
+
+cargo miri test --manifest-path "$MANIFEST" -- ${skip[@]+"${skip[@]}"}
+echo "miri: shard ${MIRI_SHARD}, ${mine} of ${#tests[@]} tests, no UB"

--- a/scripts/mutants-all.sh
+++ b/scripts/mutants-all.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 RS-Key contributors
+
+# Mutation testing over the host crates — the weekly deep-checks `mutants` row.
+#
+#   nix develop -c ./scripts/mutants-all.sh
+#   MUTANTS_SHARD=2/8 nix develop -c ./scripts/mutants-all.sh
+#
+# Coverage says a line ran. This says a test would notice if that line changed,
+# which is a different question and the one this tree keeps getting wrong: the
+# first full sweep (13 232 mutants, 2026-08-15) found `require_pin_inputs`
+# replaceable by `Ok(())` with the gate green, and the trusted display's four
+# applet loaders driven by no test at all.
+#
+# **Advisory.** It reports; it does not gate. 3247 of that first sweep's mutants
+# survived and most are not defects — code behind an off `cfg`, a guard a deeper
+# guard masks, a coordinate no test pins on purpose — so a gating row would be red
+# every week, and a row that is always red is a row nobody reads. It becomes a
+# gate when the survivors have been triaged and an accepted-survivor baseline
+# exists to diff against. What this row DOES fail on is its own apparatus: a shard
+# that tested nothing, or a run that produced no summary at all.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+HOST="${HOST_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
+OUT="${MUTANTS_OUT:-target/mutants}"
+
+# Measured 13 232 on 2026-08-15 over these crates. A floor with margin, not a
+# ratchet: its job is to catch a selection that collapsed — a `-p` roster that
+# stopped matching, an exclude glob that ate the tree — not to police the count,
+# which moves with every commit.
+MUTANT_FLOOR=10000
+
+if ! command -v cargo-mutants >/dev/null; then
+  echo "FAIL: cargo-mutants is not on PATH — this is not the dev shell." >&2
+  echo "      run it as: nix develop -c $0" >&2
+  exit 1
+fi
+
+# The roster, derived rather than hand-written: a new crate joins by existing.
+# `firmware` and `rsk-wipe` are absent for the reason `scripts/check.sh` excludes
+# them from every host row — they are `no_std` and do not build here.
+packages=()
+for dir in crates/*/; do
+  packages+=(-p "$(basename "$dir")")
+done
+
+# Two exclusions, each for a measured reason (see the sweep's triage):
+#   --target        the workspace default is thumbv8m, where no test runs at all
+#   -e **/*kani.rs  `#[cfg(kani)]` code `cargo test` never builds, so every
+#                   mutation in it survives and means nothing
+# `#[cfg(test)]` modules need no exclusion — cargo-mutants already skips them.
+common=(
+  "${packages[@]}"
+  -C "--target=$HOST"
+  -e '**/kani.rs'
+  -e '**/*_kani.rs'
+)
+
+# `|| true` because `grep -c` exits 1 on zero matches, and with `set -e` that
+# would end the script here — before the floor below could say why.
+total="$(cargo-mutants mutants --list "${common[@]}" | grep -cE '^crates/' || true)"
+echo "roster: ${total} mutants (floor ${MUTANT_FLOOR})"
+if [ "$total" -lt "$MUTANT_FLOOR" ]; then
+  echo "::error::--list yielded ${total} mutants, under the ${MUTANT_FLOOR} floor — the package roster or an exclude glob collapsed"
+  exit 1
+fi
+
+MUTANTS_SHARD="${MUTANTS_SHARD:-1/1}"
+shard_i="${MUTANTS_SHARD%%/*}"
+shard_n="${MUTANTS_SHARD##*/}"
+if ! [ "$shard_i" -ge 1 ] 2>/dev/null || ! [ "$shard_i" -le "$shard_n" ] 2>/dev/null; then
+  echo "::error::MUTANTS_SHARD=$MUTANTS_SHARD is not i/k with 1 <= i <= k"
+  exit 1
+fi
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+# `|| true` deliberately: cargo-mutants exits non-zero when mutants survive, and
+# on this row that is the expected outcome rather than a failure. The summary line
+# below is what says the run happened, so a crash cannot pass as "none survived".
+cargo-mutants mutants "${common[@]}" \
+  --shard "$MUTANTS_SHARD" -j "${MUTANTS_JOBS:-4}" --output "$OUT" 2>&1 | tee "$log" || true
+
+summary="$(grep -E '^[0-9]+ mutants tested' "$log" | tail -1 || true)"
+if [ -z "$summary" ]; then
+  echo "::error::shard ${MUTANTS_SHARD} produced no summary line — the run did not finish"
+  exit 1
+fi
+tested="${summary%% *}"
+if [ "$tested" -eq 0 ]; then
+  echo "::error::shard ${MUTANTS_SHARD} tested 0 of ${total} mutants"
+  exit 1
+fi
+
+echo "mutants: shard ${MUTANTS_SHARD}, ${summary}"
+{
+  echo "### mutants shard ${MUTANTS_SHARD}"
+  echo
+  echo '```'
+  echo "$summary"
+  echo '```'
+  echo
+  echo "Advisory row — survivors are triaged by hand, not gated. See docs/testing.md."
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/scripts/test_kani_gate.py
+++ b/scripts/test_kani_gate.py
@@ -249,6 +249,84 @@ def test_the_header_comment_alone_does_not_count(tree):
     assert only(tree.problems(), "no CI row runs the `all` tier")
 
 
+def split_tiers(tree, rows):
+    """Give the fixture a `light`/`heavy` partition of `all`, run by `rows`.
+
+    The matrix tests below all need the same two-tier tree and differ only in the
+    workflow that drives it, which is the thing under test.
+    """
+    tree.edit(
+        kani_gate.RUNNER,
+        '    all) echo "$FAST $SLOW" ;;',
+        '    all) echo "$FAST $SLOW" ;;\n'
+        '    light) echo "$FAST" ;;\n'
+        '    heavy) echo "$SLOW" ;;',
+    )
+    tree.edit(kani_gate.RUNNER, 'TIERS="pr state all"', 'TIERS="pr state all light heavy"')
+    tree.edit(kani_gate.RUNNER, "FLOOR_all=3\n", "FLOOR_all=3\nFLOOR_light=2\nFLOOR_heavy=1\n")
+    tree.edit(kani_gate.RUNNER, "COVERS_all=4\n", "COVERS_all=4\nCOVERS_light=3\nCOVERS_heavy=1\n")
+    tree.edit(kani_gate.PINNED_IN, "        run: ./scripts/kani.sh all", rows)
+    tree.edit(
+        kani_gate.DOCS,
+        "./scripts/kani.sh all\n",
+        "./scripts/kani.sh all\n./scripts/kani.sh light\n./scripts/kani.sh heavy\n",
+    )
+    tree.edit(
+        kani_gate.DOCS,
+        "| `all` | 3 | 3 | 4 | 2 s | `rsk-c::p`, 2 s |\n",
+        "| `all` | 3 | 3 | 4 | 2 s | `rsk-c::p`, 2 s |\n"
+        "| `light` | 2 | 2 | 3 | 1 s | `rsk-a::p`, 1 s |\n"
+        "| `heavy` | 1 | 1 | 1 | 2 s | `rsk-c::p`, 2 s |\n",
+    )
+
+
+MATRIX_ROW = (
+    "        run: ./scripts/kani.sh ${{ matrix.tier }}\n"
+    "    strategy:\n"
+    "      matrix:\n"
+    "        tier: [light, heavy]"
+)
+
+
+def test_a_tier_named_by_a_matrix_counts_as_run(tree):
+    """One runner per tier: the tier is in the matrix, not on the `run:` line.
+
+    Read literally, that line names a tier called `${{` and every real tier reads
+    as run by nobody — the guard would fail a workflow that proves everything.
+    """
+    split_tiers(tree, MATRIX_ROW)
+    assert tree.problems() == []
+
+
+def test_a_tier_the_matrix_omits_is_not_run(tree):
+    """The expansion is the roster: dropping a value drops the tier with it."""
+    split_tiers(tree, MATRIX_ROW.replace("[light, heavy]", "[light]"))
+    assert "no CI row runs the `heavy` tier" in " ".join(tree.problems())
+
+
+def test_a_matrix_key_declared_twice_is_refused(tree):
+    """Two rows, two meanings for `matrix.tier`, and no way to tell which proves what."""
+    split_tiers(
+        tree,
+        MATRIX_ROW + "\n  other:\n    strategy:\n      matrix:\n        tier: [pr]",
+    )
+    assert "declares `matrix.tier` twice" in " ".join(tree.problems())
+
+
+def test_an_unrelated_matrix_key_may_differ_between_rows(tree):
+    """Only a key a tier runner names is a tier: the fuzz, miri and mutants rows
+    each shard on a `matrix.shard` of their own, and their differing lists say
+    nothing about what Kani proves. Reported as a conflict, they made a correct
+    workflow fail — measured on the real one, which has three."""
+    split_tiers(
+        tree,
+        MATRIX_ROW
+        + "\n  fuzz:\n    strategy:\n      matrix:\n        shard: [1, 2]"
+        + "\n  miri:\n    strategy:\n      matrix:\n        shard: [1, 2, 3]",
+    )
+    assert tree.problems() == []
+
+
 def test_a_row_naming_a_tier_that_does_not_exist(tree):
     tree.edit(
         kani_gate.WORKFLOWS / "ci.yml",


### PR DESCRIPTION
Rebuilds `deep-checks` around two cadences and four matrices, so the rows stop
racing their own timeouts.

**Daily** — miri (3 shards), fuzz (4 shards), fuzz-coverage, repro, coverage.
**Weekly, Sunday** — kani (one runner per tier) and an advisory cargo-mutants
sweep. Each job names the cadence it is *not*, so a dispatch or a push carries no
cron and runs both; an edit to the workflow still self-tests.

`complexity` is deleted, not rescheduled: `scripts/check.sh:491` already runs
`scripts/complexity_gate.sh` on every pull request.

### Three things that had to be measured first

- **`cargo test -- --exact a b` with two names selects ZERO tests and exits 0.**
  So a Miri shard is a list of `--skip`s, which is repeatable and verified to
  subtract (25 → 23).
- **`-Zmiri-many-seeds=0..8` makes a Miri run unparseable.** Eight seed processes
  share one stdout and shred each other: `test result: test result: okokokok. 0
  passed;` is verbatim from a run that *passed*, and `--list` prints the roster
  eight times (392 lines for 49 tests). `scripts/kani.sh` refuses `--jobs` over
  the same hazard. The shard's selection is therefore checked against the lister,
  before the run is spent — never against the run's output.
- **No cheap hash splits 54 fuzz targets evenly** into both 3 and 4 buckets, and
  the multiplicative mix overflowed bash's signed 64-bit into negative shard
  numbers. Positional round-robin, balanced by construction.

### Guards

`light` is gone as a tier; `light1`/`light2`/`light3` replace it, balanced by
cost, with floors verified against the tree. `assert_light_partition` refuses a
gap, a stray or a duplicate. `scripts/kani_gate.py` learned to resolve
`${{ matrix.tier }}` — without it every tier reads as run by nobody.

Each new guard ships with a mutation table that was actually run: the tier split
(3 mutations), the matrix resolution (3), the Miri shard selection (3). They
caught six defects in this change, including a duplicate check that was dead code
and the overflow above.

### Verified / not verified

Gate green twice (`ALL CHECKS PASSED`), `kani_gate` 56/56 including four new
tests, YAML parsed, the mutants roster reproduces the sweep's 13 232, and one
Miri shard was run end to end through all eight seeds.

**No workflow row has run on a runner.** Merging is what triggers the push
self-test — every path it watches is touched — and that is the point of this
merge. The mutants sizing (8 shards × 3 jobs) is an estimate from an 18-core
sweep, labelled as one in the file, to be re-tuned from the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
