### PR TITLE
fix(ci): three defects the first deep-checks run found

### DIFF
--- a/scripts/fuzz-coverage.sh
+++ b/scripts/fuzz-coverage.sh
@@ -49,7 +49,15 @@ if [ "${#targets[@]}" -eq 0 ]; then
 fi
 # The numbers below are only as good as the corpus behind them, and in CI that
 # corpus is one evictable cache entry.
-inputs=$(find fuzz/corpus -type f 2>/dev/null | wc -l)
+# Guarded by `-d`, not by `2>/dev/null`. With no corpus directory at all `find`
+# exits 1, `pipefail` makes that the pipeline's status, and `set -e` killed this
+# script here — before the "no corpus" branch below could exit 0 politely. Silent,
+# because the redirect ate the only message. The branch below was written for an
+# EMPTY corpus; a MISSING one never reached it, and the two differ by `pipefail`.
+inputs=0
+if [ -d fuzz/corpus ]; then
+  inputs=$(find fuzz/corpus -type f | wc -l | tr -d ' ')
+fi
 echo "${#targets[@]} target(s), corpus: ${inputs} inputs"
 
 summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"

--- a/scripts/miri-all.sh
+++ b/scripts/miri-all.sh
@@ -60,6 +60,12 @@ fi
 # Round-robin, and expressed as everything-but-mine: one Miri process per shard
 # instead of one per test, because Miri re-interprets std's startup on every
 # process and that cost would dwarf the tests on a shard this size.
+#
+# `--exact` is not decoration. `--skip` matches by SUBSTRING, and this roster has
+# four containment pairs — `miri_ctaphid` inside `miri_ctaphid_roundtrip`,
+# `miri_fido_cred` inside three more — so skipping a neighbouring shard's test
+# silently took two of this one's with it. Shard 1/3 selected 15 where it owed 17,
+# on the first run that reached a runner.
 skip=()
 mine=0
 for i in "${!tests[@]}"; do
@@ -84,11 +90,11 @@ echo "shard ${MIRI_SHARD}: ${mine} of ${#tests[@]} tests"
 # seed processes write to one stdout concurrently and shred each other's lines —
 # `test result: test result: okokokok. 0 passed;` is verbatim from a run that
 # passed. `scripts/kani.sh` refuses `--jobs` over the same hazard.
-selected="$(cargo miri test --manifest-path "$MANIFEST" -- --list ${skip[@]+"${skip[@]}"} 2>/dev/null | sed -n 's/: test$//p' | sort -u | wc -l | tr -d ' ')"
+selected="$(cargo miri test --manifest-path "$MANIFEST" -- --list --exact ${skip[@]+"${skip[@]}"} 2>/dev/null | sed -n 's/: test$//p' | sort -u | wc -l | tr -d ' ')"
 if [ "${selected:-0}" -ne "$mine" ]; then
   echo "::error::shard ${MIRI_SHARD} selects ${selected:-0} tests, expected ${mine} — a --skip name no longer matches"
   exit 1
 fi
 
-cargo miri test --manifest-path "$MANIFEST" -- ${skip[@]+"${skip[@]}"}
+cargo miri test --manifest-path "$MANIFEST" -- --exact ${skip[@]+"${skip[@]}"}
 echo "miri: shard ${MIRI_SHARD}, ${mine} of ${#tests[@]} tests, no UB"

--- a/scripts/mutants-all.sh
+++ b/scripts/mutants-all.sh
@@ -75,6 +75,13 @@ if ! [ "$shard_i" -ge 1 ] 2>/dev/null || ! [ "$shard_i" -le "$shard_n" ] 2>/dev/
   exit 1
 fi
 
+# cargo-mutants creates its output directory but not the parent, and on a runner
+# whose `target/` cache missed there is no parent to create it in: "create output
+# parent directory target/mutants: No such file or directory", five shards of the
+# first real run. The apparatus check below is what caught it — the row failed as
+# "no summary line" rather than passing with nothing tested.
+mkdir -p "$OUT"
+
 log="$(mktemp)"
 trap 'rm -f "$log"' EXIT
 # `|| true` deliberately: cargo-mutants exits non-zero when mutants survive, and


### PR DESCRIPTION
Three defects the first real `deep-checks` run found, one per commit. All three
were reproduced locally before being fixed, and the fix verified the same way.

- **Miri shards ran fewer tests than they owed.** `--skip` matches by *substring*,
  and the roster has four containment pairs (`miri_ctaphid` inside
  `miri_ctaphid_roundtrip`, `miri_fido_cred` inside three more), so "skip everyone
  else" took two of the shard's own tests with it. The arithmetic predicts the run
  exactly — 1/3 owes 17 and is left 15, 3/3 owes 16 and is left 15, 2/3 untouched
  — and shards 1 and 3 are the two that failed. `--exact` fixes it.
- **cargo-mutants cannot create the parent of its own output directory.** All
  eight shards, on a runner whose `target/` cache missed.
- **`fuzz-coverage` died silently on a missing corpus directory.** `find` exits 1,
  `pipefail` makes it the pipeline's status, `set -e` ends the script — before the
  branch written to say "no corpus" and exit 0. That branch handled an *empty*
  corpus; a *missing* one never reached it, and the two differ by `pipefail`.
  Latent until per-shard cache keys first left the job with no corpus at all.

### The part worth keeping

None of the three was caught by review or by the merge gate. Two were caught by
the apparatus checks these scripts carry — "shard 2/8 produced no summary line"
and "shard 1/3 selects 15, expected 17" — which is exactly what those checks are
for: a row that cannot fail on findings still has to fail when it did not run.
Had `mutants` reported "0 survivors of 0 mutants", it would have been green and
worthless.

Green in the same run: `coverage`, `repro`, and Kani's `light1` and `light3` —
the weekly tier split working on a real runner, floors and matrix included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
