### PR TITLE
add my Waveshare RP2350-Touch-2.8 case design link and license info

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -100,12 +100,15 @@ designs fit the boards above:
 - **[Waveshare RP2350 2.8-inch case](https://makerworld.com/en/models/3204749-waveshare-rp2350-2-8inch-case)**
   by [@cofob](https://cofob.dev/). Designed for RS-Key and recommended for the
   RP2350-Touch-LCD-2.8. PETG is the recommended print material.
+- **[Waveshare RP2350 2.8-inch case](https://www.thingiverse.com/thing:7404751)**
+  by Mono. Designed for RS-Key, reliable USB and button performance as well as
+  sturdyness. PETG material recommended.
 
-The two Printables designs are licensed **CC BY-SA 4.0**: print, sell, and remix
-them freely, as long as you credit the authors and keep any derivative under the
-same license. Check each MakerWorld page for the design license before you reuse
-the design. All are third-party designs, linked for convenience, not part of
-this project.
+The two Printables designs as well as the Thingiverse design are licensed
+**CC BY-SA 4.0**: print, sell, and remix them freely, as long as you credit the
+authors and keep any derivative under the same license. Check each MakerWorld
+page for the design license before you reuse the design. All are third-party
+designs, linked for convenience, not part of this project.
 
 ## What the hardware does not give you
 


### PR DESCRIPTION
## What

add a new device case for the waveshare trusted display target, link it and add it to the explanatory passage about licensing.

## How it was tested

- [x] Host-only change (CLI / docs / CI) — no device behavior touched

## Checklist

<!-- Tick what applies; "N/A" is fine — most host-only PRs leave the firmware lines blank. -->

- [N/A] Device behavior / image changed → `config.device_release` (bcdDevice) bumped by one (hex)
      in `firmware/src/main.rs` — host-only (CLI / docs / CI / build) does not (CONTRIBUTING.md)
- [N/A] Fixes something a downgrade would reopen → flag whether the next release should advance the
      rollback **epoch** (`docs/production.md`, stage 3) — a seal-time `--rollback` call, not a code bump
- [N/A] New or changed `unsafe` → justified in `docs/unsafe.md`
- [N/A] User-visible behavior → the matching guide under `docs/` updated
- [N/A] New files carry the SPDX header (`AGPL-3.0-only`)
- [X] Commit messages use the zone prefix style (`fido:`, `piv:`, `rsk:`, `docs:`, …)
