### PR TITLE
fix(ci): the mutants row skipped an eighth of the tree

### DIFF
--- a/scripts/mutants-all.sh
+++ b/scripts/mutants-all.sh
@@ -87,8 +87,14 @@ trap 'rm -f "$log"' EXIT
 # `|| true` deliberately: cargo-mutants exits non-zero when mutants survive, and
 # on this row that is the expected outcome rather than a failure. The summary line
 # below is what says the run happened, so a crash cannot pass as "none survived".
+# cargo-mutants numbers shards from ZERO — `--shard 8/8` is "invalid value: shard
+# k must be less than n". Passing this script's 1-based number straight through
+# therefore ran indices 1..7 and never index 0: an eighth of the tree silently
+# unmutated, while the last shard failed outright. Converted here so the shard
+# number means the same thing in every row (`FUZZ_SHARD`, `MIRI_SHARD`, this one)
+# and only the flag sees the tool's own convention.
 cargo-mutants mutants "${common[@]}" \
-  --shard "$MUTANTS_SHARD" -j "${MUTANTS_JOBS:-4}" --output "$OUT" 2>&1 | tee "$log" || true
+  --shard "$((shard_i - 1))/$shard_n" -j "${MUTANTS_JOBS:-4}" --output "$OUT" 2>&1 | tee "$log" || true
 
 summary="$(grep -E '^[0-9]+ mutants tested' "$log" | tail -1 || true)"
 if [ -z "$summary" ]; then


### PR DESCRIPTION
**cargo-mutants numbers shards from zero.** `--shard 8/8` is "invalid value:
shard k must be less than n", and this script passed its own 1-based number
straight through — so the eight rows ran indices 1..7, index 0 was mutated by
nobody, and the eighth row failed outright.

The asymmetry is the point. The failing shard is the lucky half: it shouts. The
seven that skipped index 0 would have reported a clean sweep over a tree an
eighth of which was never mutated. Had cargo-mutants accepted `8/8` as "the
last", nothing would ever have said so.

Measured on `rsk-store`: shards `0/4`..`3/4` return 5 mutants each and sum to the
20 the package has; `4/4` is rejected; after the conversion all eight shards of 8
are accepted and their counts still sum to 20.

Converted at the flag, not in the workflow, so the shard number means the same
thing in `FUZZ_SHARD`, `MIRI_SHARD` and `MUTANTS_SHARD`, and only cargo-mutants
sees its own convention.

Fourth defect the two merges have turned up; three of the four were caught by the
apparatus checks these rows carry rather than by a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
